### PR TITLE
Add backtesting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/README.md
+++ b/README.md
@@ -135,36 +135,48 @@ These cheatcodes can be accessed through the `ph` instance in your assertion con
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {Credible} from "credible-std/src/Credible.sol";
-import {OwnableAssertion} from "../src/OwnableAssertion.sol";
+import {OwnableAssertion} from "../src/OwnableAssertion.a.sol";
 import {Ownable} from "../../src/Ownable.sol";
-import {CredibleTest} from "credible-std/src/CredibleTest.sol";
+import {CredibleTest} from "credible-std/CredibleTest.sol";
 import {Test} from "forge-std/Test.sol";
 
 contract TestOwnableAssertion is CredibleTest, Test {
     // Contract state variables
     Ownable public assertionAdopter;
-    address public initialOwner = address(0xdead);
+    address public initialOwner = address(0xf00);
     address public newOwner = address(0xdeadbeef);
 
+    // Set up the test environment
     function setUp() public {
-        assertionAdopter = new Ownable();
+        assertionAdopter = new Ownable(initialOwner);
         vm.deal(initialOwner, 1 ether);
     }
 
+    // Test case: Ownership changes should trigger the assertion
     function test_assertionOwnershipChanged() public {
-        address aaAddress = address(assertionAdopter);
-        string memory label = "OwnableAssertion";
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(OwnableAssertion).creationCode,
+            fnSelector: OwnableAssertion.assertionOwnershipChange.selector
+        });
 
-        // Associate the assertion with the protocol
-        // cl will manage the correct assertion execution under the hood when the protocol is being called
-        cl.addAssertion(label, aaAddress, type(OwnableAssertion).creationCode, abi.encode(assertionAdopter));
-
+        // Simulate a transaction that changes ownership
         vm.prank(initialOwner);
