### PR TITLE
feat: add V2 precompile test fixtures and cl.assertion harness

### DIFF
--- a/src/test-cases/precompiles/AssertionStorage.sol
+++ b/src/test-cases/precompiles/AssertionStorage.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+contract TestAssertionStorage is Assertion {
+    constructor() payable {}
+
+    function storeAndLoadRoundtrips() external {
+        bytes32 key = keccak256("assertion-storage-test/key-1");
+        bytes32 value = bytes32(uint256(0xdeadbeef));
+
+        ph.store(key, value);
+        require(ph.load(key) == value, "load returned wrong value");
+    }
+
+    function existsReportsWrittenKeys() external {
+        bytes32 missingKey = keccak256("assertion-storage-test/missing");
+        require(!ph.exists(missingKey), "missing key should not exist");
+
+        bytes32 key = keccak256("assertion-storage-test/key-2");
+        ph.store(key, bytes32(uint256(1)));
+        require(ph.exists(key), "key should exist after store");
+    }
+
+    function overwriteKeepsKeyExisting() external {
+        bytes32 key = keccak256("assertion-storage-test/key-3");
+        ph.store(key, bytes32(uint256(1)));
+        ph.store(key, bytes32(uint256(2)));
+        require(ph.load(key) == bytes32(uint256(2)), "overwrite did not stick");
+        require(ph.exists(key), "key should still exist after overwrite");
+    }
+
+    function valuesLeftDecreasesAsKeysAreWritten() external {
+        uint256 before_ = ph.values_left();
+        bytes32 key = keccak256("assertion-storage-test/key-4");
+        ph.store(key, bytes32(uint256(7)));
+        uint256 after_ = ph.values_left();
+        require(after_ < before_, "values_left did not decrease");
+        require(before_ - after_ == 1, "values_left should drop by exactly 1");
+
+        // Overwriting an existing key must not consume additional slots.
+        ph.store(key, bytes32(uint256(8)));
+        require(ph.values_left() == after_, "overwrite should not consume a slot");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.storeAndLoadRoundtrips.selector);
+        registerCallTrigger(this.existsReportsWrittenKeys.selector);
+        registerCallTrigger(this.overwriteKeepsKeyExisting.selector);
+        registerCallTrigger(this.valuesLeftDecreasesAsKeysAreWritten.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(1);
+    }
+}

--- a/src/test-cases/precompiles/AssetsMatchSharePrice.sol
+++ b/src/test-cases/precompiles/AssetsMatchSharePrice.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+
+contract MockVault {
+    uint256 public totalAssets;
+    uint256 public totalSupply;
+
+    function deposit(uint256 assets, uint256 shares) external {
+        totalAssets += assets;
+        totalSupply += shares;
+    }
+
+    function inflate(uint256 extraAssets) external {
+        totalAssets += extraAssets;
+    }
+}
+
+MockVault constant VAULT = MockVault(0xdCCf1eEB153eF28fdc3CF97d33f60576cF092e9c);
+
+contract TestAssetsMatchSharePrice is Assertion {
+    constructor() payable {}
+
+    function _deposits() internal view returns (PhEvm.CallInputs[] memory) {
+        return ph.getCallInputs(address(VAULT), MockVault.deposit.selector);
+    }
+
+    function proportionalDepositsKeepSharePriceConstant() external {
+        // Pre vs post-deposit (1:1 ratio preserved at every step) within zero-tolerance: must pass.
+        PhEvm.CallInputs[] memory calls = _deposits();
+        require(calls.length == 2, "expected 2 deposit calls");
+
+        require(
+            ph.assetsMatchSharePriceAt(address(VAULT), 0, _postCall(calls[0].id), _postCall(calls[1].id)),
+            "ratio-preserving deposits must keep share price stable"
+        );
+    }
+
+    function tightTolerancePassesOnStableSharePrice() external {
+        require(ph.assetsMatchSharePrice(address(VAULT), 0), "share price must be stable across all forks");
+    }
+
+    function identicalForksAlwaysPass() external {
+        require(
+            ph.assetsMatchSharePriceAt(address(VAULT), 0, _postTx(), _postTx()), "same-fork compare must pass"
+        );
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.proportionalDepositsKeepSharePriceConstant.selector);
+        registerCallTrigger(this.tightTolerancePassesOnStableSharePrice.selector);
+        registerCallTrigger(this.identicalForksAlwaysPass.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        // Two proportional deposits — 1:1 asset-to-share ratio held throughout.
+        VAULT.deposit(100, 100);
+        VAULT.deposit(50, 50);
+    }
+}

