### PR TITLE
Feat/state changes

### DIFF
--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -17,7 +17,7 @@ abstract contract Assertion is Credible {
         triggerRecorder.registerCallTrigger(fnSelector);
     }
 
-    function getStateChangesUint(bytes32 slot) internal returns (uint256[] memory) {
+    function getStateChangesUint(bytes32 slot) internal view returns (uint256[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
         // Explicit cast to uint256[]
@@ -29,7 +29,7 @@ abstract contract Assertion is Credible {
         return uintChanges;
     }
 
-    function getStateChangesAddress(bytes32 slot) internal returns (address[] memory) {
+    function getStateChangesAddress(bytes32 slot) internal view returns (address[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
         assembly {
@@ -53,7 +53,7 @@ abstract contract Assertion is Credible {
         return addressChanges;
     }
 
-    function getStateChangesBool(bytes32 slot) internal returns (bool[] memory) {
+    function getStateChangesBool(bytes32 slot) internal view returns (bool[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
         assembly {
@@ -72,5 +72,65 @@ abstract contract Assertion is Credible {
         }
 
         return boolChanges;
+    }
+
+    function getStateChangesBytes32(bytes32 slot) internal view virtual returns (bytes32[] memory) {
+        return ph.getStateChanges(slot);
+    }
+
+    function getSlotMapping(bytes32 slot, uint256 key, uint256 offset) private pure returns (bytes32) {
+        return bytes32(uint256(keccak256(abi.encodePacked(key, slot))) + offset);
+    }
+
+    function getStateChangesUint(bytes32 slot, uint256 key) internal view virtual returns (uint256[] memory) {
+        return getStateChangesUint(slot, key, 0);
+    }
+
+    function getStateChangesAddress(bytes32 slot, uint256 key) internal view virtual returns (address[] memory) {
+        return getStateChangesAddress(slot, key, 0);
+    }
+
+    function getStateChangesBool(bytes32 slot, uint256 key) internal view virtual returns (bool[] memory) {
+        return getStateChangesBool(slot, key, 0);
+    }
+
+    function getStateChangesBytes32(bytes32 slot, uint256 key) internal view virtual returns (bytes32[] memory) {
+        return getStateChangesBytes32(slot, key, 0);
+    }
+
+    function getStateChangesUint(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (uint256[] memory)
+    {
+        return getStateChangesUint(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesAddress(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (address[] memory)
+    {
+        return getStateChangesAddress(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBool(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (bool[] memory)
+    {
+        return getStateChangesBool(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBytes32(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (bytes32[] memory)
+    {
+        return getStateChangesBytes32(getSlotMapping(slot, key, slotOffset));
     }
 }

--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -16,4 +16,48 @@ abstract contract Assertion is Credible {
     function registerCallTrigger(bytes4 fnSelector) internal view {
         triggerRecorder.registerCallTrigger(fnSelector);
     }
+
+    function getStateChangesUint(bytes32 slot) internal returns (uint256[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        assembly {
+            // Return the same memory location, but interpreted as uint256[]
+            return(add(stateChanges, 0), mload(stateChanges))
+        }
+    }
+
+    function getStateChangesAddress(bytes32 slot) internal returns (address[] calldata) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        assembly {
+            // Zero out the upper 96 bits for each element to ensure clean address casting
+            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
+                let addr :=
+                    and(
+                        mload(add(add(stateChanges, 0x20), mul(i, 0x20))),
+                        0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
+                    )
+                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), addr)
+            }
+
+            // Return the modified memory as address[]
+            return(add(stateChanges, 0), mload(stateChanges))
+        }
+    }
+
+    function getStateChangesBool(bytes32 slot) internal returns (bool[] calldata) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        assembly {
+            // Convert each bytes32 to bool
+            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
+                // Any non-zero value is true, zero is false
+                let boolValue := iszero(iszero(mload(add(add(stateChanges, 0x20), mul(i, 0x20)))))
+                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), boolValue)
+            }
+
+            // Return the modified memory as bool[]
+            return(add(stateChanges, 0), mload(stateChanges))
+        }
+    }
 }

--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.13;
 
 import {Credible} from "./Credible.sol";
 import {TriggerRecorder} from "./TriggerRecorder.sol";
+import {StateChanges} from "./StateChanges.sol";
 
 /// @notice Assertion interface for the PhEvm precompile
-abstract contract Assertion is Credible {
+abstract contract Assertion is Credible, StateChanges {
     //Trigger recorder address
     TriggerRecorder constant triggerRecorder = TriggerRecorder(address(uint160(uint256(keccak256("TriggerRecorder")))));
 
@@ -15,122 +16,5 @@ abstract contract Assertion is Credible {
     /// @notice Registers a call trigger for the specified assertion function.
     function registerCallTrigger(bytes4 fnSelector) internal view {
         triggerRecorder.registerCallTrigger(fnSelector);
-    }
-
-    function getStateChangesUint(bytes32 slot) internal view returns (uint256[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
-
-        // Explicit cast to uint256[]
-        uint256[] memory uintChanges;
-        assembly {
-            uintChanges := stateChanges
-        }
-
-        return uintChanges;
-    }
-
-    function getStateChangesAddress(bytes32 slot) internal view returns (address[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
-
-        assembly {
-            // Zero out the upper 96 bits for each element to ensure clean address casting
-            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
-                let addr :=
-                    and(
-                        mload(add(add(stateChanges, 0x20), mul(i, 0x20))),
-                        0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
-                    )
-                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), addr)
-            }
-        }
-
-        // Explicit cast to address[]
-        address[] memory addressChanges;
-        assembly {
-            addressChanges := stateChanges
-        }
-
-        return addressChanges;
-    }
-
-    function getStateChangesBool(bytes32 slot) internal view returns (bool[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
-
-        assembly {
-            // Convert each bytes32 to bool
-            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
-                // Any non-zero value is true, zero is false
-                let boolValue := iszero(iszero(mload(add(add(stateChanges, 0x20), mul(i, 0x20)))))
-                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), boolValue)
-            }
-        }
-
-        // Explicit cast to bool[]
-        bool[] memory boolChanges;
-        assembly {
-            boolChanges := stateChanges
-        }
-
-        return boolChanges;
-    }
-
-    function getStateChangesBytes32(bytes32 slot) internal view virtual returns (bytes32[] memory) {
-        return ph.getStateChanges(slot);
-    }
-
-    function getSlotMapping(bytes32 slot, uint256 key, uint256 offset) private pure returns (bytes32) {
-        return bytes32(uint256(keccak256(abi.encodePacked(key, slot))) + offset);
-    }
-
-    function getStateChangesUint(bytes32 slot, uint256 key) internal view virtual returns (uint256[] memory) {
-        return getStateChangesUint(slot, key, 0);
-    }
-
-    function getStateChangesAddress(bytes32 slot, uint256 key) internal view virtual returns (address[] memory) {
-        return getStateChangesAddress(slot, key, 0);
-    }
-
-    function getStateChangesBool(bytes32 slot, uint256 key) internal view virtual returns (bool[] memory) {
-        return getStateChangesBool(slot, key, 0);
-    }
-
-    function getStateChangesBytes32(bytes32 slot, uint256 key) internal view virtual returns (bytes32[] memory) {
-        return getStateChangesBytes32(slot, key, 0);
-    }
-
-    function getStateChangesUint(bytes32 slot, uint256 key, uint256 slotOffset)
-        internal
-        view
-        virtual
-        returns (uint256[] memory)
-    {
-        return getStateChangesUint(getSlotMapping(slot, key, slotOffset));
-    }
-
-    function getStateChangesAddress(bytes32 slot, uint256 key, uint256 slotOffset)
-        internal
-        view
-        virtual
-        returns (address[] memory)
-    {
-        return getStateChangesAddress(getSlotMapping(slot, key, slotOffset));
-    }
-
-    function getStateChangesBool(bytes32 slot, uint256 key, uint256 slotOffset)
-        internal
-        view
-        virtual
-        returns (bool[] memory)
-    {
-        return getStateChangesBool(getSlotMapping(slot, key, slotOffset));
-    }
-
-    function getStateChangesBytes32(bytes32 slot, uint256 key, uint256 slotOffset)
-        internal
-        view
-        virtual
-        returns (bytes32[] memory)
-    {
-        return getStateChangesBytes32(getSlotMapping(slot, key, slotOffset));
     }
 }

--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -20,13 +20,16 @@ abstract contract Assertion is Credible {
     function getStateChangesUint(bytes32 slot) internal returns (uint256[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
+        // Explicit cast to uint256[]
+        uint256[] memory uintChanges;
         assembly {
-            // Return the same memory location, but interpreted as uint256[]
-            return(add(stateChanges, 0), mload(stateChanges))
+            uintChanges := stateChanges
         }
+
+        return uintChanges;
     }
 
-    function getStateChangesAddress(bytes32 slot) internal returns (address[] calldata) {
+    function getStateChangesAddress(bytes32 slot) internal returns (address[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
         assembly {
@@ -39,13 +42,18 @@ abstract contract Assertion is Credible {
                     )
                 mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), addr)
             }
-
-            // Return the modified memory as address[]
-            return(add(stateChanges, 0), mload(stateChanges))
         }
+
+        // Explicit cast to address[]
+        address[] memory addressChanges;
+        assembly {
+            addressChanges := stateChanges
+        }
+
+        return addressChanges;
     }
 
-    function getStateChangesBool(bytes32 slot) internal returns (bool[] calldata) {
+    function getStateChangesBool(bytes32 slot) internal returns (bool[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(slot);
 
         assembly {
@@ -55,9 +63,14 @@ abstract contract Assertion is Credible {
                 let boolValue := iszero(iszero(mload(add(add(stateChanges, 0x20), mul(i, 0x20)))))
                 mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), boolValue)
             }
-
-            // Return the modified memory as bool[]
-            return(add(stateChanges, 0), mload(stateChanges))
         }
+
+        // Explicit cast to bool[]
+        bool[] memory boolChanges;
+        assembly {
+            boolChanges := stateChanges
+        }
+
+        return boolChanges;
     }
 }

--- a/src/Credible.sol
+++ b/src/Credible.sol
@@ -6,5 +6,5 @@ import {PhEvm} from "./PhEvm.sol";
 /// @notice The Credible contract
 abstract contract Credible {
     //Precompile address -
-    PhEvm constant ph = PhEvm(address(uint160(uint256(keccak256("Kim Jong Un Sucks")))));
+    PhEvm immutable ph = PhEvm(address(uint160(uint256(keccak256("Kim Jong Un Sucks")))));
 }

--- a/src/Credible.sol
+++ b/src/Credible.sol
@@ -6,5 +6,5 @@ import {PhEvm} from "./PhEvm.sol";
 /// @notice The Credible contract
 abstract contract Credible {
     //Precompile address -
-    PhEvm immutable ph = PhEvm(address(uint160(uint256(keccak256("Kim Jong Un Sucks")))));
+    PhEvm constant ph = PhEvm(address(uint160(uint256(keccak256("Kim Jong Un Sucks")))));
 }

--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -54,5 +54,5 @@ interface PhEvm {
     function getCallInputs(address target, bytes4 selector) external view returns (CallInputs[] memory calls);
 
     // Get state changes for a given contract and storage slot.
-    function getStateChanges(address contractAddress, bytes32 slot) external returns (bytes32[] memory);
+    function getStateChanges(address contractAddress, bytes32 slot) external returns (bytes32[] memory stateChanges);
 }

--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -54,5 +54,8 @@ interface PhEvm {
     function getCallInputs(address target, bytes4 selector) external view returns (CallInputs[] memory calls);
 
     // Get state changes for a given contract and storage slot.
-    function getStateChanges(address contractAddress, bytes32 slot) external returns (bytes32[] memory stateChanges);
+    function getStateChanges(address contractAddress, bytes32 slot)
+        external
+        view
+        returns (bytes32[] memory stateChanges);
 }

--- a/src/StateChanges.sol
+++ b/src/StateChanges.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import {Credible} from "./Credible.sol";
 
 contract StateChanges is Credible {
-    function getStateChangesUint(bytes32 slot) internal view returns (uint256[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+    function getStateChangesUint(address contractAddress, bytes32 slot) internal view returns (uint256[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
         // Explicit cast to uint256[]
         uint256[] memory uintChanges;
@@ -16,8 +16,8 @@ contract StateChanges is Credible {
         return uintChanges;
     }
 
-    function getStateChangesAddress(bytes32 slot) internal view returns (address[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+    function getStateChangesAddress(address contractAddress, bytes32 slot) internal view returns (address[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
         assembly {
             // Zero out the upper 96 bits for each element to ensure clean address casting
@@ -40,8 +40,8 @@ contract StateChanges is Credible {
         return addressChanges;
     }
 
-    function getStateChangesBool(bytes32 slot) internal view returns (bool[] memory) {
-        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+    function getStateChangesBool(address contractAddress, bytes32 slot) internal view returns (bool[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
         assembly {
             // Convert each bytes32 to bool
@@ -61,63 +61,75 @@ contract StateChanges is Credible {
         return boolChanges;
     }
 
-    function getStateChangesBytes32(bytes32 slot) internal view virtual returns (bytes32[] memory) {
-        return ph.getStateChanges(slot);
+    function getStateChangesBytes32(address contractAddress, bytes32 slot) internal view returns (bytes32[] memory) {
+        return ph.getStateChanges(contractAddress, slot);
     }
 
     function getSlotMapping(bytes32 slot, uint256 key, uint256 offset) private pure returns (bytes32) {
         return bytes32(uint256(keccak256(abi.encodePacked(key, slot))) + offset);
     }
 
-    function getStateChangesUint(bytes32 slot, uint256 key) internal view virtual returns (uint256[] memory) {
-        return getStateChangesUint(slot, key, 0);
-    }
-
-    function getStateChangesAddress(bytes32 slot, uint256 key) internal view virtual returns (address[] memory) {
-        return getStateChangesAddress(slot, key, 0);
-    }
-
-    function getStateChangesBool(bytes32 slot, uint256 key) internal view virtual returns (bool[] memory) {
-        return getStateChangesBool(slot, key, 0);
-    }
-
-    function getStateChangesBytes32(bytes32 slot, uint256 key) internal view virtual returns (bytes32[] memory) {
-        return getStateChangesBytes32(slot, key, 0);
-    }
-
-    function getStateChangesUint(bytes32 slot, uint256 key, uint256 slotOffset)
+    function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
-        virtual
         returns (uint256[] memory)
     {
-        return getStateChangesUint(getSlotMapping(slot, key, slotOffset));
+        return getStateChangesUint(contractAddress, slot, key, 0);
     }
 
-    function getStateChangesAddress(bytes32 slot, uint256 key, uint256 slotOffset)
+    function getStateChangesAddress(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
-        virtual
         returns (address[] memory)
     {
-        return getStateChangesAddress(getSlotMapping(slot, key, slotOffset));
+        return getStateChangesAddress(contractAddress, slot, key, 0);
     }
 
-    function getStateChangesBool(bytes32 slot, uint256 key, uint256 slotOffset)
+    function getStateChangesBool(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
-        virtual
         returns (bool[] memory)
     {
-        return getStateChangesBool(getSlotMapping(slot, key, slotOffset));
+        return getStateChangesBool(contractAddress, slot, key, 0);
     }
 
-    function getStateChangesBytes32(bytes32 slot, uint256 key, uint256 slotOffset)
+    function getStateChangesBytes32(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
-        virtual
         returns (bytes32[] memory)
     {
-        return getStateChangesBytes32(getSlotMapping(slot, key, slotOffset));
+        return getStateChangesBytes32(contractAddress, slot, key, 0);
+    }
+
+    function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        returns (uint256[] memory)
+    {
+        return getStateChangesUint(contractAddress, getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesAddress(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        returns (address[] memory)
+    {
+        return getStateChangesAddress(contractAddress, getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBool(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        returns (bool[] memory)
+    {
+        return getStateChangesBool(contractAddress, getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBytes32(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        returns (bytes32[] memory)
+    {
+        return getStateChangesBytes32(contractAddress, getSlotMapping(slot, key, slotOffset));
     }
 }

--- a/src/StateChanges.sol
+++ b/src/StateChanges.sol
@@ -3,7 +3,18 @@ pragma solidity ^0.8.13;
 
 import {Credible} from "./Credible.sol";
 
+/**
+ * @title StateChanges
+ * @notice Helper contract for converting state changes from bytes32 arrays to typed arrays
+ * @dev Inherits from Credible to access the PhEvm interface
+ */
 contract StateChanges is Credible {
+    /**
+     * @notice Converts state changes for a slot to uint256 array
+     * @param contractAddress The address of the contract to get state changes from
+     * @param slot The storage slot to get state changes for
+     * @return Array of state changes as uint256 values
+     */
     function getStateChangesUint(address contractAddress, bytes32 slot) internal view returns (uint256[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
@@ -16,6 +27,12 @@ contract StateChanges is Credible {
         return uintChanges;
     }
 
+    /**
+     * @notice Converts state changes for a slot to address array
+     * @param contractAddress The address of the contract to get state changes from
+     * @param slot The storage slot to get state changes for
+     * @return Array of state changes as address values
+     */
     function getStateChangesAddress(address contractAddress, bytes32 slot) internal view returns (address[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
@@ -40,6 +57,12 @@ contract StateChanges is Credible {
         return addressChanges;
     }
 
+    /**
+     * @notice Converts state changes for a slot to boolean array
+     * @param contractAddress The address of the contract to get state changes from
+     * @param slot The storage slot to get state changes for
+     * @return Array of state changes as boolean values
+     */
     function getStateChangesBool(address contractAddress, bytes32 slot) internal view returns (bool[] memory) {
         bytes32[] memory stateChanges = ph.getStateChanges(contractAddress, slot);
 
@@ -61,14 +84,36 @@ contract StateChanges is Credible {
         return boolChanges;
     }
 
+    /**
+     * @notice Gets raw state changes as bytes32 array
+     * @param contractAddress The address of the contract to get state changes from
+     * @param slot The storage slot to get state changes for
+     * @return Array of state changes as bytes32 values
+     */
     function getStateChangesBytes32(address contractAddress, bytes32 slot) internal view returns (bytes32[] memory) {
         return ph.getStateChanges(contractAddress, slot);
     }
 
+    /**
+     * @notice Calculates the storage slot for a mapping with a given key and offset
+     * @param slot The base storage slot of the mapping
+     * @param key The key in the mapping
+     * @param offset Additional offset to add to the calculated slot
+     * @return The storage slot for the mapping entry
+     */
     function getSlotMapping(bytes32 slot, uint256 key, uint256 offset) private pure returns (bytes32) {
         return bytes32(uint256(keccak256(abi.encodePacked(key, slot))) + offset);
     }
 
+    // Helper functions for mapping access with keys
+
+    /**
+     * @notice Gets uint256 state changes for a mapping entry
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @return Array of state changes as uint256 values
+     */
     function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
@@ -77,6 +122,13 @@ contract StateChanges is Credible {
         return getStateChangesUint(contractAddress, slot, key, 0);
     }
 
+    /**
+     * @notice Gets address state changes for a mapping entry
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @return Array of state changes as address values
+     */
     function getStateChangesAddress(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
@@ -85,6 +137,13 @@ contract StateChanges is Credible {
         return getStateChangesAddress(contractAddress, slot, key, 0);
     }
 
+    /**
+     * @notice Gets boolean state changes for a mapping entry
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @return Array of state changes as boolean values
+     */
     function getStateChangesBool(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
@@ -93,6 +152,13 @@ contract StateChanges is Credible {
         return getStateChangesBool(contractAddress, slot, key, 0);
     }
 
+    /**
+     * @notice Gets bytes32 state changes for a mapping entry
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @return Array of state changes as bytes32 values
+     */
     function getStateChangesBytes32(address contractAddress, bytes32 slot, uint256 key)
         internal
         view
@@ -101,6 +167,16 @@ contract StateChanges is Credible {
         return getStateChangesBytes32(contractAddress, slot, key, 0);
     }
 
+    // Helper functions for mapping access with keys and offsets
+
+    /**
+     * @notice Gets uint256 state changes for a mapping entry with offset
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @param slotOffset Additional offset to add to the slot
+     * @return Array of state changes as uint256 values
+     */
     function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
         internal
         view
@@ -109,6 +185,14 @@ contract StateChanges is Credible {
         return getStateChangesUint(contractAddress, getSlotMapping(slot, key, slotOffset));
     }
 
+    /**
+     * @notice Gets address state changes for a mapping entry with offset
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @param slotOffset Additional offset to add to the slot
+     * @return Array of state changes as address values
+     */
     function getStateChangesAddress(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
         internal
         view
@@ -117,6 +201,14 @@ contract StateChanges is Credible {
         return getStateChangesAddress(contractAddress, getSlotMapping(slot, key, slotOffset));
     }
 
+    /**
+     * @notice Gets boolean state changes for a mapping entry with offset
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @param slotOffset Additional offset to add to the slot
+     * @return Array of state changes as boolean values
+     */
     function getStateChangesBool(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
         internal
         view
@@ -125,6 +217,14 @@ contract StateChanges is Credible {
         return getStateChangesBool(contractAddress, getSlotMapping(slot, key, slotOffset));
     }
 
+    /**
+     * @notice Gets bytes32 state changes for a mapping entry with offset
+     * @param contractAddress The contract address
+     * @param slot The mapping's slot
+     * @param key The mapping key
+     * @param slotOffset Additional offset to add to the slot
+     * @return Array of state changes as bytes32 values
+     */
     function getStateChangesBytes32(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
         internal
         view

--- a/src/StateChanges.sol
+++ b/src/StateChanges.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Credible} from "./Credible.sol";
+
+contract StateChanges is Credible {
+    function getStateChangesUint(bytes32 slot) internal view returns (uint256[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        // Explicit cast to uint256[]
+        uint256[] memory uintChanges;
+        assembly {
+            uintChanges := stateChanges
+        }
+
+        return uintChanges;
+    }
+
+    function getStateChangesAddress(bytes32 slot) internal view returns (address[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        assembly {
+            // Zero out the upper 96 bits for each element to ensure clean address casting
+            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
+                let addr :=
+                    and(
+                        mload(add(add(stateChanges, 0x20), mul(i, 0x20))),
+                        0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
+                    )
+                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), addr)
+            }
+        }
+
+        // Explicit cast to address[]
+        address[] memory addressChanges;
+        assembly {
+            addressChanges := stateChanges
+        }
+
+        return addressChanges;
+    }
+
+    function getStateChangesBool(bytes32 slot) internal view returns (bool[] memory) {
+        bytes32[] memory stateChanges = ph.getStateChanges(slot);
+
+        assembly {
+            // Convert each bytes32 to bool
+            for { let i := 0 } lt(i, mload(stateChanges)) { i := add(i, 1) } {
+                // Any non-zero value is true, zero is false
+                let boolValue := iszero(iszero(mload(add(add(stateChanges, 0x20), mul(i, 0x20)))))
+                mstore(add(add(stateChanges, 0x20), mul(i, 0x20)), boolValue)
+            }
+        }
+
+        // Explicit cast to bool[]
+        bool[] memory boolChanges;
+        assembly {
+            boolChanges := stateChanges
+        }
+
+        return boolChanges;
+    }
+
+    function getStateChangesBytes32(bytes32 slot) internal view virtual returns (bytes32[] memory) {
+        return ph.getStateChanges(slot);
+    }
+
+    function getSlotMapping(bytes32 slot, uint256 key, uint256 offset) private pure returns (bytes32) {
+        return bytes32(uint256(keccak256(abi.encodePacked(key, slot))) + offset);
+    }
+
+    function getStateChangesUint(bytes32 slot, uint256 key) internal view virtual returns (uint256[] memory) {
+        return getStateChangesUint(slot, key, 0);
+    }
+
+    function getStateChangesAddress(bytes32 slot, uint256 key) internal view virtual returns (address[] memory) {
+        return getStateChangesAddress(slot, key, 0);
+    }
+
+    function getStateChangesBool(bytes32 slot, uint256 key) internal view virtual returns (bool[] memory) {
+        return getStateChangesBool(slot, key, 0);
+    }
+
+    function getStateChangesBytes32(bytes32 slot, uint256 key) internal view virtual returns (bytes32[] memory) {
+        return getStateChangesBytes32(slot, key, 0);
+    }
+
+    function getStateChangesUint(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (uint256[] memory)
+    {
+        return getStateChangesUint(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesAddress(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (address[] memory)
+    {
+        return getStateChangesAddress(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBool(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (bool[] memory)
+    {
+        return getStateChangesBool(getSlotMapping(slot, key, slotOffset));
+    }
+
+    function getStateChangesBytes32(bytes32 slot, uint256 key, uint256 slotOffset)
+        internal
+        view
+        virtual
+        returns (bytes32[] memory)
+    {
+        return getStateChangesBytes32(getSlotMapping(slot, key, slotOffset));
+    }
+}

--- a/test/Assertion.t.sol
+++ b/test/Assertion.t.sol
@@ -6,7 +6,7 @@ import {MockAssertion} from "./mocks/MockAssertion.sol";
 
 contract AssertionTest is Test, MockAssertion {
     function testStateChanges() public view {
-        bytes32[] memory stateChanges = ph.getStateChanges(0x0);
+        bytes32[] memory stateChanges = ph.getStateChanges(address(this), 0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], bytes32(uint256(0x0)));
         assertEq(stateChanges[1], bytes32(uint256(0x1)));
@@ -14,7 +14,7 @@ contract AssertionTest is Test, MockAssertion {
     }
 
     function testStateChangesUint() public view {
-        uint256[] memory stateChanges = getStateChangesUint(0x0);
+        uint256[] memory stateChanges = getStateChangesUint(address(this), 0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], 0x0);
         assertEq(stateChanges[1], 0x1);
@@ -22,7 +22,7 @@ contract AssertionTest is Test, MockAssertion {
     }
 
     function testStateChangesAddress() public view {
-        address[] memory stateChanges = getStateChangesAddress(0x0);
+        address[] memory stateChanges = getStateChangesAddress(address(this), 0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], address(0x0));
         assertEq(stateChanges[1], address(0x1));
@@ -31,7 +31,7 @@ contract AssertionTest is Test, MockAssertion {
     }
 
     function testStateChangesBool() public view {
-        bool[] memory stateChanges = getStateChangesBool(0x0);
+        bool[] memory stateChanges = getStateChangesBool(address(this), 0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], false);
         assertEq(stateChanges[1], true);

--- a/test/Assertion.t.sol
+++ b/test/Assertion.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {MockAssertion} from "./mocks/MockAssertion.sol";
+
+contract AssertionTest is Test, MockAssertion {
+    function testStateChanges() public {
+        bytes32[] memory stateChanges = ph.getStateChanges(0x0);
+        assertEq(stateChanges.length, 3);
+        assertEq(stateChanges[0], bytes32(uint256(0x0)));
+        assertEq(stateChanges[1], bytes32(uint256(0x1)));
+        assertEq(stateChanges[2], bytes32(type(uint256).max));
+    }
+
+    function testStateChangesUint() public {
+        uint256[] memory stateChanges = getStateChangesUint(0x0);
+        assertEq(stateChanges.length, 3);
+        assertEq(stateChanges[0], 0x0);
+        assertEq(stateChanges[1], 0x1);
+        assertEq(stateChanges[2], type(uint256).max);
+    }
+
+    function testStateChangesAddress() public {
+        address[] memory stateChanges = getStateChangesAddress(0x0);
+        assertEq(stateChanges.length, 3);
+        assertEq(stateChanges[0], address(0x0));
+        assertEq(stateChanges[1], address(0x1));
+        assertEq(stateChanges[2], address(type(uint160).max));
+        assertEq(uint256(uint160(stateChanges[2])), uint256(type(uint160).max));
+    }
+
+    function testStateChangesBool() public {
+        bool[] memory stateChanges = getStateChangesBool(0x0);
+        assertEq(stateChanges.length, 3);
+        assertEq(stateChanges[0], false);
+        assertEq(stateChanges[1], true);
+        assertEq(stateChanges[2], true);
+
+        // Precise bit check in assembly
+        bool maxValue = stateChanges[2];
+        uint256 isExactlyOne;
+        assembly {
+            isExactlyOne := eq(maxValue, 1)
+        }
+
+        assertEq(isExactlyOne, 1);
+    }
+}

--- a/test/Assertion.t.sol
+++ b/test/Assertion.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {MockAssertion} from "./mocks/MockAssertion.sol";
 
 contract AssertionTest is Test, MockAssertion {
-    function testStateChanges() public {
+    function testStateChanges() public view {
         bytes32[] memory stateChanges = ph.getStateChanges(0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], bytes32(uint256(0x0)));
@@ -13,7 +13,7 @@ contract AssertionTest is Test, MockAssertion {
         assertEq(stateChanges[2], bytes32(type(uint256).max));
     }
 
-    function testStateChangesUint() public {
+    function testStateChangesUint() public view {
         uint256[] memory stateChanges = getStateChangesUint(0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], 0x0);
@@ -21,7 +21,7 @@ contract AssertionTest is Test, MockAssertion {
         assertEq(stateChanges[2], type(uint256).max);
     }
 
-    function testStateChangesAddress() public {
+    function testStateChangesAddress() public view {
         address[] memory stateChanges = getStateChangesAddress(0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], address(0x0));
@@ -30,7 +30,7 @@ contract AssertionTest is Test, MockAssertion {
         assertEq(uint256(uint160(stateChanges[2])), uint256(type(uint160).max));
     }
 
-    function testStateChangesBool() public {
+    function testStateChangesBool() public view {
         bool[] memory stateChanges = getStateChangesBool(0x0);
         assertEq(stateChanges.length, 3);
         assertEq(stateChanges[0], false);

--- a/test/mocks/MockAssertion.sol
+++ b/test/mocks/MockAssertion.sol
@@ -4,10 +4,23 @@ pragma solidity ^0.8.13;
 import {Assertion} from "../../src/Assertion.sol";
 import {MockPhEvm} from "./MockPhEvm.sol";
 import {PhEvm} from "../../src/PhEvm.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract MockAssertion is Assertion {
     constructor() {
-        ph = PhEvm(new MockPhEvm());
+        address mockPhEvm = address(new MockPhEvm());
+        Vm vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+        bytes memory runtimeCode;
+        assembly {
+            let size := extcodesize(mockPhEvm)
+            runtimeCode := mload(0x40)
+            mstore(0x40, add(runtimeCode, add(size, 0x20)))
+            mstore(runtimeCode, size)
+            extcodecopy(mockPhEvm, add(runtimeCode, 0x20), 0, size)
+        }
+        vm.etch(address(ph), runtimeCode);
+        MockPhEvm(address(ph)).initialize();
     }
 
     function triggers() external view override {

--- a/test/mocks/MockAssertion.sol
+++ b/test/mocks/MockAssertion.sol
@@ -2,8 +2,14 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "../../src/Assertion.sol";
+import {MockPhEvm} from "./MockPhEvm.sol";
+import {PhEvm} from "../../src/PhEvm.sol";
 
 contract MockAssertion is Assertion {
+    constructor() {
+        ph = PhEvm(new MockPhEvm());
+    }
+
     function triggers() external view override {
         registerCallTrigger(this.assertionTrue.selector);
     }

--- a/test/mocks/MockPhEvm.sol
+++ b/test/mocks/MockPhEvm.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "../../src/PhEvm.sol";
+
+contract MockPhEvm is PhEvm {
+    mapping(bytes32 slot => bytes32[] stateChanges) private slotStateChanges;
+
+    constructor() {
+        slotStateChanges[0x0] = new bytes32[](3);
+        slotStateChanges[0x0][0] = bytes32(uint256(0x0));
+        slotStateChanges[0x0][1] = bytes32(uint256(0x1));
+        slotStateChanges[0x0][2] = bytes32(type(uint256).max);
+    }
+
+    // Mock state changes for testing
+    function getStateChanges(bytes32 slot) public view returns (bytes32[] memory stateChanges) {
+        stateChanges = slotStateChanges[slot];
+    }
+
+    //Forks to the state prior to the assertion triggering transaction.
+    function forkPreState() external {}
+
+    // Forks to the state after the assertion triggering transaction
+    function forkPostState() public {}
+
+    // Loads a storage slot from an address
+    function load(address target, bytes32 slot) public view returns (bytes32 data) {}
+
+    // Get the logs from the assertion triggering transaction
+    function getLogs() public view returns (Log[] memory logs) {}
+
+    // Get the call inputs for a given target and selector
+    function getCallInputs(address target, bytes4 selector) public view returns (CallInputs[] memory calls) {}
+}

--- a/test/mocks/MockPhEvm.sol
+++ b/test/mocks/MockPhEvm.sol
@@ -6,7 +6,7 @@ import {PhEvm} from "../../src/PhEvm.sol";
 contract MockPhEvm is PhEvm {
     mapping(bytes32 slot => bytes32[] stateChanges) private slotStateChanges;
 
-    constructor() {
+    function initialize() public {
         slotStateChanges[0x0] = new bytes32[](3);
         slotStateChanges[0x0][0] = bytes32(uint256(0x0));
         slotStateChanges[0x0][1] = bytes32(uint256(0x1));

--- a/test/mocks/MockPhEvm.sol
+++ b/test/mocks/MockPhEvm.sol
@@ -14,7 +14,7 @@ contract MockPhEvm is PhEvm {
     }
 
     // Mock state changes for testing
-    function getStateChanges(bytes32 slot) public view returns (bytes32[] memory stateChanges) {
+    function getStateChanges(address, bytes32 slot) public view returns (bytes32[] memory stateChanges) {
         stateChanges = slotStateChanges[slot];
     }
 


### PR DESCRIPTION
https://linear.app/phylaxsystems/issue/ENG-91/featcredible-std-add-state-changes-fns


A couple of notes: 

Introduced

Direct slot access: `getStateChanges<TYPE>(address contractAddress, bytes32 slot)`
Mapping access: `getStateChanges<TYPE>(address contractAddress, bytes32 slot, bytes32 key)`
Mapping access with offset (values might use multiple slots if structs): `getStateChanges<TYPE>(address contractAddress, bytes32 slot, bytes32 key, uint256 offset)`