-        vm.expectRevert("Assertions Reverted"); // If the assertion fails, it will revert with this message
-        cl.validate(
-            label, aaAddress, 0, abi.encodePacked(assertionAdopter.transferOwnership.selector, abi.encode(newOwner))
-        );
+        vm.expectRevert("Ownership has changed");
+        assertionAdopter.transferOwnership(newOwner);
+    }
+
+    // Test case: No ownership change should pass the assertion
+    function test_assertionOwnershipNotChanged() public {
+        cl.assertion({
+            adopter: address(assertionAdopter),
+            createData: type(OwnableAssertion).creationCode,
+            fnSelector: OwnableAssertion.assertionOwnershipChange.selector
+        });
+
+        // Simulate a transaction that doesn't change ownership (transferring to same owner)
+        vm.prank(initialOwner);
+        assertionAdopter.transferOwnership(initialOwner);
     }
 }
 ```

--- a/scripts/backtesting/transaction_fetcher.rs
+++ b/scripts/backtesting/transaction_fetcher.rs
@@ -1,0 +1,374 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! serde = { version = "1.0", features = ["derive"] }
+//! serde_json = "1.0"
+//! reqwest = { version = "0.11", features = ["json"] }
+//! tokio = { version = "1.0", features = ["full"] }
+//! clap = { version = "4.0", features = ["derive"] }
+//! hex = "0.4"
+//! ethabi = "18.0"
+//! futures = "0.3"
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use std::time::Instant;
+use clap::{Arg, Command};
+use futures::stream::{self, StreamExt};
+use std::sync::Arc;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Transaction {
+    hash: String,
+    from: String,
+    to: Option<String>,
+    value: String,
+    input: String,
+    #[serde(rename = "transactionIndex")]
+    transaction_index: String,
+    #[serde(rename = "gasPrice")]
+    gas_price: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Block {
+    transactions: Vec<Transaction>,
+    number: String,
+    #[serde(rename = "baseFeePerGas")]
+    base_fee_per_gas: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RpcResponse {
+    result: Block,
+}
+
+#[derive(Debug, Serialize)]
+struct FilteredTransaction {
+    hash: String,
+    from: String,
+    to: String,
+    value: String,
+    data: String,
+    block_number: String,
+    transaction_index: String,
+    gas_price: String,
+}
+
+/// Fetch transactions from a block that interact with a target contract
+async fn fetch_block_transactions(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    block_number: u64,
+    target_contract: &str,
+) -> Result<Vec<FilteredTransaction>, Box<dyn std::error::Error>> {
+    // Convert block number to hex
+    let block_hex = format!("0x{:x}", block_number);
+    
+    // Prepare RPC request
+    let rpc_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBlockByNumber",
+        "params": [block_hex, true],
+        "id": 1
+    });
+
+    // Make the request using the shared client
+    let response = client
+        .post(rpc_url)
+        .header("Content-Type", "application/json")
+        .json(&rpc_request)
+        .send()
+        .await?;
+
+    let rpc_response: RpcResponse = response.json().await?;
+    let block = rpc_response.result;
+
+    // Filter transactions that interact with the target contract
+    let target_contract_lower = target_contract.to_lowercase();
+    let mut filtered_transactions = Vec::new();
+
+    for tx in block.transactions {
+        // Check if transaction is sent to the target contract
+        if let Some(to) = &tx.to {
+            if to.to_lowercase() == target_contract_lower {
+                // Convert hex block number to decimal string
+                let block_num_decimal = if block.number.starts_with("0x") {
+                    u64::from_str_radix(&block.number[2..], 16)
+                        .unwrap_or_else(|_| panic!("Invalid hex block number: {}", block.number))
+                        .to_string()
+                } else {
+                    block.number.clone()
+                };
+
+                filtered_transactions.push(FilteredTransaction {
+                    hash: tx.hash,
+                    from: tx.from,
+                    to: to.clone(),
+                    value: tx.value,
+                    data: tx.input,
+                    block_number: block_num_decimal,
+                    transaction_index: tx.transaction_index,
+                    gas_price: tx.gas_price,
+                });
+            }
+        }
+    }
+
+    Ok(filtered_transactions)
+}
+
+/// Fetch transactions from multiple blocks in parallel with batching
+async fn fetch_block_range_transactions_optimized(
+    rpc_url: &str,
+    start_block: u64,
+    end_block: u64,
+    target_contract: &str,
+    batch_size: usize,
+    max_concurrent: usize,
+) -> Result<Vec<FilteredTransaction>, Box<dyn std::error::Error>> {
+    let start_time = Instant::now();
+    println!("Starting optimized fetch: blocks {} to {} (batch size: {}, max concurrent: {})", 
+             start_block, end_block, batch_size, max_concurrent);
+
+    // Create a shared HTTP client with connection pooling
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(10)
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+
+    let client = Arc::new(client);
+    let target_contract = Arc::new(target_contract.to_string());
+    let rpc_url = Arc::new(rpc_url.to_string());
+
+    let mut all_transactions = Vec::new();
+    let mut total_blocks_processed = 0;
+    let mut total_transactions_found = 0;
+
+    // Process blocks in batches
+    for batch_start in (start_block..=end_block).step_by(batch_size) {
+        let batch_end = std::cmp::min(batch_start + batch_size as u64 - 1, end_block);
+        let batch_blocks: Vec<u64> = (batch_start..=batch_end).collect();
+        
+        println!("Processing batch: blocks {} to {}", batch_start, batch_end);
+
+        // Process blocks in this batch concurrently
+        let futures = batch_blocks.into_iter().map(|block_num| {
+            let client = Arc::clone(&client);
+            let target_contract = Arc::clone(&target_contract);
+            let rpc_url = Arc::clone(&rpc_url);
+            
+            async move {
+                match fetch_block_transactions(&client, &rpc_url, block_num, &target_contract).await {
+                    Ok(transactions) => {
+                        if !transactions.is_empty() {
+                            println!("  Block {}: found {} transactions", block_num, transactions.len());
+                        }
+                        Ok((block_num, transactions))
+                    }
+                    Err(e) => {
+                        eprintln!("  Error fetching block {}: {}", block_num, e);
+                        Err(e)
+                    }
+                }
+            }
+        });
+
+        // Execute with concurrency limit
+        let batch_results: Vec<_> = stream::iter(futures)
+            .buffer_unordered(max_concurrent)
+            .collect()
+            .await;
+
+        // Collect results from this batch
+        for result in batch_results {
+            match result {
+                Ok((_block_num, transactions)) => {
+                    total_blocks_processed += 1;
+                    total_transactions_found += transactions.len();
+                    all_transactions.extend(transactions);
+                }
+                Err(_) => {
+                    // Error already logged above
+                }
+            }
+        }
+    }
+
+    let duration = start_time.elapsed();
+    println!("Optimized fetch completed in {:?}", duration);
+    println!("Processed {} blocks, found {} transactions", total_blocks_processed, total_transactions_found);
+    println!("Average: {:.2} blocks/sec, {:.2} transactions/sec", 
+             total_blocks_processed as f64 / duration.as_secs_f64(),
+             total_transactions_found as f64 / duration.as_secs_f64());
+
+    Ok(all_transactions)
+}
+
+/// Legacy function for backward compatibility
+async fn fetch_block_range_transactions(
+    rpc_url: &str,
+    start_block: u64,
+    end_block: u64,
+    target_contract: &str,
+) -> Result<Vec<FilteredTransaction>, Box<dyn std::error::Error>> {
+    println!("Using legacy sequential fetch");
+    let mut all_transactions = Vec::new();
+
+    for block_num in start_block..=end_block {
+        println!("Fetching transactions for block {}", block_num);
+        
+        // Create a new client for each request (inefficient)
+        let client = reqwest::Client::new();
+        
+        match fetch_block_transactions(&client, rpc_url, block_num, target_contract).await {
+            Ok(mut transactions) => {
+                println!("  Found {} transactions", transactions.len());
+                all_transactions.append(&mut transactions);
+            }
+            Err(e) => {
+                eprintln!("  Error fetching block {}: {}", block_num, e);
+            }
+        }
+    }
+
+    Ok(all_transactions)
+}
+
+/// Encode transaction data for Foundry consumption
+fn encode_transactions_for_foundry(transactions: &[FilteredTransaction], output_format: &str) -> String {
+    match output_format {
+        "simple" => encode_simple_format(transactions),
+        "json" => serde_json::to_string(transactions).unwrap_or_else(|_| "[]".to_string()),
+        _ => encode_simple_format(transactions),
+    }
+}
+
+/// Encode transactions in a simple pipe-delimited format that's easy to parse in Solidity
+fn encode_simple_format(transactions: &[FilteredTransaction]) -> String {
+    if transactions.is_empty() {
+        return "0".to_string();
+    }
+    
+    let mut result = format!("{}", transactions.len());
+    
+    for tx in transactions {
+        // Format: hash|from|to|value|data|blockNumber|txIndex|gasPrice
+        result.push('|');
+        result.push_str(&tx.hash);
+        result.push('|');
+        result.push_str(&tx.from);
+        result.push('|');
+        result.push_str(&tx.to);
+        result.push('|');
+        result.push_str(&tx.value);
+        result.push('|');
+        result.push_str(&tx.data);
+        result.push('|');
+        result.push_str(&tx.block_number);
+        result.push('|');
+        result.push_str(&tx.transaction_index);
+        result.push('|');
+        result.push_str(&tx.gas_price);
+    }
+    
+    result
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let matches = Command::new("Transaction Fetcher")
+        .about("Fetches blockchain transactions for backtesting")
+        .arg(
+            Arg::new("rpc-url")
+                .long("rpc-url")
+                .value_name("URL")
+                .help("RPC endpoint URL")
+                .required(true),
+        )
+        .arg(
+            Arg::new("target-contract")
+                .long("target-contract")
+                .value_name("ADDRESS")
+                .help("Contract address to filter transactions for")
+                .required(true),
+        )
+        .arg(
+            Arg::new("start-block")
+                .long("start-block")
+                .value_name("NUMBER")
+                .help("Starting block number")
+                .required(true),
+        )
+        .arg(
+            Arg::new("end-block")
+                .long("end-block")
+                .value_name("NUMBER")
+                .help("Ending block number")
+                .required(true),
+        )
+        .arg(
+            Arg::new("output-format")
+                .long("output-format")
+                .value_name("FORMAT")
+                .help("Output format (simple, json)")
+                .default_value("simple"),
+        )
+        .arg(
+            Arg::new("optimized")
+                .long("optimized")
+                .action(clap::ArgAction::SetTrue)
+                .help("Use optimized parallel processing"),
+        )
+        .arg(
+            Arg::new("batch-size")
+                .long("batch-size")
+                .value_name("SIZE")
+                .help("Batch size for parallel processing (default: 10)")
+                .default_value("10"),
+        )
+        .arg(
+            Arg::new("max-concurrent")
+                .long("max-concurrent")
+                .value_name("COUNT")
+                .help("Maximum concurrent requests (default: 5)")
+                .default_value("5"),
+        )
+        .get_matches();
+
+    let rpc_url = matches.get_one::<String>("rpc-url").unwrap();
+    let target_contract = matches.get_one::<String>("target-contract").unwrap();
+    let start_block: u64 = matches.get_one::<String>("start-block").unwrap().parse()?;
+    let end_block: u64 = matches.get_one::<String>("end-block").unwrap().parse()?;
+    let output_format = matches.get_one::<String>("output-format").unwrap();
+    let use_optimized = matches.get_flag("optimized");
+    let batch_size: usize = matches.get_one::<String>("batch-size").unwrap().parse()?;
+    let max_concurrent: usize = matches.get_one::<String>("max-concurrent").unwrap().parse()?;
+
+    println!("TRANSACTION_DATA:START");
+    
+    let transactions = if use_optimized {
+        fetch_block_range_transactions_optimized(
+            rpc_url,
+            start_block,
+            end_block,
+            target_contract,
+            batch_size,
+            max_concurrent,
+        ).await?
+    } else {
+        fetch_block_range_transactions(
+            rpc_url,
+            start_block,
+            end_block,
+            target_contract,
+        ).await?
+    };
+
+    let encoded_data = encode_transactions_for_foundry(&transactions, output_format);
+    println!("TRANSACTION_DATA:{}", encoded_data);
+    println!("TRANSACTION_DATA:END");
+
+    Ok(())
+}

--- a/src/backtesting/BacktestingTypes.sol
+++ b/src/backtesting/BacktestingTypes.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Backtesting Types
+/// @notice Minimal type definitions for backtesting
+library BacktestingTypes {
+    /// @notice Validation result categories for detailed error analysis
+    enum ValidationResult {
+        Success, // Transaction passed all assertions
+        AssertionFailed, // Assertion logic failed (actual protocol violation)
+        TransactionReverted, // Transaction reverted during execution
+        ForkError, // Failed to fork blockchain state
+        InvalidTransaction, // Transaction data parsing or validation failed
+        GasLimitExceeded, // Transaction exceeded gas limit
+        StateMismatch, // Forked state doesn't match expected
+        UnknownError // Unexpected error during validation
+
+    }
+
+    /// @notice Transaction data from blockchain
+    struct TransactionData {
+        bytes32 hash;
+        address from;
+        address to;
+        uint256 value;
+        bytes data;
+        uint256 blockNumber;
+        uint256 transactionIndex;
+        uint256 gasPrice;
+    }
+
+    /// @notice Detailed validation result with error information
+    struct ValidationDetails {
+        ValidationResult result;
+        string errorMessage; // Human-readable error description
+        bytes errorData; // Raw error data for debugging
+        uint256 gasUsed; // Gas used by the transaction
+        bool isProtocolViolation; // Whether this represents a real protocol issue
+    }
+
+    /// @notice Configuration for backtesting runs
+    struct BacktestingConfig {
+        address targetContract;
+        uint256 endBlock;
+        uint256 blockRange;
+        bytes assertionCreationCode;
+        bytes4 assertionSelector;
+        string rpcUrl;
+    }
+
+    /// @notice Enhanced backtesting results with detailed categorization
+    struct BacktestingResults {
+        uint256 totalTransactions;
+        uint256 successfulValidations;
+        uint256 failedValidations;
+        uint256 errorTransactions;
+        // Detailed breakdown by error type
+        uint256 assertionFailures; // Real protocol violations
+        uint256 transactionReverts; // Transaction execution failures
+        uint256 forkErrors; // Blockchain state issues
+        uint256 invalidTransactions; // Data parsing issues
+        uint256 gasLimitExceeded; // Gas-related failures
+        uint256 stateMismatches; // State consistency issues
+        uint256 unknownErrors; // Unexpected failures
+    }
+}

--- a/src/backtesting/BacktestingTypes.sol
+++ b/src/backtesting/BacktestingTypes.sol
@@ -33,8 +33,6 @@ library BacktestingTypes {
     struct ValidationDetails {
         ValidationResult result;
         string errorMessage; // Human-readable error description
-        bytes errorData; // Raw error data for debugging
-        uint256 gasUsed; // Gas used by the transaction
         bool isProtocolViolation; // Whether this represents a real protocol issue
     }
 
@@ -53,7 +51,6 @@ library BacktestingTypes {
         uint256 totalTransactions;
         uint256 successfulValidations;
         uint256 failedValidations;
-        uint256 errorTransactions;
         // Detailed breakdown by error type
         uint256 assertionFailures; // Real protocol violations
         uint256 transactionReverts; // Transaction execution failures

--- a/src/backtesting/BacktestingUtils.sol
+++ b/src/backtesting/BacktestingUtils.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {StdUtils} from "forge-std/StdUtils.sol";
+import {BacktestingTypes} from "./BacktestingTypes.sol";
+
+/// @title Backtesting Utilities
+/// @notice Minimal utility functions for backtesting
+library BacktestingUtils {
+    using Strings for uint256;
+
+    /// @notice Extract transaction data from fetcher output
+    function extractDataLine(string memory output) internal pure returns (string memory) {
+        bytes memory outputBytes = bytes(output);
+        bytes memory marker = bytes("TRANSACTION_DATA:");
+
+        for (uint256 i = 0; i <= outputBytes.length - marker.length; i++) {
+            bool matches = true;
+            for (uint256 j = 0; j < marker.length; j++) {
+                if (outputBytes[i + j] != marker[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                bytes memory result = new bytes(outputBytes.length - (i + marker.length));
+                for (uint256 k = 0; k < result.length; k++) {
+                    result[k] = outputBytes[i + marker.length + k];
+                }
+                return string(result);
+            }
+        }
+        return "";
+    }
+
+    /// @notice Simple pipe-delimited string splitter
+    function splitString(string memory str, string memory) internal pure returns (string[] memory) {
+        bytes memory strBytes = bytes(str);
+
+        // Count pipes
+        uint256 count = 1;
+        for (uint256 i = 0; i < strBytes.length; i++) {
+            if (strBytes[i] == "|") count++;
+        }
+
+        string[] memory parts = new string[](count);
+        uint256 partIndex = 0;
+        uint256 start = 0;
+
+        for (uint256 i = 0; i <= strBytes.length; i++) {
+            if (i == strBytes.length || strBytes[i] == "|") {
+                bytes memory part = new bytes(i - start);
+                for (uint256 j = 0; j < part.length; j++) {
+                    part[j] = strBytes[start + j];
+                }
+                parts[partIndex++] = string(part);
+                start = i + 1;
+            }
+        }
+        return parts;
+    }
+
+    /// @notice Parse hex or decimal string to uint256
+    function stringToUint(string memory str) internal pure returns (uint256) {
+        bytes memory b = bytes(str);
+        if (b.length >= 2 && b[0] == "0" && b[1] == "x") {
+            uint256 result = 0;
+            for (uint256 i = 2; i < b.length; i++) {
+                result = result * 16 + _hexCharToUint8(b[i]);
+            }
+            return result;
+        }
+        return Strings.parseUint(str);
+    }
+
+    /// @notice Parse hex address string to address
+    function stringToAddress(string memory str) internal pure returns (address) {
+        return Strings.parseAddress(str);
+    }
+
+    /// @notice Parse hex string to bytes32
+    function stringToBytes32(string memory str) internal pure returns (bytes32) {
+        bytes memory b = bytes(str);
+        require(b.length == 66 && b[0] == "0" && b[1] == "x", "Invalid bytes32 hex");
+
+        uint256 result = 0;
+        for (uint256 i = 2; i < 66; i++) {
+            result = result * 16 + _hexCharToUint8(b[i]);
+        }
+        return bytes32(result);
+    }
+
+    /// @notice Parse hex string to bytes
+    function hexStringToBytes(string memory str) internal pure returns (bytes memory) {
+        bytes memory b = bytes(str);
+        uint256 start = (b.length >= 2 && b[0] == "0" && b[1] == "x") ? 2 : 0;
+        bytes memory result = new bytes((b.length - start) / 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            result[i] = bytes1(_hexCharToUint8(b[start + i * 2]) * 16 + _hexCharToUint8(b[start + i * 2 + 1]));
+        }
+        return result;
+    }
+
+    /// @notice Convert bytes32 to hex string
+    function bytes32ToHex(bytes32 data) internal pure returns (string memory) {
+        return Strings.toHexString(uint256(data), 32);
+    }
+
+    /// @notice Extract function selector from calldata
+    function extractFunctionSelector(bytes memory data) internal pure returns (string memory) {
+        return data.length >= 4 ? Strings.toHexString(uint32(bytes4(data)), 4) : "N/A";
+    }
+
+    /// @notice Parse transaction data string
+    function parseTransactionData(string memory txDataString)
+        internal
+        pure
+        returns (BacktestingTypes.TransactionData memory txData)
+    {
+        string[] memory parts = splitString(txDataString, "|");
+        require(parts.length >= 8, "Invalid transaction format");
+
+        txData.hash = stringToBytes32(parts[1]);
+        txData.from = stringToAddress(parts[2]);
+        txData.to = stringToAddress(parts[3]);
+        txData.value = stringToUint(parts[4]);
+        txData.data = hexStringToBytes(parts[5]);
+        txData.blockNumber = stringToUint(parts[6]);
+        txData.transactionIndex = stringToUint(parts[7]);
+        if (parts.length > 8) txData.gasPrice = stringToUint(parts[8]);
+    }
+
+    /// @notice Parse multiple transactions from a single data line
+    function parseMultipleTransactions(string memory txDataString)
+        internal
+        pure
+        returns (BacktestingTypes.TransactionData[] memory transactions)
+    {
+        string[] memory parts = splitString(txDataString, "|");
+        require(parts.length >= 9, "Invalid transaction data format");
+
+        uint256 count = stringToUint(parts[0]);
+        require(count > 0, "No transactions found");
+
+        transactions = new BacktestingTypes.TransactionData[](count);
+
+        // Each transaction has 8 fields: hash|from|to|value|data|block|txIndex|gasPrice
+        uint256 fieldsPerTransaction = 8;
+        uint256 expectedParts = 1 + (count * fieldsPerTransaction); // +1 for count at beginning
+        require(parts.length >= expectedParts, "Insufficient transaction data");
+
+        for (uint256 i = 0; i < count; i++) {
+            uint256 startIndex = 1 + (i * fieldsPerTransaction); // Skip count at beginning
+
+            transactions[i] = BacktestingTypes.TransactionData({
+                hash: stringToBytes32(parts[startIndex]),
+                from: stringToAddress(parts[startIndex + 1]),
+                to: stringToAddress(parts[startIndex + 2]),
+                value: stringToUint(parts[startIndex + 3]),
+                data: hexStringToBytes(parts[startIndex + 4]),
+                blockNumber: stringToUint(parts[startIndex + 5]),
+                transactionIndex: stringToUint(parts[startIndex + 6]),
+                gasPrice: stringToUint(parts[startIndex + 7])
+            });
+        }
+    }
+
+    /// @notice Convert hex character to uint8
+    function _hexCharToUint8(bytes1 char) private pure returns (uint8) {
+        if (char >= "0" && char <= "9") return uint8(char) - 48;
+        if (char >= "a" && char <= "f") return uint8(char) - 87;
+        if (char >= "A" && char <= "F") return uint8(char) - 55;
+        revert("Invalid hex char");
+    }
+}

--- a/src/backtesting/CredibleTestWithBacktesting.sol
+++ b/src/backtesting/CredibleTestWithBacktesting.sol
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {CredibleTest} from "../CredibleTest.sol";
+import {Test, console} from "forge-std/Test.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {BacktestingTypes} from "./BacktestingTypes.sol";
+import {BacktestingUtils} from "./BacktestingUtils.sol";
+
+/// @title Extended CredibleTest with Backtesting
+/// @notice CredibleTest with built-in backtesting functionality - as simple as cl.assertion()!
+/// @dev Users inherit from this instead of CredibleTest directly
+abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
+    using Strings for uint256;
+
+    /// @notice Execute backtesting with simple interface (like cl.assertion!)
+    /// @param targetContract Contract to test assertions against
+    /// @param endBlock Latest block to test (works backwards)
+    /// @param blockRange Number of blocks to test
+    /// @param assertionCreationCode Bytecode for assertion contract
+    /// @param assertionSelector Function selector to trigger
+    /// @param rpcUrl RPC URL for blockchain access
+    /// @return results Detailed backtesting results with error categorization
+    function executeBacktest(
+        address targetContract,
+        uint256 endBlock,
+        uint256 blockRange,
+        bytes memory assertionCreationCode,
+        bytes4 assertionSelector,
+        string memory rpcUrl
+    ) public returns (BacktestingTypes.BacktestingResults memory results) {
+        // Log configuration at the start
+        console.log("=== BACKTESTING CONFIGURATION ===");
+        console.log(string.concat("Target contract: ", Strings.toHexString(targetContract)));
+        console.log(
+            string.concat(
+                "Block range: ",
+                (endBlock > blockRange ? endBlock - blockRange + 1 : 1).toString(),
+                " to ",
+                endBlock.toString()
+            )
+        );
+        console.log(string.concat("Assertion selector: ", Strings.toHexString(uint32(assertionSelector), 4)));
+        console.log(string.concat("RPC URL: ", rpcUrl));
+        console.log("=================================");
+
+        console.log("=== BACKTESTING START ===");
+        console.log(string.concat("Target contract: ", Strings.toHexString(targetContract)));
+
+        uint256 startBlock = endBlock > blockRange ? endBlock - blockRange + 1 : 1;
+        console.log(string.concat("Block range: ", startBlock.toString(), " to ", endBlock.toString()));
+
+        BacktestingTypes.TransactionData[] memory transactions =
+            _fetchTransactions(targetContract, startBlock, endBlock, rpcUrl);
+        results.totalTransactions = transactions.length;
+        console.log(string.concat("Total transactions found: ", results.totalTransactions.toString()));
+
+        if (transactions.length == 0) {
+            console.log("No transactions to process");
+            _printResults(startBlock, endBlock);
+            return results;
+        }
+
+        for (uint256 i = 0; i < transactions.length; i++) {
+            BacktestingTypes.ValidationDetails memory validation =
+                _validateTransaction(targetContract, assertionCreationCode, assertionSelector, rpcUrl, transactions[i]);
+
+            if (validation.result == BacktestingTypes.ValidationResult.Success) {
+                results.successfulValidations++;
+                console.log(
+                    string.concat(
+                        "[PASS] TX ",
+                        (i + 1).toString(),
+                        " ",
+                        BacktestingUtils.bytes32ToHex(transactions[i].hash),
+                        " ",
+                        BacktestingUtils.extractFunctionSelector(transactions[i].data)
+                    )
+                );
+            } else {
+                results.failedValidations++;
+                _categorizeAndLogError(i, transactions[i], validation);
+                _incrementErrorCounter(results, validation.result);
+            }
+        }
+
+        _printDetailedResults(startBlock, endBlock, results);
+        return results;
+    }
+
+    /// @notice Execute backtesting with config struct
+    function executeBacktest(BacktestingTypes.BacktestingConfig memory config)
+        public
+        returns (BacktestingTypes.BacktestingResults memory results)
+    {
+        return executeBacktest(
+            config.targetContract,
+            config.endBlock,
+            config.blockRange,
+            config.assertionCreationCode,
+            config.assertionSelector,
+            config.rpcUrl
+        );
+    }
+
+    /// @notice Convenience function with RPC_URL from environment
+    function executeBacktest(
+        address targetContract,
+        uint256 endBlock,
+        uint256 blockRange,
+        bytes memory assertionCreationCode,
+        bytes4 assertionSelector
+    ) public returns (BacktestingTypes.BacktestingResults memory results) {
+        string memory rpcUrl = vm.envString("RPC_URL");
+        return executeBacktest(targetContract, endBlock, blockRange, assertionCreationCode, assertionSelector, rpcUrl);
+    }
+
+    /// @notice Fetch transactions using FFI
+    function _fetchTransactions(address targetContract, uint256 startBlock, uint256 endBlock, string memory rpcUrl)
+        private
+        returns (BacktestingTypes.TransactionData[] memory transactions)
+    {
+        // Build FFI command with optimized settings
+        string[] memory inputs = new string[](17);
+        inputs[0] = "rust-script";
+        inputs[1] = "scripts/backtesting/transaction_fetcher.rs";
+        inputs[2] = "--rpc-url";
+        inputs[3] = rpcUrl;
+        inputs[4] = "--target-contract";
+        inputs[5] = Strings.toHexString(targetContract);
+        inputs[6] = "--start-block";
+        inputs[7] = startBlock.toString();
+        inputs[8] = "--end-block";
+        inputs[9] = endBlock.toString();
+        inputs[10] = "--optimized";
+        inputs[11] = "--batch-size";
+        inputs[12] = "20"; // Optimized batch size based on performance tests
+        inputs[13] = "--max-concurrent";
+        inputs[14] = "10"; // Optimized concurrency based on performance tests
+        inputs[15] = "--output-format";
+        inputs[16] = "simple";
+
+        // Execute FFI
+        bytes memory result = vm.ffi(inputs);
+        string memory output = string(result);
+        // Parse transactions
+        string memory dataLine = BacktestingUtils.extractDataLine(output);
+
+        if (bytes(dataLine).length == 0 || keccak256(bytes(dataLine)) == keccak256(bytes("0"))) {
+            return new BacktestingTypes.TransactionData[](0);
+        }
+
+        // Parse all transactions from the data line
+        transactions = BacktestingUtils.parseMultipleTransactions(dataLine);
+    }
+
+    /// @notice Validate a single transaction with detailed error categorization
+    function _validateTransaction(
+        address targetContract,
+        bytes memory assertionCreationCode,
+        bytes4 assertionSelector,
+        string memory rpcUrl,
+        BacktestingTypes.TransactionData memory txData
+    ) private returns (BacktestingTypes.ValidationDetails memory validation) {
+        try this._forkAndValidate(targetContract, assertionCreationCode, assertionSelector, rpcUrl, txData) {
+            validation.result = BacktestingTypes.ValidationResult.Success;
+            validation.isProtocolViolation = false;
+        } catch Error(string memory reason) {
+            validation.result = BacktestingTypes.ValidationResult.AssertionFailed;
+            validation.errorMessage = reason;
+            validation.isProtocolViolation = true;
+        } catch Panic(uint256 errorCode) {
+            if (errorCode == 0x01) {
+                validation.result = BacktestingTypes.ValidationResult.AssertionFailed;
+                validation.errorMessage = "Assertion failed";
+                validation.isProtocolViolation = true;
+            } else if (errorCode == 0x11) {
+                validation.result = BacktestingTypes.ValidationResult.GasLimitExceeded;
+                validation.errorMessage = "Gas limit exceeded";
+                validation.isProtocolViolation = false;
+            } else {
+                validation.result = BacktestingTypes.ValidationResult.UnknownError;
+                validation.errorMessage = "Unknown panic";
+                validation.isProtocolViolation = false;
+            }
+        } catch (bytes memory lowLevelData) {
+            validation.result = BacktestingTypes.ValidationResult.UnknownError;
+            validation.errorData = lowLevelData;
+            validation.isProtocolViolation = false;
+        }
+    }
+
+    /// @notice Fork and validate (external for try/catch)
+    function _forkAndValidate(
+        address targetContract,
+        bytes memory assertionCreationCode,
+        bytes4 assertionSelector,
+        string memory rpcUrl,
+        BacktestingTypes.TransactionData memory txData
+    ) external {
+        // Fork to the block before the transaction
+        vm.createSelectFork(rpcUrl, txData.blockNumber - 1);
+        vm.fee(0);
+
+        // Prepare transaction sender
+        vm.stopPrank();
+        vm.deal(txData.from, 10 ether);
+
+        // Setup assertion
+        cl.assertion({adopter: targetContract, createData: assertionCreationCode, fnSelector: assertionSelector});
+
+        // Execute the transaction
+        vm.prank(txData.from);
+        (bool callSuccess,) = txData.to.call{value: txData.value}(txData.data);
+        require(callSuccess || !callSuccess, "Call completed");
+    }
+
+    /// @notice Categorize and log error details
+    function _categorizeAndLogError(
+        uint256 txIndex,
+        BacktestingTypes.TransactionData memory txData,
+        BacktestingTypes.ValidationDetails memory validation
+    ) private pure {
+        string memory errorType = _getErrorTypeString(validation.result);
+        console.log(
+            string.concat(
+                "[",
+                errorType,
+                "] TX ",
+                (txIndex + 1).toString(),
+                " ",
+                BacktestingUtils.bytes32ToHex(txData.hash),
+                " ",
+                BacktestingUtils.extractFunctionSelector(txData.data)
+            )
+        );
+
+        if (bytes(validation.errorMessage).length > 0) {
+            console.log(string.concat("  Error: ", validation.errorMessage));
+        }
+
+        if (validation.isProtocolViolation) {
+            console.log("  !!! PROTOCOL VIOLATION DETECTED");
+        }
+    }
+
+    /// @notice Increment the appropriate error counter
+    function _incrementErrorCounter(
+        BacktestingTypes.BacktestingResults memory results,
+        BacktestingTypes.ValidationResult result
+    ) private pure {
+        if (result == BacktestingTypes.ValidationResult.AssertionFailed) {
+            results.assertionFailures++;
+        } else if (result == BacktestingTypes.ValidationResult.TransactionReverted) {
+            results.transactionReverts++;
+        } else if (result == BacktestingTypes.ValidationResult.ForkError) {
+            results.forkErrors++;
+        } else if (result == BacktestingTypes.ValidationResult.InvalidTransaction) {
+            results.invalidTransactions++;
+        } else if (result == BacktestingTypes.ValidationResult.GasLimitExceeded) {
+            results.gasLimitExceeded++;
+        } else if (result == BacktestingTypes.ValidationResult.StateMismatch) {
+            results.stateMismatches++;
+        } else if (result == BacktestingTypes.ValidationResult.UnknownError) {
+            results.unknownErrors++;
+        }
+    }
+
+    /// @notice Get human-readable error type string
+    function _getErrorTypeString(BacktestingTypes.ValidationResult result) private pure returns (string memory) {
+        if (result == BacktestingTypes.ValidationResult.Success) return "PASS";
+        if (result == BacktestingTypes.ValidationResult.AssertionFailed) return "ASSERTION_FAIL";
+        if (result == BacktestingTypes.ValidationResult.TransactionReverted) return "TX_REVERT";
+        if (result == BacktestingTypes.ValidationResult.ForkError) return "FORK_ERROR";
+        if (result == BacktestingTypes.ValidationResult.InvalidTransaction) return "INVALID_TX";
+        if (result == BacktestingTypes.ValidationResult.GasLimitExceeded) return "GAS_LIMIT";
+        if (result == BacktestingTypes.ValidationResult.StateMismatch) return "STATE_MISMATCH";
+        return "UNKNOWN_ERROR";
+    }
+
+    /// @notice Print detailed results with error categorization
+    function _printDetailedResults(
+        uint256 startBlock,
+        uint256 endBlock,
+        BacktestingTypes.BacktestingResults memory results
+    ) private pure {
+        console.log("");
+        console.log("=== DETAILED BACKTESTING RESULTS ===");
+        console.log(string.concat("Block Range: ", startBlock.toString(), " - ", endBlock.toString()));
+        console.log(string.concat("Total Transactions: ", results.totalTransactions.toString()));
+        console.log(string.concat("Successful Validations: ", results.successfulValidations.toString()));
+        console.log(string.concat("Failed Validations: ", results.failedValidations.toString()));
+        console.log("");
+        console.log("=== ERROR BREAKDOWN ===");
+        console.log(string.concat("Protocol Violations (Assertion Failures): ", results.assertionFailures.toString()));
+        console.log(string.concat("Transaction Reverts: ", results.transactionReverts.toString()));
+        console.log(string.concat("Fork Errors: ", results.forkErrors.toString()));
+        console.log(string.concat("Invalid Transactions: ", results.invalidTransactions.toString()));
+        console.log(string.concat("Gas Limit Exceeded: ", results.gasLimitExceeded.toString()));
+        console.log(string.concat("State Mismatches: ", results.stateMismatches.toString()));
+        console.log(string.concat("Unknown Errors: ", results.unknownErrors.toString()));
+        console.log("");
+
+        uint256 successRate =
+            results.totalTransactions > 0 ? (results.successfulValidations * 100) / results.totalTransactions : 0;
+        console.log(string.concat("Success Rate: ", successRate.toString(), "%"));
+
+        if (results.assertionFailures > 0) {
+            console.log(string.concat("!!! PROTOCOL VIOLATIONS DETECTED: ", results.assertionFailures.toString()));
+        }
+        console.log("================================");
+    }
+
+    /// @notice Print results summary (legacy function for backward compatibility)
+    function _printResults(uint256 startBlock, uint256 endBlock) private pure {
+        console.log("");
+        console.log("=== BACKTESTING RESULTS ===");
+        console.log(string.concat("Block Range: ", startBlock.toString(), " - ", endBlock.toString()));
+        console.log("=========================");
+    }
+}

--- a/src/backtesting/CredibleTestWithBacktesting.sol
+++ b/src/backtesting/CredibleTestWithBacktesting.sol
@@ -8,12 +8,12 @@ import {BacktestingTypes} from "./BacktestingTypes.sol";
 import {BacktestingUtils} from "./BacktestingUtils.sol";
 
 /// @title Extended CredibleTest with Backtesting
-/// @notice CredibleTest with built-in backtesting functionality - as simple as cl.assertion()!
+/// @notice CredibleTest with built-in backtesting functionality
 /// @dev Users inherit from this instead of CredibleTest directly
 abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
     using Strings for uint256;
 
-    /// @notice Execute backtesting with simple interface (like cl.assertion!)
+    /// @notice Execute backtesting with simple interface
     /// @param targetContract Contract to test assertions against
     /// @param endBlock Latest block to test (works backwards)
     /// @param blockRange Number of blocks to test
@@ -57,7 +57,7 @@ abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
 
         if (transactions.length == 0) {
             console.log("No transactions to process");
-            _printResults(startBlock, endBlock);
+            console.log(string.concat("Block range: ", startBlock.toString(), " to ", endBlock.toString()));
             return results;
         }
 
@@ -121,7 +121,7 @@ abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
         returns (BacktestingTypes.TransactionData[] memory transactions)
     {
         // Build FFI command with optimized settings
-        string[] memory inputs = new string[](17);
+        string[] memory inputs = new string[](16);
         inputs[0] = "rust-script";
         inputs[1] = "scripts/backtesting/transaction_fetcher.rs";
         inputs[2] = "--rpc-url";
@@ -132,13 +132,12 @@ abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
         inputs[7] = startBlock.toString();
         inputs[8] = "--end-block";
         inputs[9] = endBlock.toString();
-        inputs[10] = "--optimized";
-        inputs[11] = "--batch-size";
-        inputs[12] = "20"; // Optimized batch size based on performance tests
-        inputs[13] = "--max-concurrent";
-        inputs[14] = "10"; // Optimized concurrency based on performance tests
-        inputs[15] = "--output-format";
-        inputs[16] = "simple";
+        inputs[10] = "--batch-size";
+        inputs[11] = "20"; // Optimized batch size based on performance tests
+        inputs[12] = "--max-concurrent";
+        inputs[13] = "10"; // Optimized concurrency based on performance tests
+        inputs[14] = "--output-format";
+        inputs[15] = "simple";
 
         // Execute FFI
         bytes memory result = vm.ffi(inputs);
@@ -183,9 +182,8 @@ abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
                 validation.errorMessage = "Unknown panic";
                 validation.isProtocolViolation = false;
             }
-        } catch (bytes memory lowLevelData) {
+        } catch (bytes memory) {
             validation.result = BacktestingTypes.ValidationResult.UnknownError;
-            validation.errorData = lowLevelData;
             validation.isProtocolViolation = false;
         }
     }
@@ -309,13 +307,5 @@ abstract contract CredibleTestWithBacktesting is CredibleTest, Test {
             console.log(string.concat("!!! PROTOCOL VIOLATIONS DETECTED: ", results.assertionFailures.toString()));
         }
         console.log("================================");
-    }
-
-    /// @notice Print results summary (legacy function for backward compatibility)
-    function _printResults(uint256 startBlock, uint256 endBlock) private pure {
-        console.log("");
-        console.log("=== BACKTESTING RESULTS ===");
-        console.log(string.concat("Block Range: ", startBlock.toString(), " - ", endBlock.toString()));
-        console.log("=========================");
     }
 }

--- a/src/backtesting/README.md
+++ b/src/backtesting/README.md
@@ -1,0 +1,184 @@
+# Backtesting Module
+
+Backtesting functionality for credible-std that allows you to test assertions against historical blockchain transactions.
+
+## Overview
+
+The backtesting module provides a simple interface to validate assertions against real blockchain transactions.
+
+## Quick Start
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {CredibleTestWithBacktesting} from "../src/backtesting/CredibleTestWithBacktesting.sol";
+import {BacktestingTypes} from "../src/backtesting/BacktestingTypes.sol";
+import {MyAssertion} from "../assertions/src/MyAssertion.a.sol";
+
+contract MyBacktestingTest is CredibleTestWithBacktesting {
+    function testHistoricalTransactions() public {
+        // Execute backtesting with one function call
+        BacktestingTypes.BacktestingResults memory results = executeBacktest({
+            targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+            endBlock: 31336940,
+            blockRange: 20,
+            assertionCreationCode: type(MyAssertion).creationCode,
+            assertionSelector: MyAssertion.assertionInvariant.selector,
+            rpcUrl: "https://sepolia.optimism.io"
+        });
+
+        // Check results
+        assert(results.assertionFailures == 0, "Found protocol violations!");
+    }
+}
+```
+
+## Running Tests
+
+You can either define the RPC in the environment variable `RPC_URL` or pass it as a parameter to the `executeBacktest` function.
+
+```bash
+# Set RPC URL environment variable
+export RPC_URL="https://sepolia.optimism.io"
+
+# Run backtesting tests
+pcl test --ffi --match-test testHistoricalTransactions
+
+# With RPC URL in the command
+pcl test --ffi --match-test testHistoricalTransactions --rpc-url https://sepolia.optimism.io
+```
+
+## API Reference
+
+### Main Function
+
+```solidity
+function executeBacktest(
+    address targetContract, // Contract to test assertions against
+    uint256 endBlock, // Latest block to test (works backwards)
+    uint256 blockRange, // Number of blocks to test
+    bytes memory assertionCreationCode, // Bytecode for assertion contract
+    bytes4 assertionSelector, // Function selector to trigger
+    string memory rpcUrl // RPC URL endpoint
+) public returns (BacktestingTypes.BacktestingResults memory results)
+```
+
+### Configuration Struct
+
+```solidity
+struct BacktestingConfig {
+    address targetContract;      // Contract to test assertions against
+    uint256 endBlock;            // Latest block to test (works backwards)
+    uint256 blockRange;          // Number of blocks to test
+    bytes assertionCreationCode; // Bytecode for assertion contract
+    bytes4 assertionSelector;    // Function selector to trigger
+    string rpcUrl;               // RPC URL for blockchain access
+}
+```
+
+### Results Struct
+
+```solidity
+struct BacktestingResults {
+    uint256 totalTransactions;
+    uint256 successfulValidations;
+    uint256 failedValidations;
+    uint256 errorTransactions;
+    
+    // Detailed error breakdown
+    uint256 assertionFailures;      // Real protocol violations
+    uint256 transactionReverts;     // Transaction execution failures
+    uint256 forkErrors;             // Blockchain state issues
+    uint256 invalidTransactions;    // Data parsing issues
+    uint256 gasLimitExceeded;       // Gas-related failures
+    uint256 stateMismatches;        // State consistency issues
+    uint256 unknownErrors;          // Unexpected failures
+}
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```solidity
+function testBasicBacktesting() public {
+    BacktestingTypes.BacktestingResults memory results = executeBacktest({
+        targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+        endBlock: 31336940,
+        blockRange: 20,
+        assertionCreationCode: type(MyAssertion).creationCode,
+        assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+        rpcUrl: "https://sepolia.optimism.io"
+    });
+
+    console.log("Success rate:", (results.successfulValidations * 100) / results.totalTransactions, "%");
+}
+```
+
+### Using Configuration Struct
+
+```solidity
+function setUp() public {
+    config = BacktestingTypes.BacktestingConfig({
+        targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+        endBlock: 31336940,
+        blockRange: 20,
+        assertionCreationCode: type(MyAssertion).creationCode,
+        assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+        rpcUrl: "https://sepolia.optimism.io"
+    });
+}
+
+function testWithConfig() public {
+    BacktestingTypes.BacktestingResults memory results = executeBacktest(config);
+    // Process results...
+}
+```
+
+### Using Environment Variable
+
+```solidity
+function testWithEnvRPC() public {
+    // Uses RPC_URL from environment
+    BacktestingTypes.BacktestingResults memory results = executeBacktest({
+        targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia 
+        endBlock: 31336940,
+        blockRange: 20,
+        assertionCreationCode: type(MyAssertion).creationCode,
+        assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+        // no rpcUrl needed
+    });
+}
+```
+
+## Error Categorization
+
+The backtesting system provides this error categorization:
+
+- **AssertionFailures**: Real protocol violations (most important)
+- **TransactionReverts**: Expected transaction failures
+- **ForkErrors**: Blockchain state access issues
+- **InvalidTransactions**: Data parsing problems
+- **GasLimitExceeded**: Performance issues
+- **StateMismatches**: State consistency problems
+- **UnknownErrors**: Unexpected failures
+
+## Requirements
+
+- **Rust**: For transaction fetching (rust-script)
+- **RPC Endpoint**: For blockchain data access
+- **Assertion Contract**: Compiled bytecode and function selector
+
+## File Structure
+
+```
+src/backtesting/
+├── BacktestingTypes.sol          # Type definitions
+├── BacktestingUtils.sol          # Utility functions
+├── CredibleTestWithBacktesting.sol # Main backtesting contract
+└── README.md                     # This file
+
+scripts/backtesting/
+└── transaction_fetcher.rs        # Rust script for transaction fetching
+```

--- a/src/backtesting/test/assertion/src/ERC20Assertion.a.sol
+++ b/src/backtesting/test/assertion/src/ERC20Assertion.a.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../../../Assertion.sol";
+import {PhEvm} from "../../../../PhEvm.sol";
+import {console} from "../../../../Console.sol";
+import {MockERC20} from "../../src/MockERC20.sol";
+
+/// @title ERC20Assertion
+/// @notice Contract containing invariant assertions for ERC20 token transfers
+/// @dev These assertions verify that transfers maintain proper balance accounting
+contract ERC20Assertion is Assertion {
+    /// @notice Registers which functions should trigger which assertions
+    /// @dev Links transfer and transferFrom functions to their respective invariant checks
+    function triggers() external view override {
+        registerCallTrigger(this.assertionTransferInvariant.selector, MockERC20.transfer.selector);
+        registerCallTrigger(this.assertionTransferFromInvariant.selector, MockERC20.transferFrom.selector);
+    }
+
+    /// @notice Verifies the transfer invariant
+    /// @dev This assertion ensures that:
+    /// 1. Sender's balance decreases by exactly the transfer amount
+    /// 2. Receiver's balance increases by exactly the transfer amount
+    /// 3. Total supply remains unchanged
+    /// 4. No tokens are created or destroyed during transfer
+    function assertionTransferInvariant() external {
+        MockERC20 token = MockERC20(ph.getAssertionAdopter());
+
+        // Get all transfer calls that occurred
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(token), MockERC20.transfer.selector);
+
+        // Capture the state before any transfers
+        ph.forkPreTx();
+        uint256 preTotalSupply = token.totalSupply();
+
+        // Capture the state after transfers
+        ph.forkPostTx();
+        uint256 postTotalSupply = token.totalSupply();
+
+        // Ensure total supply never changes during transfers
+        require(postTotalSupply == preTotalSupply, "Total supply changed during transfer");
+
+        // Check each transfer call individually
+        for (uint256 i = 0; i < calls.length; i++) {
+            // Skip proxy calls to avoid double counting
+            if (calls[i].bytecode_address == calls[i].target_address) {
+                continue;
+            }
+
+            // Decode the transfer parameters
+            (address to, uint256 amount) = abi.decode(calls[i].input, (address, uint256));
+            address from = calls[i].caller;
+
+            // Get balances before the transfer
+            ph.forkPreCall(calls[i].id);
+            uint256 fromPreBalance = token.balanceOf(from);
+            uint256 toPreBalance = token.balanceOf(to);
+
+            // Get balances after the transfer
+            ph.forkPostCall(calls[i].id);
+            uint256 fromPostBalance = token.balanceOf(from);
+            uint256 toPostBalance = token.balanceOf(to);
+
+            // Handle self-transfer case (from == to)
+            if (from == to) {
+                require(fromPostBalance == fromPreBalance, "Self-transfer changed balance");
+            } else {
+                // Verify sender's balance decreased by the correct amount
+                require(fromPostBalance == fromPreBalance - amount, "Sender balance not decreased correctly");
+
+                // Verify receiver's balance increased by the correct amount
+                require(toPostBalance == toPreBalance + amount, "Receiver balance not increased correctly");
+            }
+        }
+        console.log("Transfer invariant reached the end");
+    }
+
+    /// @notice Verifies the transferFrom invariant
+    /// @dev This assertion ensures that:
+    /// 1. Sender's balance decreases by exactly the transfer amount
+    /// 2. Receiver's balance increases by exactly the transfer amount
+    /// 3. Total supply remains unchanged
+    /// 4. No tokens are created or destroyed during transferFrom
+    function assertionTransferFromInvariant() external {
+        MockERC20 token = MockERC20(ph.getAssertionAdopter());
+
+        // Get all transferFrom calls that occurred
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(token), MockERC20.transferFrom.selector);
+
+        // Capture the state before any transfers
+        ph.forkPreTx();
+        uint256 preTotalSupply = token.totalSupply();
+
+        // Capture the state after transfers
+        ph.forkPostTx();
+        uint256 postTotalSupply = token.totalSupply();
+
+        // Ensure total supply never changes during transfers
+        require(postTotalSupply == preTotalSupply, "Total supply changed during transferFrom");
+
+        // Check each transferFrom call individually
+        for (uint256 i = 0; i < calls.length; i++) {
+            // Skip proxy calls to avoid double counting
+            if (calls[i].bytecode_address == calls[i].target_address) {
+                continue;
+            }
+
+            // Decode the transferFrom parameters
+            (address from, address to, uint256 amount) = abi.decode(calls[i].input, (address, address, uint256));
+
+            // Get balances before the transfer
+            ph.forkPreCall(calls[i].id);
+            uint256 fromPreBalance = token.balanceOf(from);
+            uint256 toPreBalance = token.balanceOf(to);
+
+            // Get balances after the transfer
+            ph.forkPostCall(calls[i].id);
+            uint256 fromPostBalance = token.balanceOf(from);
+            uint256 toPostBalance = token.balanceOf(to);
+
+            // Handle self-transfer case (from == to)
+            if (from == to) {
+                require(fromPostBalance == fromPreBalance, "Self-transferFrom changed balance");
+            } else {
+                // Verify sender's balance decreased by the correct amount
+                require(
+                    fromPostBalance == fromPreBalance - amount, "Sender balance not decreased correctly in transferFrom"
+                );
+
+                // Verify receiver's balance increased by the correct amount
+                require(
+                    toPostBalance == toPreBalance + amount, "Receiver balance not increased correctly in transferFrom"
+                );
+            }
+        }
+    }
+}

--- a/src/backtesting/test/assertion/test/UsdcOpSepoliaBacktesting.t.sol
+++ b/src/backtesting/test/assertion/test/UsdcOpSepoliaBacktesting.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test, console} from "forge-std/Test.sol";
+import {CredibleTestWithBacktesting} from "../../../CredibleTestWithBacktesting.sol";
+import {BacktestingTypes} from "../../../BacktestingTypes.sol";
+import {ERC20Assertion} from "../src/ERC20Assertion.a.sol";
+
+/// @title Simple Backtesting Test
+/// @notice Demonstrates the backtesting interface
+contract UsdcOpSepoliaBacktestingTest is CredibleTestWithBacktesting {
+    // Configuration that can be set in setUp()
+    BacktestingTypes.BacktestingConfig public config;
+
+    /// @notice Setup backtesting configuration - automatically called by Forge!
+    function setUp() public {
+        // Configure your backtesting parameters here
+        config = BacktestingTypes.BacktestingConfig({
+            targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+            endBlock: 31336940, // Known block with transfer
+            blockRange: 20, // 20 blocks before
+            assertionCreationCode: type(ERC20Assertion).creationCode,
+            assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+            rpcUrl: "https://sepolia.optimism.io"
+        });
+    }
+
+    /// @notice Test ERC20 assertion with setup configuration - ultra clean!
+    function testBacktestingWithSetup() public {
+        // Execute backtesting using setup configuration - one line!
+        BacktestingTypes.BacktestingResults memory results = executeBacktest(config);
+
+        // Results are automatically logged
+        console.log("=== SETUP-BASED RESULTS ===");
+        console.log("Total processed:", results.totalTransactions);
+        console.log(
+            "Success rate:",
+            results.totalTransactions > 0 ? (results.successfulValidations * 100) / results.totalTransactions : 0,
+            "%"
+        );
+    }
+
+    /// @notice Test USDC on mainnet Sepolia
+    function testMainnetSepoliaUSDC() public {
+        console.log("=== MAINNET SEPOLIA USDC BACKTESTING ===");
+
+        // Execute backtesting on mainnet Sepolia USDC
+        BacktestingTypes.BacktestingResults memory results = executeBacktest({
+            targetContract: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238, // USDC on mainnet Sepolia
+            endBlock: 8925198, // Recent block on mainnet Sepolia
+            blockRange: 10, // 10 blocks before
+            assertionCreationCode: type(ERC20Assertion).creationCode,
+            assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+            rpcUrl: "https://eth-sepolia.g.alchemy.com/v2/cA7wNaynRKdZ96F6sBZTC"
+        });
+
+        // Results are automatically logged
+        console.log("=== MAINNET SEPOLIA RESULTS ===");
+        console.log("Total processed:", results.totalTransactions);
+        console.log(
+            "Success rate:",
+            results.totalTransactions > 0 ? (results.successfulValidations * 100) / results.totalTransactions : 0,
+            "%"
+        );
+    }
+
+    /// @notice Test ERC20 assertion with the new interface
+    function testSimpleERC20Backtesting() public {
+        // Skip if RPC_URL not provided
+        try vm.envString("RPC_URL") returns (string memory) {
+            console.log("=== SIMPLE BACKTESTING DEMO ===");
+
+            // Execute backtesting with one simple function call!
+            BacktestingTypes.BacktestingResults memory results = executeBacktest({
+                targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+                endBlock: 31250000, // Recent block
+                blockRange: 100, // Test range
+                assertionCreationCode: type(ERC20Assertion).creationCode,
+                assertionSelector: ERC20Assertion.assertionTransferInvariant.selector
+            });
+
+            // Results are automatically logged, but we can also use them
+            console.log("=== FINAL SUMMARY ===");
+            console.log("Total processed:", results.totalTransactions);
+            console.log(
+                "Success rate:",
+                results.totalTransactions > 0 ? (results.successfulValidations * 100) / results.totalTransactions : 0,
+                "%"
+            );
+        } catch {
+            console.log("WARNING: RPC_URL not provided, skipping backtesting test");
+        }
+    }
+
+    /// @notice Test with explicit RPC URL
+    function testSimpleBacktestingWithRPC() public {
+        console.log("=== SIMPLE BACKTESTING WITH EXPLICIT RPC ===");
+
+        // Execute backtesting with explicit RPC
+        BacktestingTypes.BacktestingResults memory results = executeBacktest({
+            targetContract: 0x5fd84259d66Cd46123540766Be93DFE6D43130D7, // USDC on Optimism Sepolia
+            endBlock: 31336940, // Known block with transfer
+            blockRange: 20, // 20 blocks before
+            assertionCreationCode: type(ERC20Assertion).creationCode,
+            assertionSelector: ERC20Assertion.assertionTransferInvariant.selector,
+            rpcUrl: "https://sepolia.optimism.io"
+        });
+
+        // Demonstrate how easy it is to use the results
+        if (results.totalTransactions > 0) {
+            uint256 successRate = (results.successfulValidations * 100) / results.totalTransactions;
+            console.log("Backtesting completed with", successRate, "% success rate");
+
+            if (results.failedValidations > 0) {
+                console.log("WARNING:", results.failedValidations, "transactions failed assertions");
+            }
+
+            if (results.assertionFailures > 0) {
+                console.log("ERROR:", results.assertionFailures, "transactions had assertion failures");
+            }
+        } else {
+            console.log("No transactions found in the specified range");
+        }
+    }
+
+    /// @notice Demonstrate different assertion types
+    function testMultipleAssertionTypes() public pure {
+        // This demonstrates how easy it would be to test different assertions
+        // (commented out since we don't have the contracts, but shows the pattern)
+
+        /*
+        // Test ERC20 transfers
+        executeBacktest({
+            targetContract: 0x...,
+            endBlock: 31250000,
+            blockRange: 100,
+            assertionCreationCode: type(ERC20Assertion).creationCode,
+            assertionSelector: ERC20Assertion.assertionTransferInvariant.selector
+        });
+        
+        // Test lending protocol
+        executeBacktest({
+            targetContract: 0x...,
+            endBlock: 31250000,
+            blockRange: 100,
+            assertionCreationCode: type(LendingAssertion).creationCode,
+            assertionSelector: LendingAssertion.assertionDepositInvariant.selector
+        });
+        
+        // Test DEX swaps
+        executeBacktest({
+            targetContract: 0x...,
+            endBlock: 31250000,
+            blockRange: 100,
+            assertionCreationCode: type(DEXAssertion).creationCode,
+            assertionSelector: DEXAssertion.assertionSwapInvariant.selector
+        });
+        */
+
+        console.log("Multiple assertion types would be this easy to test!");
+    }
+}

--- a/src/backtesting/test/src/MockERC20.sol
+++ b/src/backtesting/test/src/MockERC20.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
+/// @title Mock ERC20 Token for Testing
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 1000000 * 10 ** 6); // Mint 1M tokens to deployer (6 decimals like USDC)
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return 6; // Match USDC decimals
+    }
+
+    /// @notice Transfer tokens to another address
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        address owner = _msgSender();
+        _transfer(owner, to, amount);
+        return true;
+    }
+
+    /// @notice Transfer tokens from one address to another using allowance
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        address spender = _msgSender();
+        _spendAllowance(from, spender, amount);
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    /// @notice Approve another address to spend tokens on your behalf
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        address owner = _msgSender();
+        _approve(owner, spender, amount);
+        return true;
+    }
+}


### PR DESCRIPTION
Add comprehensive backtesting functionality to credible-std that allows testing
assertions against historical blockchain transactions.

Key Features:
- Simple API: executeBacktest() function with multiple overloads
- Error categorization: Detailed breakdown of validation results

Technical Implementation:
- BacktestingTypes.sol: Type definitions for transactions and results
- BacktestingUtils.sol: Utility functions for data parsing and processing
- CredibleTestWithBacktesting.sol: Main backtesting contract with error categorization
- transaction_fetcher.rs: Rust script with parallel processing
- README.md: Documentation with examples