--- a/src/test-cases/precompiles/AssetsMatchSharePrice.sol
+++ b/src/test-cases/precompiles/AssetsMatchSharePrice.sol
@@ -43,9 +43,7 @@ contract TestAssetsMatchSharePrice is Assertion {
     }
 
     function identicalForksAlwaysPass() external {
-        require(
-            ph.assetsMatchSharePriceAt(address(VAULT), 0, _postTx(), _postTx()), "same-fork compare must pass"
-        );
+        require(ph.assetsMatchSharePriceAt(address(VAULT), 0, _postTx(), _postTx()), "same-fork compare must pass");
     }
 
     function triggers() external view override {

--- a/src/test-cases/precompiles/ConserveBalance.sol
+++ b/src/test-cases/precompiles/ConserveBalance.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+
+contract BalanceToken {
+    mapping(address => uint256) internal _balanceOf;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balanceOf[account];
+    }
+
+    function setBalance(address account, uint256 amount) external {
+        _balanceOf[account] = amount;
+    }
+
+    function transfer(address from, address to, uint256 amount) external {
+        _balanceOf[from] -= amount;
+        _balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}
+
+BalanceToken constant TOKEN = BalanceToken(0xdCCf1eEB153eF28fdc3CF97d33f60576cF092e9c);
+
+address constant HOLDER = address(0xBEEF);
+address constant MOVER = address(0xCAFE);
+
+contract TestConserveBalance is Assertion {
+    constructor() payable {}
+
+    function conservedAccountReturnsTrue() external {
+        // HOLDER is never touched in TriggeringTx; balance must match across forks.
+        require(ph.conserveBalance(_preTx(), _postTx(), address(TOKEN), HOLDER), "HOLDER balance must be conserved");
+    }
+
+    function changedAccountReturnsFalse() external {
+        // MOVER's balance shifts during the transaction; conservation must fail.
+        require(!ph.conserveBalance(_preTx(), _postTx(), address(TOKEN), MOVER), "MOVER balance should differ");
+    }
+
+    function identicalForksAlwaysConserve() external {
+        require(ph.conserveBalance(_postTx(), _postTx(), address(TOKEN), MOVER), "same-fork compare must hold");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.conservedAccountReturnsTrue.selector);
+        registerCallTrigger(this.changedAccountReturnsFalse.selector);
+        registerCallTrigger(this.identicalForksAlwaysConserve.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TOKEN.setBalance(MOVER, 100);
+        TOKEN.transfer(MOVER, address(0xDEAD), 25);
+    }
+}

--- a/src/test-cases/precompiles/Context.sol
+++ b/src/test-cases/precompiles/Context.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+contract TestContext is Assertion {
+    constructor() payable {}
+
+    function checkContext() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+
+        require(ctx.selector == Target.writeStorage.selector, "ctx.selector != writeStorage");
+        require(ctx.callEnd >= ctx.callStart, "callEnd < callStart");
+
+        bytes memory input = ph.callinputAt(ctx.callStart);
+        require(
+            keccak256(input) == keccak256(abi.encodeWithSelector(Target.writeStorage.selector, uint256(42))),
+            "ctx.callStart input mismatch"
+        );
+
+        // PostCall fork at ctx.callEnd should reflect the write.
+        bytes32 slot = bytes32(uint256(0));
+        bytes32 post = ph.loadStateAt(address(TARGET), slot, _postCall(ctx.callEnd));
+        require(post == bytes32(uint256(42)), "post-call value != 42");
+    }
+
+    function triggers() external view override {
+        registerFnCallTrigger(this.checkContext.selector, Target.writeStorage.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(42);
+    }
+}

--- a/src/test-cases/precompiles/Erc20Transfers.sol
+++ b/src/test-cases/precompiles/Erc20Transfers.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+
+contract MockErc20 {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function transferFromTo(address from, address to, uint256 value) external {
+        emit Transfer(from, to, value);
+    }
+}
+
+MockErc20 constant TOKEN_A = MockErc20(0xdCCf1eEB153eF28fdc3CF97d33f60576cF092e9c);
+MockErc20 constant TOKEN_B = MockErc20(0x40f7EBE92dD6bdbEECADFFF3F9d7A1B33Cf8d7c0);
+
+address constant ALICE = address(0xA11CE);
+address constant BOB = address(0xB0B);
+address constant CAROL = address(0xCA801);
+
+contract TestErc20Transfers is Assertion {
+    constructor() payable {}
+
+    function _postTxFork() internal pure returns (PhEvm.ForkId memory) {
+        return _postTx();
+    }
+
+    function getErc20TransfersReturnsAllTransfersForToken() external view {
+        PhEvm.Erc20TransferData[] memory transfers = ph.getErc20Transfers(address(TOKEN_A), _postTxFork());
+        require(transfers.length == 3, "expected 3 transfers on TOKEN_A");
+
+        require(transfers[0].token_addr == address(TOKEN_A), "transfer[0] token mismatch");
+        require(transfers[0].from == ALICE && transfers[0].to == BOB, "transfer[0] from/to");
+        require(transfers[0].value == 100, "transfer[0] value != 100");
+
+        require(transfers[1].from == ALICE && transfers[1].to == BOB, "transfer[1] from/to");
+        require(transfers[1].value == 200, "transfer[1] value != 200");
+
+        require(transfers[2].from == BOB && transfers[2].to == CAROL, "transfer[2] from/to");
+        require(transfers[2].value == 50, "transfer[2] value != 50");
+    }
+
+    function getErc20TransfersForTokensMergesAcrossTokens() external view {
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(TOKEN_A);
+        tokens[1] = address(TOKEN_B);
+
+        PhEvm.Erc20TransferData[] memory transfers = ph.getErc20TransfersForTokens(tokens, _postTxFork());
+        require(transfers.length == 4, "expected 3 + 1 = 4 combined transfers");
+    }
+
+    function changedErc20BalanceDeltasReturnsRawTransfers() external view {
+        PhEvm.Erc20TransferData[] memory deltas = ph.changedErc20BalanceDeltas(address(TOKEN_A), _postTxFork());
+        require(deltas.length == 3, "changedErc20BalanceDeltas should mirror getErc20Transfers");
+    }
+
+    function reduceErc20BalanceDeltasAggregatesByPair() external view {
+        PhEvm.Erc20TransferData[] memory deltas = ph.reduceErc20BalanceDeltas(address(TOKEN_A), _postTxFork());
+
+        // Pairs: (ALICE -> BOB) collapses to one row of 300, (BOB -> CAROL) stays at 50.
+        require(deltas.length == 2, "expected 2 reduced pairs");
+
+        require(deltas[0].from == ALICE && deltas[0].to == BOB, "pair[0] should be ALICE->BOB");
+        require(deltas[0].value == 300, "ALICE->BOB net != 300");
+
+        require(deltas[1].from == BOB && deltas[1].to == CAROL, "pair[1] should be BOB->CAROL");
+        require(deltas[1].value == 50, "BOB->CAROL net != 50");
+    }
+
+    function unknownTokenReturnsEmpty() external view {
+        PhEvm.Erc20TransferData[] memory transfers =
+            ph.getErc20Transfers(address(0x000000000000000000000000000000000000dEaD), _postTxFork());
+        require(transfers.length == 0, "non-token address should yield no transfers");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.getErc20TransfersReturnsAllTransfersForToken.selector);
+        registerCallTrigger(this.getErc20TransfersForTokensMergesAcrossTokens.selector);
+        registerCallTrigger(this.changedErc20BalanceDeltasReturnsRawTransfers.selector);
+        registerCallTrigger(this.reduceErc20BalanceDeltasAggregatesByPair.selector);
+        registerCallTrigger(this.unknownTokenReturnsEmpty.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TOKEN_A.transferFromTo(ALICE, BOB, 100);
+        TOKEN_A.transferFromTo(ALICE, BOB, 200);
+        TOKEN_A.transferFromTo(BOB, CAROL, 50);
+        TOKEN_B.transferFromTo(ALICE, CAROL, 1);
+    }
+}

--- a/src/test-cases/precompiles/GetLogsForCall.sol
+++ b/src/test-cases/precompiles/GetLogsForCall.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+contract TestGetLogsForCall is Assertion {
+    constructor() payable {}
+
+    function _anyEmitter() internal pure returns (PhEvm.LogQuery memory) {
+        return PhEvm.LogQuery({emitter: address(0), signature: bytes32(0)});
+    }
+
+    function _logQueryForTarget() internal pure returns (PhEvm.LogQuery memory) {
+        return PhEvm.LogQuery({emitter: address(TARGET), signature: Target.Log.selector});
+    }
+
+    function logsAreScopedToTheirCall() external view {
+        PhEvm.CallInputs[] memory writes = ph.getCallInputs(address(TARGET), Target.writeStorage.selector);
+        require(writes.length == 2, "expected 2 writeStorage calls");
+
+        PhEvm.Log[] memory firstLogs = ph.getLogsForCall(_logQueryForTarget(), writes[0].id);
+        require(firstLogs.length == 1, "first call: expected 1 log");
+        require(firstLogs[0].emitter == address(TARGET), "first log emitter mismatch");
+        require(bytes32(firstLogs[0].data) == bytes32(uint256(11)), "first log data != 11");
+
+        PhEvm.Log[] memory secondLogs = ph.getLogsForCall(_logQueryForTarget(), writes[1].id);
+        require(secondLogs.length == 1, "second call: expected 1 log");
+        require(bytes32(secondLogs[0].data) == bytes32(uint256(22)), "second log data != 22");
+    }
+
+    function emptyQueryReturnsAllLogsInCallFrame() external view {
+        PhEvm.CallInputs[] memory writes = ph.getCallInputs(address(TARGET), Target.writeStorage.selector);
+        require(writes.length == 2, "expected 2 writeStorage calls");
+
+        PhEvm.Log[] memory logs = ph.getLogsForCall(_anyEmitter(), writes[0].id);
+        require(logs.length == 1, "expected 1 log in first call frame");
+    }
+
+    function nonMatchingSignatureReturnsEmpty() external view {
+        PhEvm.CallInputs[] memory writes = ph.getCallInputs(address(TARGET), Target.writeStorage.selector);
+        require(writes.length == 2, "expected 2 writeStorage calls");
+
+        PhEvm.LogQuery memory query =
+            PhEvm.LogQuery({emitter: address(TARGET), signature: keccak256("Nonexistent(uint256)")});
+        PhEvm.Log[] memory logs = ph.getLogsForCall(query, writes[0].id);
+        require(logs.length == 0, "non-matching signature should return empty");
+    }
+
+    function callWithoutLogsReturnsEmpty() external view {
+        PhEvm.CallInputs[] memory reads = ph.getStaticCallInputs(address(TARGET), Target.readStorage.selector);
+        require(reads.length == 1, "expected 1 readStorage staticcall");
+
+        PhEvm.Log[] memory logs = ph.getLogsForCall(_anyEmitter(), reads[0].id);
+        require(logs.length == 0, "readStorage emits no logs");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.logsAreScopedToTheirCall.selector);
+        registerCallTrigger(this.emptyQueryReturnsAllLogsInCallFrame.selector);
+        registerCallTrigger(this.nonMatchingSignatureReturnsEmpty.selector);
+        registerCallTrigger(this.callWithoutLogsReturnsEmpty.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(11);
+        TARGET.writeStorage(22);
+        TARGET.readStorage();
+    }
+}

--- a/src/test-cases/precompiles/InflowOutflowContext.sol
+++ b/src/test-cases/precompiles/InflowOutflowContext.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+/// @dev Verifies the inflow/outflow context precompiles return a zeroed struct when called
+///      outside of their watchCumulative{Inflow,Outflow} trigger context. The non-zero
+///      paths require a circuit-breaker fixture and are covered by protection-suite tests.
+contract TestInflowOutflowContextOutsideTrigger is Assertion {
+    constructor() payable {}
+
+    function outflowContextOutsideTriggerIsZero() external view {
+        PhEvm.OutflowContext memory ctx = ph.outflowContext();
+        require(ctx.token == address(0), "outflow token must be zero outside trigger");
+        require(ctx.cumulativeOutflow == 0, "outflow cumulative must be zero");
+        require(ctx.absoluteOutflow == 0, "outflow absolute must be zero");
+        require(ctx.currentBps == 0, "outflow bps must be zero");
+        require(ctx.tvlSnapshot == 0, "outflow tvl must be zero");
+        require(ctx.windowStart == 0, "outflow windowStart must be zero");
+        require(ctx.windowEnd == 0, "outflow windowEnd must be zero");
+    }
+
+    function inflowContextOutsideTriggerIsZero() external view {
+        PhEvm.InflowContext memory ctx = ph.inflowContext();
+        require(ctx.token == address(0), "inflow token must be zero outside trigger");
+        require(ctx.cumulativeInflow == 0, "inflow cumulative must be zero");
+        require(ctx.absoluteInflow == 0, "inflow absolute must be zero");
+        require(ctx.currentBps == 0, "inflow bps must be zero");
+        require(ctx.tvlSnapshot == 0, "inflow tvl must be zero");
+        require(ctx.windowStart == 0, "inflow windowStart must be zero");
+        require(ctx.windowEnd == 0, "inflow windowEnd must be zero");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.outflowContextOutsideTriggerIsZero.selector);
+        registerCallTrigger(this.inflowContextOutsideTriggerIsZero.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(1);
+    }
+}

--- a/src/test-cases/precompiles/MatchingCalls.sol
+++ b/src/test-cases/precompiles/MatchingCalls.sol
@@ -10,11 +10,7 @@ contract TestMatchingCalls is Assertion {
 
     function _anyFilter() internal pure returns (PhEvm.CallFilter memory) {
         return PhEvm.CallFilter({
-            callType: 0,
-            minDepth: 0,
-            maxDepth: type(uint32).max,
-            topLevelOnly: false,
-            successOnly: false
+            callType: 0, minDepth: 0, maxDepth: type(uint32).max, topLevelOnly: false, successOnly: false
         });
     }
 
@@ -33,8 +29,7 @@ contract TestMatchingCalls is Assertion {
         PhEvm.CallFilter memory filter = _anyFilter();
         filter.callType = 2; // STATICCALL
 
-        PhEvm.TriggerCall[] memory calls =
-            ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
         require(calls.length == 1, "expected exactly 1 staticcall to readStorage");
         require(calls[0].callType == 2, "callType != STATICCALL");
     }
@@ -43,8 +38,7 @@ contract TestMatchingCalls is Assertion {
         PhEvm.CallFilter memory filter = _anyFilter();
         filter.callType = 1; // CALL
 
-        PhEvm.TriggerCall[] memory calls =
-            ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
         require(calls.length == 0, "CALL filter should not match staticcall");
     }
 
@@ -52,8 +46,7 @@ contract TestMatchingCalls is Assertion {
         PhEvm.CallFilter memory filter = _anyFilter();
         filter.topLevelOnly = true;
 
-        PhEvm.TriggerCall[] memory calls =
-            ph.matchingCalls(address(TARGET), Target.writeStorage.selector, filter, 10);
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(address(TARGET), Target.writeStorage.selector, filter, 10);
         // Only the top-level writeStorage(1) call is depth==1; the call from incrementStorage is nested.
         require(calls.length == 1, "expected 1 top-level writeStorage");
         require(calls[0].depth == 1, "depth != 1");

--- a/src/test-cases/precompiles/MatchingCalls.sol
+++ b/src/test-cases/precompiles/MatchingCalls.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+contract TestMatchingCalls is Assertion {
+    constructor() payable {}
+
+    function _anyFilter() internal pure returns (PhEvm.CallFilter memory) {
+        return PhEvm.CallFilter({
+            callType: 0,
+            minDepth: 0,
+            maxDepth: type(uint32).max,
+            topLevelOnly: false,
+            successOnly: false
+        });
+    }
+
+    function matchesAllWriteCalls() external view {
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.writeStorage.selector, _anyFilter(), 10);
+        require(calls.length == 3, "expected 3 writeStorage calls (incl. nested)");
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            require(calls[i].target == address(TARGET), "target mismatch");
+            require(calls[i].selector == Target.writeStorage.selector, "selector mismatch");
+        }
+    }
+
+    function staticCallTypeFilterMatchesOnlyStaticCalls() external view {
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.callType = 2; // STATICCALL
+
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
+        require(calls.length == 1, "expected exactly 1 staticcall to readStorage");
+        require(calls[0].callType == 2, "callType != STATICCALL");
+    }
+
+    function callTypeFilterExcludesStaticCalls() external view {
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.callType = 1; // CALL
+
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.readStorage.selector, filter, 10);
+        require(calls.length == 0, "CALL filter should not match staticcall");
+    }
+
+    function topLevelOnlyExcludesNestedCalls() external view {
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.topLevelOnly = true;
+
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.writeStorage.selector, filter, 10);
+        // Only the top-level writeStorage(1) call is depth==1; the call from incrementStorage is nested.
+        require(calls.length == 1, "expected 1 top-level writeStorage");
+        require(calls[0].depth == 1, "depth != 1");
+    }
+
+    function successOnlyExcludesFailedCalls() external view {
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.successOnly = true;
+
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.writeStorageAndRevert.selector, filter, 10);
+        require(calls.length == 0, "successOnly should exclude the reverting call");
+
+        filter.successOnly = false;
+        calls = ph.matchingCalls(address(TARGET), Target.writeStorageAndRevert.selector, filter, 10);
+        require(calls.length == 1, "expected 1 reverting call when successOnly=false");
+        require(!calls[0].success, "expected success=false");
+    }
+
+    function limitTruncatesResultArray() external view {
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(address(TARGET), Target.writeStorage.selector, _anyFilter(), 1);
+        require(calls.length == 1, "limit=1 should truncate to 1 result");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.matchesAllWriteCalls.selector);
+        registerCallTrigger(this.staticCallTypeFilterMatchesOnlyStaticCalls.selector);
+        registerCallTrigger(this.callTypeFilterExcludesStaticCalls.selector);
+        registerCallTrigger(this.topLevelOnlyExcludesNestedCalls.selector);
+        registerCallTrigger(this.successOnlyExcludesFailedCalls.selector);
+        registerCallTrigger(this.limitTruncatesResultArray.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(1);
+        TARGET.incrementStorage(); // nested writeStorage(2)
+        TARGET.readStorage(); // staticcall
+        try TARGET.writeStorageAndRevert(99) {
+            revert("expected revert");
+        } catch {}
+    }
+}

