### PR TITLE
feat(anomaly): anomalous tx detection interface

### DIFF
--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -133,6 +133,20 @@ abstract contract Assertion is ForkUtils, StateChanges {
         triggerRecorder.watchCumulativeInflow(token, thresholdBps, windowDuration, fnSelector);
     }
 
+    /// @notice Registers an anomaly-detection trigger. Fires whenever the
+    ///         executor's configured AnomalySubsystem produces a score for
+    ///         `target` in a transaction that touches it.
+    /// @dev The model owns the firing decision: the trigger fires whenever
+    ///      the subsystem returns a score at all. The assertion reads the
+    ///      score back via `ph.anomalyContext(target)` and decides whether
+    ///      to revert, run extra checks, or ignore.
+    /// @param target The address whose anomaly score this assertion observes.
+    /// @param fnSelector The assertion function to invoke when `target` is
+    ///        scored.
+    function watchAnomaly(address target, bytes4 fnSelector) internal view {
+        triggerRecorder.watchAnomaly(target, fnSelector);
+    }
+
     // ---------------------------------------------------------------
     //  V2 call matching
     // ---------------------------------------------------------------

--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -481,6 +481,26 @@ interface PhEvm {
     function inflowContext() external view returns (InflowContext memory ctx);
 
     // ---------------------------------------------------------------
+    //  V2: Anomaly detection
+    // ---------------------------------------------------------------
+
+    /// @notice Context returned by `anomalyContext(target)` describing the
+    ///         anomaly detector's view of `target` for the current tx.
+    /// @dev `scoreBps` is in basis points (0..=10_000), where 0 is
+    ///      "very likely not anomalous" and 10_000 is "very likely anomalous".
+    struct AnomalyContext {
+        uint16 scoreBps;
+    }
+
+    /// @notice Returns the anomaly detector's view of `target` for the
+    ///         current transaction.
+    /// @dev Returns a zero-filled context when `target` was not 
+    ///      able to be scored, such that it fails open.
+    /// @param target The address whose anomaly context to read.
+    /// @return ctx The anomaly context for `target` in the current tx.
+    function anomalyContext(address target) external view returns (AnomalyContext memory ctx);
+
+    // ---------------------------------------------------------------
     //  V2: Protection suite — oracle sanity
     // ---------------------------------------------------------------
 

--- a/src/TriggerRecorder.sol
+++ b/src/TriggerRecorder.sol
@@ -85,4 +85,16 @@ interface TriggerRecorder {
     function watchCumulativeInflow(address token, uint256 thresholdBps, uint256 windowDuration, bytes4 fnSelector)
         external
         view;
+
+    /// @notice Registers an anomaly-detection trigger. Fires whenever the
+    ///         executor's configured AnomalySubsystem produces a score for
+    ///         `target` in a transaction that touches it.
+    /// @dev The model owns the firing decision: the trigger fires whenever
+    ///      anomaly detection returns a score at all. The assertion reads the
+    ///      score back via `ph.anomalyContext(target)` and decides whether
+    ///      to revert, run extra checks, or ignore.
+    /// @param target The address whose anomaly score this assertion observes.
+    /// @param fnSelector The assertion function to invoke when `target` is
+    ///        scored.
+    function watchAnomaly(address target, bytes4 fnSelector) external view;
 }


### PR DESCRIPTION
Adds interface for detecting and reacting to anomalous transactions. Notably omits test coverage for the moment until cheat codes land in `phorge`.