--- a/src/test-cases/precompiles/MathPrecompiles.sol
+++ b/src/test-cases/precompiles/MathPrecompiles.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+import {Target, TARGET} from "../common/Target.sol";
+
+contract TestMathPrecompiles is Assertion {
+    constructor() payable {}
+
+    function mulDivDownRoundsTowardZero() external view {
+        require(ph.mulDivDown(7, 3, 2) == 10, "7*3/2 floor != 10");
+        require(ph.mulDivDown(6, 3, 2) == 9, "6*3/2 floor != 9");
+        require(ph.mulDivDown(0, 1234, 5) == 0, "0*x/y != 0");
+        require(ph.mulDivDown(1, 1, 2) == 0, "1*1/2 floor != 0");
+    }
+
+    function mulDivUpRoundsAwayFromZero() external view {
+        require(ph.mulDivUp(7, 3, 2) == 11, "7*3/2 ceil != 11");
+        require(ph.mulDivUp(6, 3, 2) == 9, "6*3/2 ceil != 9 (exact)");
+        require(ph.mulDivUp(1, 1, 2) == 1, "1*1/2 ceil != 1");
+        require(ph.mulDivUp(0, 1234, 5) == 0, "ceil(0) != 0");
+    }
+
+    function mulDivHandlesWideIntermediates() external view {
+        // Without 512-bit intermediates, max * 2 would overflow.
+        uint256 max = type(uint256).max;
+        require(ph.mulDivDown(max, 2, max) == 2, "mulDivDown(max,2,max) != 2");
+        require(ph.mulDivUp(max, 2, max) == 2, "mulDivUp(max,2,max) != 2");
+    }
+
+    function normalizeDecimalsUpscalesAndDownscales() external view {
+        require(ph.normalizeDecimals(1e6, 6, 18) == 1e18, "1e6@6 -> 18 != 1e18");
+        require(ph.normalizeDecimals(1e18, 18, 6) == 1e6, "1e18@18 -> 6 != 1e6");
+        require(ph.normalizeDecimals(123, 8, 8) == 123, "no-op decimals changed value");
+        require(ph.normalizeDecimals(0, 6, 18) == 0, "0 should stay 0");
+    }
+
+    function ratioGePassesExactEquality() external view {
+        // 10/2 == 5/1 — equal ratios, zero tolerance.
+        require(ph.ratioGe(10, 2, 5, 1, 0), "10/2 >= 5/1 should hold");
+    }
+
+    function ratioGeFailsWhenStrictlySmaller() external view {
+        // 4/2 < 5/2, zero tolerance.
+        require(!ph.ratioGe(4, 2, 5, 2, 0), "4/2 should not be >= 5/2");
+    }
+
+    function ratioGeRespectsTolerance() external view {
+        // 19/1 vs 20/1 with 1000 bps tolerance: 19 >= 20 * (1 - 0.10) = 18 -> true
+        require(ph.ratioGe(19, 1, 20, 1, 1000), "19 should clear 20 within 10% tolerance");
+
+        // 17/1 vs 20/1 with 1000 bps: 17 < 18 -> false
+        require(!ph.ratioGe(17, 1, 20, 1, 1000), "17 should fail 20 within 10% tolerance");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.mulDivDownRoundsTowardZero.selector);
+        registerCallTrigger(this.mulDivUpRoundsAwayFromZero.selector);
+        registerCallTrigger(this.mulDivHandlesWideIntermediates.selector);
+        registerCallTrigger(this.normalizeDecimalsUpscalesAndDownscales.selector);
+        registerCallTrigger(this.ratioGePassesExactEquality.selector);
+        registerCallTrigger(this.ratioGeFailsWhenStrictlySmaller.selector);
+        registerCallTrigger(this.ratioGeRespectsTolerance.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        TARGET.writeStorage(1);
+    }
+}

--- a/src/test-cases/precompiles/OracleSanity.sol
+++ b/src/test-cases/precompiles/OracleSanity.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../Assertion.sol";
+import {PhEvm} from "../../PhEvm.sol";
+
+contract MockOracle {
+    uint256 public price;
+
+    function setPrice(uint256 newPrice) external {
+        price = newPrice;
+    }
+
+    function latestPrice() external view returns (uint256) {
+        return price;
+    }
+}
+
+MockOracle constant ORACLE = MockOracle(0xdCCf1eEB153eF28fdc3CF97d33f60576cF092e9c);
+
+contract TestOracleSanity is Assertion {
+    constructor() payable {}
+
+    function _query() internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(MockOracle.latestPrice.selector);
+    }
+
+    function _setPriceCalls() internal view returns (PhEvm.CallInputs[] memory) {
+        return ph.getCallInputs(address(ORACLE), MockOracle.setPrice.selector);
+    }
+
+    function smallMoveWithinToleranceReturnsTrue() external {
+        // Compare post-state of the two adjacent setPrice calls (1e18 -> 1.005e18 ≈ 0.5%).
+        PhEvm.CallInputs[] memory calls = _setPriceCalls();
+        require(calls.length == 2, "expected 2 setPrice calls");
+
+        require(
+            ph.oracleSanityAt(address(ORACLE), _query(), 1000, _postCall(calls[0].id), _postCall(calls[1].id)),
+            "0.5% move should pass 10% tolerance"
+        );
+    }
+
+    function largeMoveOutsideToleranceReturnsFalse() external {
+        PhEvm.CallInputs[] memory calls = _setPriceCalls();
+        require(calls.length == 2, "expected 2 setPrice calls");
+
+        // 0.5% > 10 bps tolerance.
+        require(
+            !ph.oracleSanityAt(address(ORACLE), _query(), 10, _postCall(calls[0].id), _postCall(calls[1].id)),
+            "0.5% move should fail 0.1% tolerance"
+        );
+    }
+
+    function identicalForksAlwaysPass() external {
+        require(ph.oracleSanityAt(address(ORACLE), _query(), 0, _postTx(), _postTx()), "same-fork compare must pass");
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.smallMoveWithinToleranceReturnsTrue.selector);
+        registerCallTrigger(this.largeMoveOutsideToleranceReturnsFalse.selector);
+        registerCallTrigger(this.identicalForksAlwaysPass.selector);
+    }
+}
+
+contract TriggeringTx {
+    constructor() payable {
+        ORACLE.setPrice(1e18);
+        ORACLE.setPrice(1.005e18);
+    }
+}

--- a/test/precompiles/V2Precompiles.t.sol
+++ b/test/precompiles/V2Precompiles.t.sol
@@ -64,9 +64,7 @@ contract V2PrecompilesTest is Test, CredibleTest {
     function test_CallInputAt_emptyCalldataReturnsEmptyBytes() public {
         _etchTarget();
         _arm(
-            address(TARGET),
-            type(TestCallInputAt).creationCode,
-            TestCallInputAt.emptyCalldataReturnsEmptyBytes.selector
+            address(TARGET), type(TestCallInputAt).creationCode, TestCallInputAt.emptyCalldataReturnsEmptyBytes.selector
         );
         new CallInputAtTx();
     }
@@ -137,9 +135,7 @@ contract V2PrecompilesTest is Test, CredibleTest {
     function test_GetLogsForCall_logsAreScopedToTheirCall() public {
         _etchTarget();
         _arm(
-            address(TARGET),
-            type(TestGetLogsForCall).creationCode,
-            TestGetLogsForCall.logsAreScopedToTheirCall.selector
+            address(TARGET), type(TestGetLogsForCall).creationCode, TestGetLogsForCall.logsAreScopedToTheirCall.selector
         );
         new LogsForCallTx();
     }
@@ -336,7 +332,9 @@ contract V2PrecompilesTest is Test, CredibleTest {
     function test_Erc20_unknownTokenReturnsEmpty() public {
         _etchErc20();
         _arm(
-            address(TOKEN_A), type(TestErc20Transfers).creationCode, TestErc20Transfers.unknownTokenReturnsEmpty.selector
+            address(TOKEN_A),
+            type(TestErc20Transfers).creationCode,
+            TestErc20Transfers.unknownTokenReturnsEmpty.selector
         );
         new Erc20Tx();
     }

--- a/test/precompiles/V2Precompiles.t.sol
+++ b/test/precompiles/V2Precompiles.t.sol
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../src/CredibleTest.sol";
+import {Target, TARGET} from "../../src/test-cases/common/Target.sol";
+
+import {TestCallInputAt, TriggeringTx as CallInputAtTx} from "../../src/test-cases/precompiles/CallInputAt.sol";
+import {TestContext, TriggeringTx as ContextTx} from "../../src/test-cases/precompiles/Context.sol";
+import {TestMatchingCalls, TriggeringTx as MatchingCallsTx} from "../../src/test-cases/precompiles/MatchingCalls.sol";
+import {TestGetLogsForCall, TriggeringTx as LogsForCallTx} from "../../src/test-cases/precompiles/GetLogsForCall.sol";
+import {TestAssertionStorage, TriggeringTx as StorageTx} from "../../src/test-cases/precompiles/AssertionStorage.sol";
+import {TestMathPrecompiles, TriggeringTx as MathTx} from "../../src/test-cases/precompiles/MathPrecompiles.sol";
+import {
+    TestErc20Transfers,
+    MockErc20,
+    TOKEN_A,
+    TOKEN_B,
+    TriggeringTx as Erc20Tx
+} from "../../src/test-cases/precompiles/Erc20Transfers.sol";
+import {
+    TestConserveBalance,
+    BalanceToken,
+    TOKEN as BAL_TOKEN,
+    TriggeringTx as ConserveTx
+} from "../../src/test-cases/precompiles/ConserveBalance.sol";
+import {
+    TestOracleSanity,
+    MockOracle,
+    ORACLE,
+    TriggeringTx as OracleTx
+} from "../../src/test-cases/precompiles/OracleSanity.sol";
+import {
+    TestAssetsMatchSharePrice,
+    MockVault,
+    VAULT,
+    TriggeringTx as VaultTx
+} from "../../src/test-cases/precompiles/AssetsMatchSharePrice.sol";
+import {
+    TestInflowOutflowContextOutsideTrigger,
+    TriggeringTx as InflowOutflowTx
+} from "../../src/test-cases/precompiles/InflowOutflowContext.sol";
+
+/// @notice cl.assertion-armed harness for the V2 precompile fixtures.
+/// @dev Each test arms a single assertion function against its adopter, then deploys the
+///      fixture's TriggeringTx so its constructor performs the watched operations.
+contract V2PrecompilesTest is Test, CredibleTest {
+    function _etchTarget() internal {
+        vm.etch(address(TARGET), address(new Target()).code);
+    }
+
+    function _arm(address adopter, bytes memory createCode, bytes4 sel) internal {
+        cl.assertion(adopter, createCode, sel);
+    }
+
+    // ── CallInputAt ─────────────────────────────────────────────────────────
+    function test_CallInputAt_callInputAt() public {
+        _etchTarget();
+        _arm(address(TARGET), type(TestCallInputAt).creationCode, TestCallInputAt.callInputAt.selector);
+        new CallInputAtTx();
+    }
+
+    function test_CallInputAt_emptyCalldataReturnsEmptyBytes() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestCallInputAt).creationCode,
+            TestCallInputAt.emptyCalldataReturnsEmptyBytes.selector
+        );
+        new CallInputAtTx();
+    }
+
+    // ── Context ─────────────────────────────────────────────────────────────
+    function test_Context_checkContext() public {
+        _etchTarget();
+        _arm(address(TARGET), type(TestContext).creationCode, TestContext.checkContext.selector);
+        new ContextTx();
+    }
+
+    // ── MatchingCalls ───────────────────────────────────────────────────────
+    function test_MatchingCalls_matchesAllWriteCalls() public {
+        _etchTarget();
+        _arm(address(TARGET), type(TestMatchingCalls).creationCode, TestMatchingCalls.matchesAllWriteCalls.selector);
+        new MatchingCallsTx();
+    }
+
+    function test_MatchingCalls_staticCallTypeFilterMatchesOnlyStaticCalls() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMatchingCalls).creationCode,
+            TestMatchingCalls.staticCallTypeFilterMatchesOnlyStaticCalls.selector
+        );
+        new MatchingCallsTx();
+    }
+
+    function test_MatchingCalls_callTypeFilterExcludesStaticCalls() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMatchingCalls).creationCode,
+            TestMatchingCalls.callTypeFilterExcludesStaticCalls.selector
+        );
+        new MatchingCallsTx();
+    }
+
+    function test_MatchingCalls_topLevelOnlyExcludesNestedCalls() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMatchingCalls).creationCode,
+            TestMatchingCalls.topLevelOnlyExcludesNestedCalls.selector
+        );
+        new MatchingCallsTx();
+    }
+
+    function test_MatchingCalls_successOnlyExcludesFailedCalls() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMatchingCalls).creationCode,
+            TestMatchingCalls.successOnlyExcludesFailedCalls.selector
+        );
+        new MatchingCallsTx();
+    }
+
+    function test_MatchingCalls_limitTruncatesResultArray() public {
+        _etchTarget();
+        _arm(
+            address(TARGET), type(TestMatchingCalls).creationCode, TestMatchingCalls.limitTruncatesResultArray.selector
+        );
+        new MatchingCallsTx();
+    }
+
+    // ── GetLogsForCall ──────────────────────────────────────────────────────
+    function test_GetLogsForCall_logsAreScopedToTheirCall() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestGetLogsForCall).creationCode,
+            TestGetLogsForCall.logsAreScopedToTheirCall.selector
+        );
+        new LogsForCallTx();
+    }
+
+    function test_GetLogsForCall_emptyQueryReturnsAllLogsInCallFrame() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestGetLogsForCall).creationCode,
+            TestGetLogsForCall.emptyQueryReturnsAllLogsInCallFrame.selector
+        );
+        new LogsForCallTx();
+    }
+
+    function test_GetLogsForCall_nonMatchingSignatureReturnsEmpty() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestGetLogsForCall).creationCode,
+            TestGetLogsForCall.nonMatchingSignatureReturnsEmpty.selector
+        );
+        new LogsForCallTx();
+    }
+
+    function test_GetLogsForCall_callWithoutLogsReturnsEmpty() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestGetLogsForCall).creationCode,
+            TestGetLogsForCall.callWithoutLogsReturnsEmpty.selector
+        );
+        new LogsForCallTx();
+    }
+
+    // ── AssertionStorage ────────────────────────────────────────────────────
+    function test_AssertionStorage_storeAndLoadRoundtrips() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestAssertionStorage).creationCode,
+            TestAssertionStorage.storeAndLoadRoundtrips.selector
+        );
+        new StorageTx();
+    }
+
+    function test_AssertionStorage_existsReportsWrittenKeys() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestAssertionStorage).creationCode,
+            TestAssertionStorage.existsReportsWrittenKeys.selector
+        );
+        new StorageTx();
+    }
+
+    function test_AssertionStorage_overwriteKeepsKeyExisting() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestAssertionStorage).creationCode,
+            TestAssertionStorage.overwriteKeepsKeyExisting.selector
+        );
+        new StorageTx();
+    }
+
+    function test_AssertionStorage_valuesLeftDecreasesAsKeysAreWritten() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestAssertionStorage).creationCode,
+            TestAssertionStorage.valuesLeftDecreasesAsKeysAreWritten.selector
+        );
+        new StorageTx();
+    }
+
+    // ── MathPrecompiles ─────────────────────────────────────────────────────
+    function test_Math_mulDivDownRoundsTowardZero() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.mulDivDownRoundsTowardZero.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_mulDivUpRoundsAwayFromZero() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.mulDivUpRoundsAwayFromZero.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_mulDivHandlesWideIntermediates() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.mulDivHandlesWideIntermediates.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_normalizeDecimalsUpscalesAndDownscales() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.normalizeDecimalsUpscalesAndDownscales.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_ratioGePassesExactEquality() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.ratioGePassesExactEquality.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_ratioGeFailsWhenStrictlySmaller() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.ratioGeFailsWhenStrictlySmaller.selector
+        );
+        new MathTx();
+    }
+
+    function test_Math_ratioGeRespectsTolerance() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestMathPrecompiles).creationCode,
+            TestMathPrecompiles.ratioGeRespectsTolerance.selector
+        );
+        new MathTx();
+    }
+
+    // ── Erc20Transfers ──────────────────────────────────────────────────────
+    function _etchErc20() internal {
+        bytes memory code = address(new MockErc20()).code;
+        vm.etch(address(TOKEN_A), code);
+        vm.etch(address(TOKEN_B), code);
+    }
+
+    function test_Erc20_getErc20TransfersReturnsAllTransfersForToken() public {
+        _etchErc20();
+        _arm(
+            address(TOKEN_A),
+            type(TestErc20Transfers).creationCode,
+            TestErc20Transfers.getErc20TransfersReturnsAllTransfersForToken.selector
+        );
+        new Erc20Tx();
+    }
+
+    function test_Erc20_getErc20TransfersForTokensMergesAcrossTokens() public {
+        _etchErc20();
+        _arm(
+            address(TOKEN_A),
+            type(TestErc20Transfers).creationCode,
+            TestErc20Transfers.getErc20TransfersForTokensMergesAcrossTokens.selector
+        );
+        new Erc20Tx();
+    }
+
+    function test_Erc20_changedErc20BalanceDeltasReturnsRawTransfers() public {
+        _etchErc20();
+        _arm(
+            address(TOKEN_A),
+            type(TestErc20Transfers).creationCode,
+            TestErc20Transfers.changedErc20BalanceDeltasReturnsRawTransfers.selector
+        );
+        new Erc20Tx();
+    }
+
+    function test_Erc20_reduceErc20BalanceDeltasAggregatesByPair() public {
+        _etchErc20();
+        _arm(
+            address(TOKEN_A),
+            type(TestErc20Transfers).creationCode,
+            TestErc20Transfers.reduceErc20BalanceDeltasAggregatesByPair.selector
+        );
+        new Erc20Tx();
+    }
+
+    function test_Erc20_unknownTokenReturnsEmpty() public {
+        _etchErc20();
+        _arm(
+            address(TOKEN_A), type(TestErc20Transfers).creationCode, TestErc20Transfers.unknownTokenReturnsEmpty.selector
+        );
+        new Erc20Tx();
+    }
+
+    // ── ConserveBalance ─────────────────────────────────────────────────────
+    function _etchBalanceToken() internal {
+        vm.etch(address(BAL_TOKEN), address(new BalanceToken()).code);
+    }
+
+    function test_Conserve_conservedAccountReturnsTrue() public {
+        _etchBalanceToken();
+        _arm(
+            address(BAL_TOKEN),
+            type(TestConserveBalance).creationCode,
+            TestConserveBalance.conservedAccountReturnsTrue.selector
+        );
+        new ConserveTx();
+    }
+
+    function test_Conserve_changedAccountReturnsFalse() public {
+        _etchBalanceToken();
+        _arm(
+            address(BAL_TOKEN),
+            type(TestConserveBalance).creationCode,
+            TestConserveBalance.changedAccountReturnsFalse.selector
+        );
+        new ConserveTx();
+    }
+
+    function test_Conserve_identicalForksAlwaysConserve() public {
+        _etchBalanceToken();
+        _arm(
+            address(BAL_TOKEN),
+            type(TestConserveBalance).creationCode,
+            TestConserveBalance.identicalForksAlwaysConserve.selector
+        );
+        new ConserveTx();
+    }
+
+    // ── OracleSanity ────────────────────────────────────────────────────────
+    function _etchOracle() internal {
+        vm.etch(address(ORACLE), address(new MockOracle()).code);
+    }
+
+    function test_Oracle_smallMoveWithinToleranceReturnsTrue() public {
+        _etchOracle();
+        _arm(
+            address(ORACLE),
+            type(TestOracleSanity).creationCode,
+            TestOracleSanity.smallMoveWithinToleranceReturnsTrue.selector
+        );
+        new OracleTx();
+    }
+
+    function test_Oracle_largeMoveOutsideToleranceReturnsFalse() public {
+        _etchOracle();
+        _arm(
+            address(ORACLE),
+            type(TestOracleSanity).creationCode,
+            TestOracleSanity.largeMoveOutsideToleranceReturnsFalse.selector
+        );
+        new OracleTx();
+    }
+
+    function test_Oracle_identicalForksAlwaysPass() public {
+        _etchOracle();
+        _arm(address(ORACLE), type(TestOracleSanity).creationCode, TestOracleSanity.identicalForksAlwaysPass.selector);
+        new OracleTx();
+    }
+
+    // ── AssetsMatchSharePrice ───────────────────────────────────────────────
+    function _etchVault() internal {
+        vm.etch(address(VAULT), address(new MockVault()).code);
+    }
+
+    function test_Vault_proportionalDepositsKeepSharePriceConstant() public {
+        _etchVault();
+        _arm(
+            address(VAULT),
+            type(TestAssetsMatchSharePrice).creationCode,
+            TestAssetsMatchSharePrice.proportionalDepositsKeepSharePriceConstant.selector
+        );
+        new VaultTx();
+    }
+
+    function test_Vault_tightTolerancePassesOnStableSharePrice() public {
+        _etchVault();
+        _arm(
+            address(VAULT),
+            type(TestAssetsMatchSharePrice).creationCode,
+            TestAssetsMatchSharePrice.tightTolerancePassesOnStableSharePrice.selector
+        );
+        new VaultTx();
+    }
+
+    function test_Vault_identicalForksAlwaysPass() public {
+        _etchVault();
+        _arm(
+            address(VAULT),
+            type(TestAssetsMatchSharePrice).creationCode,
+            TestAssetsMatchSharePrice.identicalForksAlwaysPass.selector
+        );
+        new VaultTx();
+    }
+
+    // ── InflowOutflowContext (outside-trigger zero-struct semantics) ────────
+    function test_InflowOutflow_outflowContextOutsideTriggerIsZero() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestInflowOutflowContextOutsideTrigger).creationCode,
+            TestInflowOutflowContextOutsideTrigger.outflowContextOutsideTriggerIsZero.selector
+        );
+        new InflowOutflowTx();
+    }
+
+    function test_InflowOutflow_inflowContextOutsideTriggerIsZero() public {
+        _etchTarget();
+        _arm(
+            address(TARGET),
+            type(TestInflowOutflowContextOutsideTrigger).creationCode,
+            TestInflowOutflowContextOutsideTrigger.inflowContextOutsideTriggerIsZero.selector
+        );
+        new InflowOutflowTx();
+    }
+}


### PR DESCRIPTION
Adds fixture pairs (Assertion + TriggeringTx) under src/test-cases/precompiles covering context(), matchingCalls, getLogsForCall, callinputAt, persistent assertion storage, math precompiles (mulDiv/normalizeDecimals/ratioGe), ERC20 transfer queries, conserveBalance, oracleSanity, assetsMatchSharePrice, and outside-trigger inflow/outflow context zeroing.

Wires a cl.assertion-armed harness in test/precompiles/V2Precompiles.t.sol that etches each fixture's mock bytecode, arms a single assertion selector, and deploys the fixture's TriggeringTx to exercise the watched operations.