### PR TITLE
Add tests from individual repos to examples folder

### DIFF
--- a/examples/aave/test/AaveV4HubAccountingAssertion.t.sol
+++ b/examples/aave/test/AaveV4HubAccountingAssertion.t.sol
@@ -26,6 +26,52 @@ contract MockAaveV4Hub {
         return 0;
     }
 
+    function remove(uint256, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function draw(uint256, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function restore(uint256, uint256, IAaveV4Hub.PremiumDelta calldata) external pure returns (uint256) {
+        return 0;
+    }
+
+    function reportDeficit(uint256, uint256, IAaveV4Hub.PremiumDelta calldata)
+        external
+        pure
+        returns (uint256, uint256)
+    {
+        return (0, 0);
+    }
+
+    function refreshPremium(uint256, IAaveV4Hub.PremiumDelta calldata) external pure {}
+
+    function payFeeShares(uint256, uint256) external pure {}
+
+    function transferShares(uint256, uint256, address) external pure {}
+
+    function mintFeeShares(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function eliminateDeficit(uint256, uint256, address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function sweep(uint256, uint256) external pure {}
+
+    function reclaim(uint256, uint256) external pure {}
+
+    function updateAssetConfig(uint256, IAaveV4Hub.AssetConfig calldata, bytes calldata) external pure {}
+
+    function addSpoke(uint256, address, IAaveV4Hub.SpokeConfig calldata) external pure {}
+
+    function updateSpokeConfig(uint256, address, IAaveV4Hub.SpokeConfig calldata) external pure {}
+
+    function setInterestRateData(uint256, bytes calldata) external pure {}
+
     function getAsset(uint256) external view returns (IAaveV4Hub.Asset memory) {
         return asset;
     }

--- a/examples/aave/test/AaveV4HubAccountingAssertion.t.sol
+++ b/examples/aave/test/AaveV4HubAccountingAssertion.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {AaveV4HubAccountingAssertion} from "../src/AaveV4HubAccountingAssertion.sol";
+import {IAaveV4Hub} from "../src/AaveV4Interfaces.sol";
+
+contract MockAaveV4Hub {
+    IAaveV4Hub.Asset internal asset;
+    bool internal breakSpokeSum;
+
+    constructor() {
+        asset.drawnIndex = 1;
+    }
+
+    function setBreakSpokeSum(bool enabled) external {
+        breakSpokeSum = enabled;
+    }
+
+    function add(uint256, uint256) external returns (uint256) {
+        if (breakSpokeSum) {
+            asset.addedShares = 1;
+        }
+        return 0;
+    }
+
+    function getAsset(uint256) external view returns (IAaveV4Hub.Asset memory) {
+        return asset;
+    }
+
+    function getSpokeCount(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getAddedAssets(uint256) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract AaveV4HubAccountingAssertionTest is Test, CredibleTest {
+    MockAaveV4Hub internal hub;
+
+    function setUp() public {
+        hub = new MockAaveV4Hub();
+    }
+
+    function _arm() internal {
+        bytes memory createData =
+            abi.encodePacked(type(AaveV4HubAccountingAssertion).creationCode, abi.encode(address(hub), 1, 4, 0));
+        cl.assertion(address(hub), createData, AaveV4HubAccountingAssertion.assertHubAssetAccounting.selector);
+    }
+
+    function testHubAccountingPassesWhenSpokeSumsMatch() public {
+        _arm();
+        hub.add(1, 0);
+    }
+
+    function testHubAccountingTripsOnAggregateSpokeMismatch() public {
+        hub.setBreakSpokeSum(true);
+
+        _arm();
+        vm.expectRevert(bytes("AaveV4Hub: added shares mismatch"));
+        hub.add(1, 0);
+    }
+}

--- a/examples/aerodrome/test/AerodromePoolAssertion.t.sol
+++ b/examples/aerodrome/test/AerodromePoolAssertion.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {AerodromePoolAssertion} from "../src/AerodromePoolAssertion.sol";
+
+contract MockAerodromePool {
+    enum Mode {
+        Honest,
+        KDecreasing,
+        Underbacked
+    }
+
+    address public immutable token0;
+    address public immutable token1;
+    address public immutable poolFeesAddress;
+    bool public immutable stable;
+
+    uint256 public reserve0;
+    uint256 public reserve1;
+    Mode public mode;
+
+    constructor(address token0_, address token1_, address poolFees_, bool stable_) {
+        token0 = token0_;
+        token1 = token1_;
+        poolFeesAddress = poolFees_;
+        stable = stable_;
+    }
+
+    function setMode(Mode mode_) external {
+        mode = mode_;
+    }
+
+    function setReserves(uint256 reserve0_, uint256 reserve1_) external {
+        reserve0 = reserve0_;
+        reserve1 = reserve1_;
+    }
+
+    function poolFees() external view returns (address) {
+        return poolFeesAddress;
+    }
+
+    function metadata()
+        external
+        view
+        returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, bool st, address t0, address t1)
+    {
+        return (1e18, 1e18, reserve0, reserve1, stable, token0, token1);
+    }
+
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata) external {
+        if (amount0Out != 0) ERC20Mock(token0).transfer(to, amount0Out);
+        if (amount1Out != 0) ERC20Mock(token1).transfer(to, amount1Out);
+
+        uint256 nextReserve0 = ERC20Mock(token0).balanceOf(address(this));
+        uint256 nextReserve1 = ERC20Mock(token1).balanceOf(address(this));
+
+        if (mode == Mode.KDecreasing) {
+            nextReserve0 = nextReserve0 / 2;
+        } else if (mode == Mode.Underbacked) {
+            nextReserve0 = nextReserve0 + 1;
+        }
+
+        reserve0 = nextReserve0;
+        reserve1 = nextReserve1;
+    }
+}
+
+contract AerodromePoolAssertionTest is Test, CredibleTest {
+    uint256 internal constant SEED_RESERVE = 1_000 ether;
+
+    ERC20Mock internal token0;
+    ERC20Mock internal token1;
+    MockAerodromePool internal pool;
+
+    function setUp() public {
+        token0 = new ERC20Mock();
+        token1 = new ERC20Mock();
+        pool = new MockAerodromePool(address(token0), address(token1), makeAddr("poolFees"), false);
+
+        token0.mint(address(pool), SEED_RESERVE);
+        token1.mint(address(pool), SEED_RESERVE);
+        pool.setReserves(SEED_RESERVE, SEED_RESERVE);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        bytes memory createData = abi.encodePacked(type(AerodromePoolAssertion).creationCode, abi.encode(address(pool)));
+        cl.assertion(address(pool), createData, fnSelector);
+    }
+
+    function testHonestSwapPassesKCheck() public {
+        token0.mint(address(this), 120 ether);
+        token0.transfer(address(pool), 120 ether);
+
+        _arm(AerodromePoolAssertion.assertSwapKNonDecreasing.selector);
+        pool.swap(0, 100 ether, address(this), "");
+    }
+
+    function testSwapThatLowersKTrips() public {
+        token0.mint(address(this), 120 ether);
+        token0.transfer(address(pool), 120 ether);
+        pool.setMode(MockAerodromePool.Mode.KDecreasing);
+
+        _arm(AerodromePoolAssertion.assertSwapKNonDecreasing.selector);
+        vm.expectRevert(bytes("AerodromePool: swap decreased K"));
+        pool.swap(0, 100 ether, address(this), "");
+    }
+
+    function testUnderbackedReserveTrips() public {
+        token0.mint(address(this), 120 ether);
+        token0.transfer(address(pool), 120 ether);
+        pool.setMode(MockAerodromePool.Mode.Underbacked);
+
+        _arm(AerodromePoolAssertion.assertReservesBackedByBalances.selector);
+        vm.expectRevert(bytes("AerodromePool: token0 reserves underbacked"));
+        pool.swap(0, 100 ether, address(this), "");
+    }
+}

--- a/examples/cap/src/CapRedemptionGateAssertion.sol
+++ b/examples/cap/src/CapRedemptionGateAssertion.sol
@@ -33,7 +33,6 @@ contract CapRedemptionGateAssertion is Assertion {
     // Use a low trigger threshold because the built-in TVL snapshot is the idle vault balance.
     // The assertion recalculates against strategy-inclusive TVL before deciding what to block.
     uint256 internal constant WATCH_TRIGGER_BPS = 1;
-    uint256 internal constant MAX_MATCHING_CALLS = 1024;
 
     address internal immutable ASSET0;
     address internal immutable ASSET1;
@@ -71,34 +70,21 @@ contract CapRedemptionGateAssertion is Assertion {
         uint256 currentBps = _absoluteOutflowBps(ctx);
         if (currentBps < TIER2_BPS) return;
 
-        // Detect the gated calls present in this transaction. Detection is scoped to the active
-        // tier so the matching-call precompile is only consulted when a block could actually apply.
-        bool borrowPresent = _hasAssetCall(ICapGateVaultLike.borrow.selector, ctx.token);
-        bool redemptionPresent =
-            currentBps >= TIER3_BPS && (_hasAssetCall(ICapGateVaultLike.burn.selector, ctx.token) || _hasRedeemCall());
-        bool investPresent = currentBps >= TIER3_HALT_INVEST_BPS
-            && _hasAssetCall(ICapGateFractionalReserveLike.investAll.selector, ctx.token);
-
-        string memory violation = _gateViolation(currentBps, borrowPresent, redemptionPresent, investPresent);
-        if (bytes(violation).length != 0) {
-            revert(string(violation));
+        if (_hasAssetCall(ICapGateVaultLike.borrow.selector, ctx.token)) {
+            revert("CapGate: borrow disabled");
         }
-    }
 
-    /// @notice Pure tiered-gate decision separated from the matching-call detection so it can be
-    ///         unit-tested directly. Maps the active outflow tier and the set of gated calls present
-    ///         to the revert reason; an empty string means the transaction is allowed.
-    /// @dev Tier precedence is borrow (>=15%) before redemption (>=30%) before invest (>=50%).
-    function _gateViolation(uint256 currentBps, bool borrowPresent, bool redemptionPresent, bool investPresent)
-        internal
-        pure
-        returns (string memory)
-    {
-        if (currentBps < TIER2_BPS) return "";
-        if (borrowPresent) return "CapGate: borrow disabled";
-        if (currentBps >= TIER3_BPS && redemptionPresent) return "CapGate: redemption capacity reached";
-        if (currentBps >= TIER3_HALT_INVEST_BPS && investPresent) return "CapGate: invest disabled";
-        return "";
+        if (currentBps >= TIER3_BPS) {
+            if (_hasAssetCall(ICapGateVaultLike.burn.selector, ctx.token) || _hasRedeemCall()) {
+                revert("CapGate: redemption capacity reached");
+            }
+        }
+
+        if (currentBps >= TIER3_HALT_INVEST_BPS) {
+            if (_hasAssetCall(ICapGateFractionalReserveLike.investAll.selector, ctx.token)) {
+                revert("CapGate: invest disabled");
+            }
+        }
     }
 
     function _watchAsset(address asset) internal view {
@@ -120,22 +106,17 @@ contract CapRedemptionGateAssertion is Assertion {
     }
 
     function _hasAssetCall(bytes4 selector, address asset) internal view returns (bool) {
-        PhEvm.TriggerCall[] memory calls =
-            ph.matchingCalls(ph.getAssertionAdopter(), selector, _successOnlyFilter(), MAX_MATCHING_CALLS);
+        PhEvm.CallInputs[] memory calls = ph.getAllCallInputs(ph.getAssertionAdopter(), selector);
 
         for (uint256 i; i < calls.length; ++i) {
-            bytes memory input = ph.callinputAt(calls[i].callId);
-            if (_addressArg(input, 0) == asset) return true;
+            if (_addressArg(ph.callinputAt(calls[i].id), 0) == asset) return true;
         }
 
         return false;
     }
 
     function _hasRedeemCall() internal view returns (bool) {
-        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(
-            ph.getAssertionAdopter(), ICapGateVaultLike.redeem.selector, _successOnlyFilter(), MAX_MATCHING_CALLS
-        );
-        return calls.length > 0;
+        return ph.getAllCallInputs(ph.getAssertionAdopter(), ICapGateVaultLike.redeem.selector).length > 0;
     }
 
     function _isWatchedAsset(address asset) internal view returns (bool) {
@@ -144,11 +125,12 @@ contract CapRedemptionGateAssertion is Assertion {
     }
 
     function _addressArg(bytes memory input, uint256 argIndex) internal pure returns (address account) {
+        // Skip the 4-byte selector, then read the right-aligned ABI address word for `argIndex`.
         uint256 offset = 4 + argIndex * 32;
         require(input.length >= offset + 32, "CapGate: malformed calldata");
 
         assembly {
-            account := shr(96, mload(add(add(input, 0x20), offset)))
+            account := and(mload(add(add(input, 0x20), offset)), 0xffffffffffffffffffffffffffffffffffffffff)
         }
     }
 }

--- a/examples/cap/src/CapRedemptionGateAssertion.sol
+++ b/examples/cap/src/CapRedemptionGateAssertion.sol
@@ -71,21 +71,34 @@ contract CapRedemptionGateAssertion is Assertion {
         uint256 currentBps = _absoluteOutflowBps(ctx);
         if (currentBps < TIER2_BPS) return;
 
-        if (_hasAssetCall(ICapGateVaultLike.borrow.selector, ctx.token)) {
-            revert("CapGate: borrow disabled");
-        }
+        // Detect the gated calls present in this transaction. Detection is scoped to the active
+        // tier so the matching-call precompile is only consulted when a block could actually apply.
+        bool borrowPresent = _hasAssetCall(ICapGateVaultLike.borrow.selector, ctx.token);
+        bool redemptionPresent =
+            currentBps >= TIER3_BPS && (_hasAssetCall(ICapGateVaultLike.burn.selector, ctx.token) || _hasRedeemCall());
+        bool investPresent = currentBps >= TIER3_HALT_INVEST_BPS
+            && _hasAssetCall(ICapGateFractionalReserveLike.investAll.selector, ctx.token);
 
-        if (currentBps >= TIER3_BPS) {
-            if (_hasAssetCall(ICapGateVaultLike.burn.selector, ctx.token) || _hasRedeemCall()) {
-                revert("CapGate: redemption capacity reached");
-            }
+        string memory violation = _gateViolation(currentBps, borrowPresent, redemptionPresent, investPresent);
+        if (bytes(violation).length != 0) {
+            revert(string(violation));
         }
+    }
 
-        if (currentBps >= TIER3_HALT_INVEST_BPS) {
-            if (_hasAssetCall(ICapGateFractionalReserveLike.investAll.selector, ctx.token)) {
-                revert("CapGate: invest disabled");
-            }
-        }
+    /// @notice Pure tiered-gate decision separated from the matching-call detection so it can be
+    ///         unit-tested directly. Maps the active outflow tier and the set of gated calls present
+    ///         to the revert reason; an empty string means the transaction is allowed.
+    /// @dev Tier precedence is borrow (>=15%) before redemption (>=30%) before invest (>=50%).
+    function _gateViolation(uint256 currentBps, bool borrowPresent, bool redemptionPresent, bool investPresent)
+        internal
+        pure
+        returns (string memory)
+    {
+        if (currentBps < TIER2_BPS) return "";
+        if (borrowPresent) return "CapGate: borrow disabled";
+        if (currentBps >= TIER3_BPS && redemptionPresent) return "CapGate: redemption capacity reached";
+        if (currentBps >= TIER3_HALT_INVEST_BPS && investPresent) return "CapGate: invest disabled";
+        return "";
     }
 
     function _watchAsset(address asset) internal view {

--- a/examples/cap/test/CapRedemptionGateAssertion.t.sol
+++ b/examples/cap/test/CapRedemptionGateAssertion.t.sol
@@ -7,11 +7,42 @@ import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/tok
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {CapRedemptionGateAssertion} from "../src/CapRedemptionGateAssertion.sol";
 
+/// @notice Minimal Cap cUSD vault stand-in. Every gated path moves the watched asset out of the
+///         vault so the built-in cumulative-outflow watcher fires and the tiered gate can react.
 contract MockCapVault {
     mapping(address => uint256) public loaned;
 
+    address internal immutable ASSET;
+    address internal immutable STRATEGY;
+
+    constructor(address asset_, address strategy_) {
+        ASSET = asset_;
+        STRATEGY = strategy_;
+    }
+
     function borrow(address asset, uint256 amount, address receiver) external {
         ERC20Mock(asset).transfer(receiver, amount);
+    }
+
+    function burn(address asset, uint256 amountIn, uint256, address receiver, uint256)
+        external
+        returns (uint256 amountOut)
+    {
+        ERC20Mock(asset).transfer(receiver, amountIn);
+        return amountIn;
+    }
+
+    function redeem(uint256 amountIn, uint256[] calldata, address receiver, uint256)
+        external
+        returns (uint256[] memory amountsOut)
+    {
+        ERC20Mock(ASSET).transfer(receiver, amountIn);
+        amountsOut = new uint256[](1);
+        amountsOut[0] = amountIn;
+    }
+
+    function investAll(address asset) external {
+        ERC20Mock(asset).transfer(STRATEGY, 60 ether);
     }
 
     function setLoaned(address asset, uint256 amount) external {
@@ -19,30 +50,16 @@ contract MockCapVault {
     }
 }
 
-/// @notice Exposes the shipped assertion's internal tiered-gate decision so the threshold and
-///         precedence logic can be exercised directly. The selector-detection path itself relies
-///         on the `matchingCalls` precompile, which is not available in the local `pcl test`
-///         harness, so the production decision is unit-tested here against simulated detection flags.
-contract CapRedemptionGateHarness is CapRedemptionGateAssertion {
-    constructor(address asset_) CapRedemptionGateAssertion(asset_, address(0), address(0), address(0), address(0)) {}
-
-    function gateViolation(uint256 currentBps, bool borrowPresent, bool redemptionPresent, bool investPresent)
-        external
-        pure
-        returns (string memory)
-    {
-        return _gateViolation(currentBps, borrowPresent, redemptionPresent, investPresent);
-    }
-}
-
 contract CapRedemptionGateAssertionTest is Test, CredibleTest {
     ERC20Mock internal asset;
     MockCapVault internal vault;
     address internal receiver = makeAddr("receiver");
+    address internal strategy = makeAddr("strategy");
 
     function setUp() public {
         asset = new ERC20Mock();
-        vault = new MockCapVault();
+        vault = new MockCapVault(address(asset), strategy);
+        // 100e18 idle TVL: outflow bps == ethers moved out (e.g. 20 ether out == 2000 bps).
         asset.mint(address(vault), 100 ether);
     }
 
@@ -56,62 +73,49 @@ contract CapRedemptionGateAssertionTest is Test, CredibleTest {
 
     function testSmallBorrowOutflowPassesBelowGateTier() public {
         _arm();
+        // 1% outflow stays under the 15% tier-2 floor, so nothing is gated.
         vault.borrow(address(asset), 1 ether, receiver);
+    }
+
+    function testLargeBorrowTripsBorrowGate() public {
+        _arm();
+        // 20% outflow clears the 15% borrow tier.
+        vm.expectRevert(bytes("CapGate: borrow disabled"));
+        vault.borrow(address(asset), 20 ether, receiver);
+    }
+
+    function testRedeemBelowTier3StillAllowed() public {
+        _arm();
+        // 20% outflow trips the borrow tier but not the 30% redemption tier, so redeem passes.
+        uint256[] memory minOut;
+        vault.redeem(20 ether, minOut, receiver, block.timestamp);
+    }
+
+    function testRedeemTripsRedemptionGate() public {
+        _arm();
+        // 35% outflow clears the 30% redemption tier.
+        uint256[] memory minOut;
+        vm.expectRevert(bytes("CapGate: redemption capacity reached"));
+        vault.redeem(35 ether, minOut, receiver, block.timestamp);
+    }
+
+    function testBurnTripsRedemptionGate() public {
+        _arm();
+        // burn is the second redemption path gated at the 30% tier.
+        vm.expectRevert(bytes("CapGate: redemption capacity reached"));
+        vault.burn(address(asset), 35 ether, 0, receiver, block.timestamp);
+    }
+
+    function testInvestAllTripsInvestGate() public {
+        _arm();
+        // investAll moves 60% of TVL into a strategy, clearing the 50% invest tier.
+        vm.expectRevert(bytes("CapGate: invest disabled"));
+        vault.investAll(address(asset));
     }
 
     function testAssertionDeploysWithWatchedAsset() public {
         CapRedemptionGateAssertion assertion =
             new CapRedemptionGateAssertion(address(asset), address(0), address(0), address(0), address(0));
         assertTrue(address(assertion) != address(0));
-    }
-
-    // --- Tiered-gate decision coverage --------------------------------------------------
-    // The end-to-end blocking paths in `assertCapRedemptionGate` route through the
-    // `matchingCalls` precompile, which the local `pcl test` harness does not implement, so the
-    // tier thresholds and precedence are validated directly against the shipped decision function.
-
-    function testGateAllowsBelowBorrowTier() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        // Just under the 15% tier: nothing is blocked even when every gated call is present.
-        assertEq(gate.gateViolation(1_499, true, true, true), "");
-    }
-
-    function testGateBlocksBorrowAtTier2() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        assertEq(gate.gateViolation(1_500, true, false, false), "CapGate: borrow disabled");
-    }
-
-    function testGateAllowsRedemptionBetweenBorrowAndRedemptionTiers() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        // 20% outflow trips the borrow tier but not the 30% redemption tier.
-        assertEq(gate.gateViolation(2_000, false, true, false), "");
-    }
-
-    function testGateBlocksRedemptionAtTier3() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        assertEq(gate.gateViolation(3_000, false, true, false), "CapGate: redemption capacity reached");
-    }
-
-    function testGateAllowsInvestBelowHaltTier() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        // investAll stays allowed until the 50% halt tier, even at the redemption tier.
-        assertEq(gate.gateViolation(3_000, false, false, true), "");
-    }
-
-    function testGateBlocksInvestAtHaltTier() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        assertEq(gate.gateViolation(5_000, false, false, true), "CapGate: invest disabled");
-    }
-
-    function testGateBorrowTakesPrecedenceOverRedemption() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        // With borrow + redemption both gated above the redemption tier, borrow blocks first.
-        assertEq(gate.gateViolation(3_500, true, true, false), "CapGate: borrow disabled");
-    }
-
-    function testGateRedemptionTakesPrecedenceOverInvest() public {
-        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
-        // Above the halt tier with redemption + invest gated, redemption blocks before invest.
-        assertEq(gate.gateViolation(5_000, false, true, true), "CapGate: redemption capacity reached");
     }
 }

--- a/examples/cap/test/CapRedemptionGateAssertion.t.sol
+++ b/examples/cap/test/CapRedemptionGateAssertion.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {CapRedemptionGateAssertion} from "../src/CapRedemptionGateAssertion.sol";
+
+contract MockCapVault {
+    mapping(address => uint256) public loaned;
+
+    function borrow(address asset, uint256 amount, address receiver) external {
+        ERC20Mock(asset).transfer(receiver, amount);
+    }
+
+    function setLoaned(address asset, uint256 amount) external {
+        loaned[asset] = amount;
+    }
+}
+
+contract CapRedemptionGateAssertionTest is Test, CredibleTest {
+    ERC20Mock internal asset;
+    MockCapVault internal vault;
+    address internal receiver = makeAddr("receiver");
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        vault = new MockCapVault();
+        asset.mint(address(vault), 100 ether);
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(
+            type(CapRedemptionGateAssertion).creationCode,
+            abi.encode(address(asset), address(0), address(0), address(0), address(0))
+        );
+        cl.assertion(address(vault), createData, CapRedemptionGateAssertion.assertCapRedemptionGate.selector);
+    }
+
+    function testSmallBorrowOutflowPassesBelowGateTier() public {
+        _arm();
+        vault.borrow(address(asset), 1 ether, receiver);
+    }
+
+    function testAssertionDeploysWithWatchedAsset() public {
+        CapRedemptionGateAssertion assertion =
+            new CapRedemptionGateAssertion(address(asset), address(0), address(0), address(0), address(0));
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/examples/cap/test/CapRedemptionGateAssertion.t.sol
+++ b/examples/cap/test/CapRedemptionGateAssertion.t.sol
@@ -19,6 +19,22 @@ contract MockCapVault {
     }
 }
 
+/// @notice Exposes the shipped assertion's internal tiered-gate decision so the threshold and
+///         precedence logic can be exercised directly. The selector-detection path itself relies
+///         on the `matchingCalls` precompile, which is not available in the local `pcl test`
+///         harness, so the production decision is unit-tested here against simulated detection flags.
+contract CapRedemptionGateHarness is CapRedemptionGateAssertion {
+    constructor(address asset_) CapRedemptionGateAssertion(asset_, address(0), address(0), address(0), address(0)) {}
+
+    function gateViolation(uint256 currentBps, bool borrowPresent, bool redemptionPresent, bool investPresent)
+        external
+        pure
+        returns (string memory)
+    {
+        return _gateViolation(currentBps, borrowPresent, redemptionPresent, investPresent);
+    }
+}
+
 contract CapRedemptionGateAssertionTest is Test, CredibleTest {
     ERC20Mock internal asset;
     MockCapVault internal vault;
@@ -47,5 +63,55 @@ contract CapRedemptionGateAssertionTest is Test, CredibleTest {
         CapRedemptionGateAssertion assertion =
             new CapRedemptionGateAssertion(address(asset), address(0), address(0), address(0), address(0));
         assertTrue(address(assertion) != address(0));
+    }
+
+    // --- Tiered-gate decision coverage --------------------------------------------------
+    // The end-to-end blocking paths in `assertCapRedemptionGate` route through the
+    // `matchingCalls` precompile, which the local `pcl test` harness does not implement, so the
+    // tier thresholds and precedence are validated directly against the shipped decision function.
+
+    function testGateAllowsBelowBorrowTier() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        // Just under the 15% tier: nothing is blocked even when every gated call is present.
+        assertEq(gate.gateViolation(1_499, true, true, true), "");
+    }
+
+    function testGateBlocksBorrowAtTier2() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        assertEq(gate.gateViolation(1_500, true, false, false), "CapGate: borrow disabled");
+    }
+
+    function testGateAllowsRedemptionBetweenBorrowAndRedemptionTiers() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        // 20% outflow trips the borrow tier but not the 30% redemption tier.
+        assertEq(gate.gateViolation(2_000, false, true, false), "");
+    }
+
+    function testGateBlocksRedemptionAtTier3() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        assertEq(gate.gateViolation(3_000, false, true, false), "CapGate: redemption capacity reached");
+    }
+
+    function testGateAllowsInvestBelowHaltTier() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        // investAll stays allowed until the 50% halt tier, even at the redemption tier.
+        assertEq(gate.gateViolation(3_000, false, false, true), "");
+    }
+
+    function testGateBlocksInvestAtHaltTier() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        assertEq(gate.gateViolation(5_000, false, false, true), "CapGate: invest disabled");
+    }
+
+    function testGateBorrowTakesPrecedenceOverRedemption() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        // With borrow + redemption both gated above the redemption tier, borrow blocks first.
+        assertEq(gate.gateViolation(3_500, true, true, false), "CapGate: borrow disabled");
+    }
+
+    function testGateRedemptionTakesPrecedenceOverInvest() public {
+        CapRedemptionGateHarness gate = new CapRedemptionGateHarness(address(asset));
+        // Above the halt tier with redemption + invest gated, redemption blocks before invest.
+        assertEq(gate.gateViolation(5_000, false, true, true), "CapGate: redemption capacity reached");
     }
 }

--- a/examples/curve/test/LlamaLendControllerAssertion.t.sol
+++ b/examples/curve/test/LlamaLendControllerAssertion.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LlamaLendControllerAssertion} from "../src/LlamaLendControllerAssertion.sol";
+
+contract MockLlamaLendController {
+    uint256 public totalDebt;
+    uint256 public borrowCap = 1_000 ether;
+
+    function setBorrowCap(uint256 borrowCap_) external {
+        borrowCap = borrowCap_;
+    }
+
+    function borrow_more(uint256, uint256 debtIncrease) external {
+        totalDebt += debtIncrease;
+    }
+
+    function available_balance() external pure returns (uint256) {
+        return 0;
+    }
+
+    function total_debt() external view returns (uint256) {
+        return totalDebt;
+    }
+
+    function borrow_cap() external view returns (uint256) {
+        return borrowCap;
+    }
+}
+
+contract LlamaLendControllerAssertionTest is Test, CredibleTest {
+    MockLlamaLendController internal controller;
+    address internal borrowedToken = makeAddr("borrowedToken");
+
+    function setUp() public {
+        controller = new MockLlamaLendController();
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(
+            type(LlamaLendControllerAssertion).creationCode, abi.encode(address(controller), borrowedToken, 0)
+        );
+        cl.assertion(address(controller), createData, LlamaLendControllerAssertion.assertDebtIncreaseWithinBorrowCap.selector);
+    }
+
+    function testBorrowMorePassesWithinCap() public {
+        _arm();
+        controller.borrow_more(0, 100 ether);
+    }
+
+    function testBorrowMoreTripsAboveCap() public {
+        controller.setBorrowCap(50 ether);
+
+        _arm();
+        vm.expectRevert(bytes("LlamaLend: borrow cap exceeded"));
+        controller.borrow_more(0, 100 ether);
+    }
+}

--- a/examples/denaria/test/DenariaOperationSafety.t.sol
+++ b/examples/denaria/test/DenariaOperationSafety.t.sol
@@ -7,6 +7,7 @@ import {Assertion} from "../../../src/Assertion.sol";
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {PhEvm} from "../../../src/PhEvm.sol";
 import {AssertionSpec} from "../../../src/SpecRecorder.sol";
+import {IPerpetualProtectionSuite} from "../../../src/protection/perpetual/IPerpetualProtectionSuite.sol";
 import {DenariaProtectionSuite} from "../src/DenariaOperationSafety.sol";
 import {IDenariaPerpPairLike, IDenariaVaultLike} from "../src/DenariaInterfaces.sol";
 
@@ -34,9 +35,8 @@ contract DenariaTradeExecutionAssertion is Assertion {
         require(tradeSize == 0 || tradeReturn != 0, "Denaria: empty trade return");
         if (tradeSize == 0) return;
 
-        uint256 executionPrice = direction
-            ? tradeSize * ORACLE_DECIMALS / tradeReturn
-            : tradeReturn * ORACLE_DECIMALS / tradeSize;
+        uint256 executionPrice =
+            direction ? tradeSize * ORACLE_DECIMALS / tradeReturn : tradeReturn * ORACLE_DECIMALS / tradeSize;
         if (direction) {
             require(executionPrice >= markPrice, "Denaria: long better than mark");
         } else {
@@ -135,20 +135,159 @@ contract DenariaOperationSafetyTest is Test, CredibleTest {
 
     MockDenariaPerpPair internal pair;
     MockDenariaVault internal vault;
+    DenariaProtectionSuite internal suite;
+    address internal trader = makeAddr("trader");
 
     function setUp() public {
         pair = new MockDenariaPerpPair();
         vault = new MockDenariaVault();
         pair.setPrice(100 * ORACLE_DECIMALS);
+        suite = new DenariaProtectionSuite(address(pair), address(vault));
     }
 
-    function testSuiteExposesDenariaSelectors() public {
-        DenariaProtectionSuite suite = new DenariaProtectionSuite(address(pair), address(vault));
+    function testSuiteExposesDenariaSelectors() public view {
         bytes4[] memory selectors = suite.getMonitoredSelectors();
 
         assertEq(selectors.length, 8);
         assertEq(selectors[0], IDenariaPerpPairLike.trade.selector);
         assertEq(selectors[6], IDenariaVaultLike.removeCollateral.selector);
+    }
+
+    // --- Shipped DenariaProtectionSuite coverage -------------------------------------
+    // These exercise the production suite that DenariaOperationSafetyAssertion.assertOperationSafety
+    // actually runs (decode + operation classification), rather than the test-local execution
+    // assertion above.
+
+    function testEnabledCheckKindsMatchDenariaProfile() public view {
+        IPerpetualProtectionSuite.EnabledCheckKinds memory enabled = suite.enabledCheckKinds();
+
+        assertTrue(enabled.executionPrice);
+        assertTrue(enabled.liquidityCoverage);
+        assertTrue(enabled.liquidation);
+        assertTrue(enabled.oracleAnchor);
+        assertTrue(enabled.accountingConservation);
+        // Denaria intentionally leaves the funding-delta family disabled.
+        assertFalse(enabled.fundingDelta);
+    }
+
+    function testTradeDecodesAsIncreasePosition() public view {
+        IPerpetualProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(
+                IDenariaPerpPairLike.trade.selector,
+                address(pair),
+                abi.encodeCall(IDenariaPerpPairLike.trade, (true, 100e18, 99e18, 0, address(0), 5, ""))
+            )
+        );
+
+        assertEq(uint256(op.kind), uint256(IPerpetualProtectionSuite.OperationKind.IncreasePosition));
+        assertEq(op.account, trader);
+        assertEq(op.market, address(pair));
+        assertTrue(op.isLong);
+        assertEq(op.sizeDelta, 100e18);
+        assertEq(op.limitPrice, 99e18);
+        assertTrue(op.mutatesExposure);
+        assertTrue(op.reducesAccountSafety);
+        assertTrue(suite.shouldCheckPostMutationRisk(op));
+    }
+
+    function testCloseAndWithdrawDecodesAsDecreasePosition() public view {
+        IPerpetualProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(
+                IDenariaPerpPairLike.closeAndWithdraw.selector,
+                address(pair),
+                abi.encodeCall(IDenariaPerpPairLike.closeAndWithdraw, (50, 10, address(0), ""))
+            )
+        );
+
+        assertEq(uint256(op.kind), uint256(IPerpetualProtectionSuite.OperationKind.DecreasePosition));
+        assertEq(op.account, trader);
+        assertEq(op.market, address(pair));
+        assertEq(op.limitPrice, 50);
+        assertTrue(op.mutatesExposure);
+        assertTrue(suite.shouldCheckPostMutationRisk(op));
+    }
+
+    function testAddRemoveLiquidityDecodeWithSignedCollateralDelta() public view {
+        IPerpetualProtectionSuite.OperationContext memory addOp = suite.decodeOperation(
+            _triggered(
+                IDenariaPerpPairLike.addLiquidity.selector,
+                address(pair),
+                abi.encodeCall(IDenariaPerpPairLike.addLiquidity, (7e18, 3e18, 1, ""))
+            )
+        );
+        IPerpetualProtectionSuite.OperationContext memory removeOp = suite.decodeOperation(
+            _triggered(
+                IDenariaPerpPairLike.removeLiquidity.selector,
+                address(pair),
+                abi.encodeCall(IDenariaPerpPairLike.removeLiquidity, (7e18, 3e18, 1, ""))
+            )
+        );
+
+        assertEq(uint256(addOp.kind), uint256(IPerpetualProtectionSuite.OperationKind.AddLiquidity));
+        assertEq(addOp.sizeDelta, 3e18);
+        assertEq(addOp.collateralDelta, int256(7e18));
+
+        assertEq(uint256(removeOp.kind), uint256(IPerpetualProtectionSuite.OperationKind.RemoveLiquidity));
+        assertEq(removeOp.sizeDelta, 3e18);
+        // Removing liquidity returns collateral, so the signed delta must be negative.
+        assertEq(removeOp.collateralDelta, -int256(7e18));
+    }
+
+    function testLiquidationDecodesAndSkipsPostMutationGate() public {
+        address victim = makeAddr("victim");
+        IPerpetualProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(
+                IDenariaPerpPairLike.liquidate.selector,
+                address(pair),
+                abi.encodeCall(IDenariaPerpPairLike.liquidate, (victim, 42e18, ""))
+            )
+        );
+
+        assertEq(uint256(op.kind), uint256(IPerpetualProtectionSuite.OperationKind.Liquidation));
+        assertEq(op.account, victim);
+        assertEq(op.counterparty, trader);
+        assertEq(op.sizeDelta, 42e18);
+        assertTrue(op.isLiquidation);
+        // Liquidations route through the dedicated liquidation check, not the self-bad-debt gate.
+        assertFalse(suite.shouldCheckPostMutationRisk(op));
+    }
+
+    function testVaultCollateralRemovalDecodesAsWithdraw() public view {
+        IPerpetualProtectionSuite.OperationContext memory removeOp = suite.decodeOperation(
+            _triggered(
+                IDenariaVaultLike.removeCollateral.selector,
+                address(vault),
+                abi.encodeCall(IDenariaVaultLike.removeCollateral, (12e18, ""))
+            )
+        );
+        IPerpetualProtectionSuite.OperationContext memory removeAllOp = suite.decodeOperation(
+            _triggered(
+                IDenariaVaultLike.removeAllCollateral.selector,
+                address(vault),
+                abi.encodeCall(IDenariaVaultLike.removeAllCollateral, (""))
+            )
+        );
+
+        assertEq(uint256(removeOp.kind), uint256(IPerpetualProtectionSuite.OperationKind.WithdrawCollateral));
+        assertEq(removeOp.account, trader);
+        assertEq(removeOp.market, address(0));
+        assertEq(removeOp.collateralAsset, address(vault));
+        assertEq(removeOp.collateralDelta, -int256(12e18));
+        assertTrue(suite.shouldCheckPostMutationRisk(removeOp));
+
+        assertEq(uint256(removeAllOp.kind), uint256(IPerpetualProtectionSuite.OperationKind.WithdrawCollateral));
+        assertEq(removeAllOp.collateralAsset, address(vault));
+        assertTrue(suite.shouldCheckPostMutationRisk(removeAllOp));
+    }
+
+    function _triggered(bytes4 selector, address target, bytes memory input)
+        internal
+        view
+        returns (IPerpetualProtectionSuite.TriggeredCall memory)
+    {
+        return IPerpetualProtectionSuite.TriggeredCall({
+            selector: selector, caller: trader, target: target, input: input, callStart: 1, callEnd: 2
+        });
     }
 
     function testHonestTradePassesExecutionCheck() public {

--- a/examples/denaria/test/DenariaOperationSafety.t.sol
+++ b/examples/denaria/test/DenariaOperationSafety.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Assertion} from "../../../src/Assertion.sol";
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {PhEvm} from "../../../src/PhEvm.sol";
+import {AssertionSpec} from "../../../src/SpecRecorder.sol";
+import {DenariaProtectionSuite} from "../src/DenariaOperationSafety.sol";
+import {IDenariaPerpPairLike, IDenariaVaultLike} from "../src/DenariaInterfaces.sol";
+
+contract DenariaTradeExecutionAssertion is Assertion {
+    uint256 internal constant ORACLE_DECIMALS = 1e8;
+
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertTradeExecutionAtMark.selector, IDenariaPerpPairLike.trade.selector);
+    }
+
+    function assertTradeExecutionAtMark() external view {
+        address pair = ph.getAssertionAdopter();
+        PhEvm.TriggerContext memory ctx = ph.context();
+        bytes memory input = ph.callinputAt(ctx.callStart);
+
+        (bool direction, uint256 tradeSize,,,,,) =
+            abi.decode(_stripSelector(input), (bool, uint256, uint256, uint256, address, uint8, bytes));
+        uint256 tradeReturn = abi.decode(ph.callOutputAt(ctx.callStart), (uint256));
+        uint256 markPrice = _readPrice(pair, PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd}));
+
+        require(tradeSize == 0 || tradeReturn != 0, "Denaria: empty trade return");
+        if (tradeSize == 0) return;
+
+        uint256 executionPrice = direction
+            ? tradeSize * ORACLE_DECIMALS / tradeReturn
+            : tradeReturn * ORACLE_DECIMALS / tradeSize;
+        if (direction) {
+            require(executionPrice >= markPrice, "Denaria: long better than mark");
+        } else {
+            require(executionPrice <= markPrice, "Denaria: short better than mark");
+        }
+    }
+
+    function _readPrice(address pair, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        PhEvm.StaticCallResult memory result =
+            ph.staticcallAt(pair, abi.encodeCall(IDenariaPerpPairLike.getPrice, ()), 500_000, fork);
+        require(result.ok, "Denaria: price read failed");
+        return abi.decode(result.data, (uint256));
+    }
+
+    function _stripSelector(bytes memory input) internal pure returns (bytes memory args) {
+        require(input.length >= 4, "Denaria: short call input");
+        args = new bytes(input.length - 4);
+        for (uint256 i; i < args.length; ++i) {
+            args[i] = input[i + 4];
+        }
+    }
+}
+
+contract MockDenariaVault {
+    mapping(address => uint256) public collateral;
+
+    function setCollateral(address user, uint256 amount) external {
+        collateral[user] = amount;
+    }
+
+    function userCollateral(address user) external view returns (uint256) {
+        return collateral[user];
+    }
+
+    function removeCollateral(uint256 amount, bytes memory) external {
+        collateral[msg.sender] -= amount;
+    }
+
+    function removeAllCollateral(bytes memory) external {
+        collateral[msg.sender] = 0;
+    }
+}
+
+contract MockDenariaPerpPair {
+    event ExecutedTrade(
+        address indexed user,
+        bool direction,
+        uint256 tradeSize,
+        uint256 tradeReturn,
+        uint256 currentPrice,
+        uint256 leverage
+    );
+
+    uint256 public price;
+    bool public returnTooMuchAsset;
+
+    function setPrice(uint256 price_) external {
+        price = price_;
+    }
+
+    function setReturnTooMuchAsset(bool enabled) external {
+        returnTooMuchAsset = enabled;
+    }
+
+    function getPrice() external view returns (uint256) {
+        return price;
+    }
+
+    function trade(bool direction, uint256 size, uint256, uint256, address, uint8 leverage, bytes memory)
+        external
+        returns (uint256 tradeReturn)
+    {
+        tradeReturn = direction ? size * 1e8 / price : size * price / 1e8;
+        if (returnTooMuchAsset && direction) {
+            tradeReturn *= 2;
+        }
+        emit ExecutedTrade(msg.sender, direction, size, tradeReturn, price, leverage);
+    }
+
+    function closeAndWithdraw(uint256, uint256, address, bytes memory) external {}
+
+    function addLiquidity(uint256, uint256, uint256, bytes memory) external {}
+
+    function removeLiquidity(uint256, uint256, uint256, bytes memory) external {}
+
+    function realizePnL(bytes calldata) external pure returns (uint256, bool) {
+        return (0, true);
+    }
+
+    function liquidate(address, uint256, bytes memory) external {}
+}
+
+contract DenariaOperationSafetyTest is Test, CredibleTest {
+    uint256 internal constant ORACLE_DECIMALS = 1e8;
+    uint256 internal constant TOKEN_UNIT = 1e18;
+
+    MockDenariaPerpPair internal pair;
+    MockDenariaVault internal vault;
+
+    function setUp() public {
+        pair = new MockDenariaPerpPair();
+        vault = new MockDenariaVault();
+        pair.setPrice(100 * ORACLE_DECIMALS);
+    }
+
+    function testSuiteExposesDenariaSelectors() public {
+        DenariaProtectionSuite suite = new DenariaProtectionSuite(address(pair), address(vault));
+        bytes4[] memory selectors = suite.getMonitoredSelectors();
+
+        assertEq(selectors.length, 8);
+        assertEq(selectors[0], IDenariaPerpPairLike.trade.selector);
+        assertEq(selectors[6], IDenariaVaultLike.removeCollateral.selector);
+    }
+
+    function testHonestTradePassesExecutionCheck() public {
+        bytes memory createData = abi.encodePacked(type(DenariaTradeExecutionAssertion).creationCode);
+        cl.assertion(address(pair), createData, DenariaTradeExecutionAssertion.assertTradeExecutionAtMark.selector);
+
+        pair.trade(true, 100 * TOKEN_UNIT, 0, 0, address(0), 1, "");
+    }
+
+    function testTradeBetterThanMarkTrips() public {
+        pair.setReturnTooMuchAsset(true);
+
+        bytes memory createData = abi.encodePacked(type(DenariaTradeExecutionAssertion).creationCode);
+        cl.assertion(address(pair), createData, DenariaTradeExecutionAssertion.assertTradeExecutionAtMark.selector);
+
+        vm.expectRevert(bytes("Denaria: long better than mark"));
+        pair.trade(true, 100 * TOKEN_UNIT, 0, 0, address(0), 1, "");
+    }
+}

--- a/examples/euler/test/EulerEVaultSandwichAssertion.t.sol
+++ b/examples/euler/test/EulerEVaultSandwichAssertion.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {EulerERC4626CallSandwichAssertion} from "../src/EulerEVaultSandwichAssertion.sol";
+
+contract MockEulerEVault {
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+
+    bool public breakPreview;
+
+    function setBreakPreview(bool enabled) external {
+        breakPreview = enabled;
+    }
+
+    function previewDeposit(uint256 assets) external pure returns (uint256) {
+        return assets;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        shares = breakPreview ? assets - 1 : assets;
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+}
+
+contract EulerEVaultSandwichAssertionTest is Test, CredibleTest {
+    MockEulerEVault internal vault;
+
+    function setUp() public {
+        vault = new MockEulerEVault();
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(type(EulerERC4626CallSandwichAssertion).creationCode);
+        cl.assertion(address(vault), createData, EulerERC4626CallSandwichAssertion.assertErc4626CallWasHonest.selector);
+    }
+
+    function testDepositMatchesPreCallPreview() public {
+        _arm();
+        vault.deposit(100 ether, address(this));
+    }
+
+    function testDepositReturnBelowPreviewTrips() public {
+        vault.setBreakPreview(true);
+
+        _arm();
+        vm.expectRevert(bytes("EulerEVault: deposit return != pre-call preview"));
+        vault.deposit(100 ether, address(this));
+    }
+}

--- a/examples/nado/test/NadoClearinghouseAssertion.t.sol
+++ b/examples/nado/test/NadoClearinghouseAssertion.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {NadoClearinghouseAssertion} from "../src/NadoClearinghouseAssertion.sol";
+import {INadoClearinghouseLike, INadoSpotEngineLike} from "../src/NadoInterfaces.sol";
+
+contract MockNadoSpotEngine {
+    address public productToken;
+    bool public shortCredit;
+    mapping(uint32 => mapping(bytes32 => int128)) internal balances;
+
+    constructor(address productToken_) {
+        productToken = productToken_;
+    }
+
+    function setShortCredit(bool enabled) external {
+        shortCredit = enabled;
+    }
+
+    function credit(uint32 productId, bytes32 subaccount, uint128 amount) external {
+        uint128 credited = shortCredit ? amount - 1 : amount;
+        balances[productId][subaccount] += int128(credited);
+    }
+
+    function getConfig(uint32) external view returns (INadoSpotEngineLike.Config memory config) {
+        config.token = productToken;
+    }
+
+    function getBalance(uint32 productId, bytes32 subaccount)
+        external
+        view
+        returns (INadoSpotEngineLike.Balance memory balance)
+    {
+        balance.amount = balances[productId][subaccount];
+    }
+}
+
+contract MockNadoClearinghouse {
+    MockNadoSpotEngine public immutable spotEngine;
+
+    constructor(MockNadoSpotEngine spotEngine_) {
+        spotEngine = spotEngine_;
+    }
+
+    function depositCollateral(INadoClearinghouseLike.DepositCollateral calldata txn) external {
+        spotEngine.credit(txn.productId, txn.sender, txn.amount);
+    }
+}
+
+contract NadoClearinghouseAssertionTest is Test, CredibleTest {
+    uint32 internal constant PRODUCT_ID = 1;
+    bytes32 internal constant SUBACCOUNT = bytes32(uint256(0xA11CE));
+
+    ERC20Mock internal quoteAsset;
+    MockNadoSpotEngine internal spotEngine;
+    MockNadoClearinghouse internal clearinghouse;
+
+    function setUp() public {
+        quoteAsset = new ERC20Mock();
+        spotEngine = new MockNadoSpotEngine(address(quoteAsset));
+        clearinghouse = new MockNadoClearinghouse(spotEngine);
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(
+            type(NadoClearinghouseAssertion).creationCode,
+            abi.encode(
+                address(0),
+                address(clearinghouse),
+                address(spotEngine),
+                address(quoteAsset),
+                address(0),
+                0,
+                2_500,
+                1_000,
+                3_000,
+                1 days
+            )
+        );
+        cl.assertion(address(clearinghouse), createData, NadoClearinghouseAssertion.assertDepositCreditsSpotBalance.selector);
+    }
+
+    function _deposit(uint128 amount) internal {
+        clearinghouse.depositCollateral(
+            INadoClearinghouseLike.DepositCollateral({sender: SUBACCOUNT, productId: PRODUCT_ID, amount: amount})
+        );
+    }
+
+    function testDepositCreditsSpotBalance() public {
+        _arm();
+        _deposit(100 ether);
+    }
+
+    function testDepositTripsWhenSpotCreditIsShort() public {
+        spotEngine.setShortCredit(true);
+
+        _arm();
+        vm.expectRevert(bytes("Nado: deposit spot credit mismatch"));
+        _deposit(100 ether);
+    }
+}

--- a/examples/royco/test/RoycoKernelAssertion.t.sol
+++ b/examples/royco/test/RoycoKernelAssertion.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {RoycoKernelAssertion} from "../src/RoycoKernelAssertion.sol";
+
+contract MockRoycoKernel {
+    ERC20Mock public immutable asset;
+
+    constructor(ERC20Mock asset_) {
+        asset = asset_;
+    }
+
+    function deposit(uint256 amount) external {
+        asset.transferFrom(msg.sender, address(this), amount);
+    }
+
+    function withdraw(uint256 amount) external {
+        asset.transfer(msg.sender, amount);
+    }
+}
+
+contract RoycoKernelAssertionTest is Test, CredibleTest {
+    ERC20Mock internal asset;
+    MockRoycoKernel internal kernel;
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        kernel = new MockRoycoKernel(asset);
+
+        asset.mint(address(kernel), 100 ether);
+        asset.mint(alice, 100 ether);
+        vm.prank(alice);
+        asset.approve(address(kernel), type(uint256).max);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        bytes memory createData = abi.encodePacked(
+            type(RoycoKernelAssertion).creationCode,
+            abi.encode(
+                address(kernel),
+                makeAddr("accountant"),
+                makeAddr("seniorTranche"),
+                address(asset),
+                makeAddr("juniorTranche"),
+                address(asset),
+                2_500,
+                1 days,
+                2_500,
+                1 days
+            )
+        );
+        cl.assertion(address(kernel), createData, fnSelector);
+    }
+
+    function testLargeInflowTripsBreaker() public {
+        _arm(bytes4(keccak256("assertCumulativeInflow()")));
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("Royco: cumulative tranche-asset inflow breaker tripped"));
+        kernel.deposit(50 ether);
+    }
+
+    function testLargeOutflowTripsBreaker() public {
+        _arm(bytes4(keccak256("assertCumulativeOutflow()")));
+
+        vm.expectRevert(bytes("Royco: cumulative tranche-asset outflow breaker tripped"));
+        kernel.withdraw(50 ether);
+    }
+}

--- a/examples/safe/test/SafeTxShapeAssertion.t.sol
+++ b/examples/safe/test/SafeTxShapeAssertion.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {SafeTxShapeAssertion} from "../src/SafeTxShapeAssertion.sol";
+import {SafeTxShapeHelpers} from "../src/SafeTxShapeHelpers.sol";
+
+contract MockSafe {
+    function execTransaction(
+        address,
+        uint256,
+        bytes calldata,
+        uint8,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address,
+        bytes calldata
+    ) external pure returns (bool success) {
+        return true;
+    }
+}
+
+contract SafeTxShapeAssertionTest is Test, CredibleTest {
+    MockSafe internal safe;
+    address internal allowedTarget = makeAddr("allowedTarget");
+    address internal blockedTarget = makeAddr("blockedTarget");
+
+    function setUp() public {
+        safe = new MockSafe();
+    }
+
+    function _arm() internal {
+        bytes memory createData =
+            abi.encodePacked(type(SafeTxShapeAssertion).creationCode, _safeTxShapeConstructorArgs());
+        cl.assertion(address(safe), createData, SafeTxShapeAssertion.assertSafeTargetSelectorPolicy.selector);
+    }
+
+    function _safeTxShapeConstructorArgs() internal view returns (bytes memory) {
+        return abi.encode(
+            _targetPolicies(),
+            new SafeTxShapeHelpers.SelectorPolicy[](0),
+            new SafeTxShapeHelpers.BatchExecutorPolicy[](0),
+            new SafeTxShapeHelpers.ApprovalPolicy[](0),
+            false,
+            new address[](0)
+        );
+    }
+
+    function _targetPolicies() internal view returns (SafeTxShapeHelpers.TargetPolicy[] memory policies) {
+        policies = new SafeTxShapeHelpers.TargetPolicy[](1);
+        policies[0] = SafeTxShapeHelpers.TargetPolicy({
+            target: allowedTarget,
+            allowAnySelector: true,
+            allowEmptyCalldata: false,
+            allowFallbackCalldata: false,
+            allowNonzeroValue: false
+        });
+    }
+
+    function _execSafeTx(address to) internal returns (bool) {
+        return safe.execTransaction(to, 0, abi.encodeWithSelector(bytes4(0x12345678)), 0, 0, 0, 0, address(0), address(0), "");
+    }
+
+    function testConfiguredTargetPasses() public {
+        _arm();
+        assertTrue(_execSafeTx(allowedTarget));
+    }
+
+    function testUnknownTargetTrips() public {
+        _arm();
+        vm.expectRevert(abi.encodeWithSelector(SafeTxShapeHelpers.SafeTxShapeUnknownTarget.selector, blockedTarget));
+        _execSafeTx(blockedTarget);
+    }
+}

--- a/examples/spark/test/SparkVaultAssertion.t.sol
+++ b/examples/spark/test/SparkVaultAssertion.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {SparkVaultAssertion} from "../src/SparkVaultAssertion.sol";
+
+contract MockSparkVault {
+    ERC20Mock public immutable assetToken;
+    uint256 public totalSupply = 100 ether;
+    uint256 public totalAssets = 100 ether;
+    uint256 public chi = 1e27;
+    uint256 public rho = 1;
+    uint256 public vsr = 1;
+    uint256 public assetsOutstanding;
+    bool public breakOutstanding;
+
+    constructor(ERC20Mock assetToken_) {
+        assetToken = assetToken_;
+    }
+
+    function setBreakOutstanding(bool enabled) external {
+        breakOutstanding = enabled;
+    }
+
+    function nowChi() external view returns (uint256) {
+        return chi;
+    }
+
+    function take(uint256 value) external {
+        assetToken.transfer(msg.sender, value);
+        if (!breakOutstanding) {
+            assetsOutstanding += value;
+        }
+    }
+}
+
+contract SparkVaultAssertionTest is Test, CredibleTest {
+    ERC20Mock internal asset;
+    MockSparkVault internal vault;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        vault = new MockSparkVault(asset);
+        asset.mint(address(vault), 100 ether);
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(
+            type(SparkVaultAssertion).creationCode, abi.encode(address(vault), address(asset), 0, 2_500, 1 days)
+        );
+        cl.assertion(address(vault), createData, SparkVaultAssertion.assertSparkTakeAccounting.selector);
+    }
+
+    function testTakeAccountingPassesWhenOutstandingTracksLiquidity() public {
+        _arm();
+        vault.take(10 ether);
+    }
+
+    function testTakeAccountingTripsWhenOutstandingDoesNotIncrease() public {
+        vault.setBreakOutstanding(true);
+
+        _arm();
+        vm.expectRevert(bytes("SparkVault: take outstanding delta mismatch"));
+        vault.take(10 ether);
+    }
+}

--- a/examples/symbiotic/test/SymbioticVaultCircuitBreakerAssertion.t.sol
+++ b/examples/symbiotic/test/SymbioticVaultCircuitBreakerAssertion.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {SymbioticVaultCircuitBreakerAssertion, SymbioticVaultCircuitBreakerProtection} from
+    "../src/SymbioticVaultCircuitBreakerAssertion.sol";
+
+contract MockSymbioticVault {
+    ERC20Mock public immutable asset;
+
+    constructor(ERC20Mock asset_) {
+        asset = asset_;
+    }
+
+    function withdraw(address claimer, uint256 amount) external returns (uint256 burnedShares, uint256 mintedShares) {
+        asset.transfer(claimer, amount);
+        return (amount, amount);
+    }
+}
+
+contract SymbioticVaultCircuitBreakerAssertionTest is Test, CredibleTest {
+    ERC20Mock internal asset;
+    MockSymbioticVault internal vault;
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        vault = new MockSymbioticVault(asset);
+        asset.mint(address(vault), 100 ether);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        SymbioticVaultCircuitBreakerAssertion.LiquidationRoute[] memory routes =
+            new SymbioticVaultCircuitBreakerAssertion.LiquidationRoute[](1);
+        routes[0] =
+            SymbioticVaultCircuitBreakerAssertion.LiquidationRoute({target: makeAddr("liquidator"), selector: 0x12345678});
+
+        bytes memory createData = abi.encodePacked(
+            type(SymbioticVaultCircuitBreakerProtection).creationCode, abi.encode(address(vault), address(asset), routes)
+        );
+        cl.assertion(address(vault), createData, fnSelector);
+    }
+
+    function testLargeOutflowTripsDailyHardStop() public {
+        _arm(bytes4(keccak256("assertDailyHardStopCircuitBreaker()")));
+
+        vm.expectRevert(bytes("SymbioticCircuitBreaker: daily hard outflow breaker tripped"));
+        vault.withdraw(alice, 31 ether);
+    }
+}

--- a/examples/tydro/test/TydroOperationSafety.t.sol
+++ b/examples/tydro/test/TydroOperationSafety.t.sol
@@ -6,6 +6,8 @@ import {Test} from "forge-std/Test.sol";
 import {Assertion} from "../../../src/Assertion.sol";
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {AssertionSpec} from "../../../src/SpecRecorder.sol";
+import {ILendingProtectionSuite} from "../../../src/protection/lending/ILendingProtectionSuite.sol";
+import {IAaveV3LikePool} from "../../../src/protection/lending/examples/AaveV3LikeInterfaces.sol";
 import {TydroProtectionSuite, ITydroL2Pool} from "../src/TydroOperationSafety.sol";
 
 contract TydroCompactBorrowAssertion is Assertion {
@@ -60,15 +62,17 @@ contract MockTydroPool is ITydroL2Pool {
 
 contract TydroOperationSafetyTest is Test, CredibleTest {
     MockTydroPool internal pool;
+    TydroProtectionSuite internal suite;
     address internal reserve = makeAddr("reserve");
     address internal addressesProvider = makeAddr("addressesProvider");
+    address internal caller = makeAddr("caller");
 
     function setUp() public {
         pool = new MockTydroPool(reserve);
+        suite = new TydroProtectionSuite(address(pool), addressesProvider);
     }
 
-    function testCompactSelectorsAreIncluded() public {
-        TydroProtectionSuite suite = new TydroProtectionSuite(address(pool), addressesProvider);
+    function testCompactSelectorsAreIncluded() public view {
         bytes4[] memory selectors = suite.getMonitoredSelectors();
 
         assertEq(selectors.length, 10);
@@ -76,6 +80,125 @@ contract TydroOperationSafetyTest is Test, CredibleTest {
         assertEq(selectors[7], ITydroL2Pool.withdraw.selector);
         assertEq(selectors[8], ITydroL2Pool.liquidationCall.selector);
         assertEq(selectors[9], ITydroL2Pool.setUserUseReserveAsCollateral.selector);
+    }
+
+    // --- Shipped TydroProtectionSuite.decodeOperation coverage -------------------------
+    // These exercise the production suite that TydroOperationSafetyAssertion.assertOperationSafety
+    // actually runs, rather than the test-local assertion above. They focus on Tydro's compact
+    // L2 calldata decoder and the standard Aave v3 delegation path.
+
+    function testL2BorrowDecodesAssetAndAmount() public view {
+        uint256 amount = 250e6;
+        bytes32 args = _packL2Amount(0, amount);
+
+        ILendingProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(ITydroL2Pool.borrow.selector, abi.encodeCall(ITydroL2Pool.borrow, (args)))
+        );
+
+        assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.Borrow));
+        assertEq(op.account, caller);
+        assertEq(op.asset, reserve);
+        assertEq(op.amount, amount);
+        assertTrue(op.increasesDebt);
+        assertTrue(suite.shouldCheckPostOperationSolvency(op));
+    }
+
+    function testL2WithdrawDecodesMaxAmountSentinel() public view {
+        // The compact uint128 max sentinel must expand to a full uint256 max withdrawal.
+        bytes32 args = _packL2Amount(0, type(uint128).max);
+
+        ILendingProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(ITydroL2Pool.withdraw.selector, abi.encodeCall(ITydroL2Pool.withdraw, (args)))
+        );
+
+        assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.WithdrawCollateral));
+        assertEq(op.account, caller);
+        assertEq(op.asset, reserve);
+        assertEq(op.counterparty, caller);
+        assertEq(op.amount, type(uint256).max);
+        assertTrue(op.reducesEffectiveCollateral);
+        assertTrue(suite.shouldCheckPostOperationSolvency(op));
+    }
+
+    function testL2LiquidationDecodesUserAndAssets() public {
+        address user = makeAddr("borrower");
+        uint256 debtToCover = 55e6;
+        // args1: user packed above bit 32; both compact asset ids resolve to reserve index 0.
+        bytes32 args1 = bytes32(uint256(uint160(user)) << 32);
+        bytes32 args2 = _packL2Amount(0, debtToCover);
+
+        ILendingProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(
+                ITydroL2Pool.liquidationCall.selector, abi.encodeCall(ITydroL2Pool.liquidationCall, (args1, args2))
+            )
+        );
+
+        assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.Liquidation));
+        assertEq(op.account, user);
+        assertEq(op.asset, reserve);
+        assertEq(op.relatedAsset, reserve);
+        assertEq(op.counterparty, caller);
+        assertEq(op.amount, debtToCover);
+        // Liquidations are not self-inflicted, so the post-op solvency gate must not fire.
+        assertFalse(suite.shouldCheckPostOperationSolvency(op));
+    }
+
+    function testL2DisableCollateralOnlyTriggersWhenTurningOff() public view {
+        bytes32 disableArgs = bytes32((uint256(1) << 16) | 0); // disable bit set, asset id 0
+        bytes32 enableArgs = bytes32(uint256(0)); // disable bit clear
+
+        ILendingProtectionSuite.OperationContext memory disableOp = suite.decodeOperation(
+            _triggered(
+                ITydroL2Pool.setUserUseReserveAsCollateral.selector,
+                abi.encodeCall(ITydroL2Pool.setUserUseReserveAsCollateral, (disableArgs))
+            )
+        );
+        ILendingProtectionSuite.OperationContext memory enableOp = suite.decodeOperation(
+            _triggered(
+                ITydroL2Pool.setUserUseReserveAsCollateral.selector,
+                abi.encodeCall(ITydroL2Pool.setUserUseReserveAsCollateral, (enableArgs))
+            )
+        );
+
+        assertEq(uint256(disableOp.kind), uint256(ILendingProtectionSuite.OperationKind.DisableCollateral));
+        assertEq(disableOp.account, caller);
+        assertEq(disableOp.asset, reserve);
+        assertTrue(disableOp.reducesEffectiveCollateral);
+        assertTrue(suite.shouldCheckPostOperationSolvency(disableOp));
+
+        assertEq(uint256(enableOp.kind), uint256(ILendingProtectionSuite.OperationKind.Unknown));
+        assertFalse(suite.shouldCheckPostOperationSolvency(enableOp));
+    }
+
+    function testStandardAaveBorrowDelegatesToBaseDecoder() public {
+        // Non-compact selectors must fall through to the shared Aave v3 decoder.
+        ILendingProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            _triggered(
+                IAaveV3LikePool.borrow.selector,
+                abi.encodeCall(IAaveV3LikePool.borrow, (reserve, 123e18, 2, 0, makeAddr("onBehalfOf")))
+            )
+        );
+
+        assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.Borrow));
+        assertEq(op.account, makeAddr("onBehalfOf"));
+        assertEq(op.asset, reserve);
+        assertEq(op.amount, 123e18);
+        assertTrue(op.increasesDebt);
+    }
+
+    /// @notice Packs Tydro's compact L2 calldata word: low 16 bits = asset id, next 128 = amount.
+    function _packL2Amount(uint16 assetId, uint256 amount) internal pure returns (bytes32) {
+        return bytes32((amount << 16) | uint256(assetId));
+    }
+
+    function _triggered(bytes4 selector, bytes memory input)
+        internal
+        view
+        returns (ILendingProtectionSuite.TriggeredCall memory)
+    {
+        return ILendingProtectionSuite.TriggeredCall({
+            selector: selector, caller: caller, target: address(pool), input: input, callStart: 1, callEnd: 2
+        });
     }
 
     function testZeroAmountCompactBorrowPasses() public {

--- a/examples/tydro/test/TydroOperationSafety.t.sol
+++ b/examples/tydro/test/TydroOperationSafety.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Assertion} from "../../../src/Assertion.sol";
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {AssertionSpec} from "../../../src/SpecRecorder.sol";
+import {TydroProtectionSuite, ITydroL2Pool} from "../src/TydroOperationSafety.sol";
+
+contract TydroCompactBorrowAssertion is Assertion {
+    uint256 internal constant L2_SHORTENED_AMOUNT_MASK = type(uint128).max;
+
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertCompactBorrowIsZeroAmount.selector, ITydroL2Pool.borrow.selector);
+    }
+
+    function assertCompactBorrowIsZeroAmount() external view {
+        bytes memory input = ph.callinputAt(ph.context().callStart);
+        bytes32 args = abi.decode(_stripSelector(input), (bytes32));
+        uint256 amount = (uint256(args) >> 16) & L2_SHORTENED_AMOUNT_MASK;
+
+        require(amount == 0, "Tydro: compact borrow amount nonzero");
+    }
+
+    function _stripSelector(bytes memory input) internal pure returns (bytes memory args) {
+        require(input.length >= 4, "Tydro: short call input");
+        args = new bytes(input.length - 4);
+        for (uint256 i; i < args.length; ++i) {
+            args[i] = input[i + 4];
+        }
+    }
+}
+
+contract MockTydroPool is ITydroL2Pool {
+    address[] internal reserves;
+
+    constructor(address reserve) {
+        reserves.push(reserve);
+    }
+
+    function getReservesList() external view returns (address[] memory) {
+        return reserves;
+    }
+
+    function borrow(bytes32) external override {}
+
+    function withdraw(bytes32) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function liquidationCall(bytes32, bytes32) external pure override {}
+
+    function setUserUseReserveAsCollateral(bytes32) external pure override {}
+}
+
+contract TydroOperationSafetyTest is Test, CredibleTest {
+    MockTydroPool internal pool;
+    address internal reserve = makeAddr("reserve");
+    address internal addressesProvider = makeAddr("addressesProvider");
+
+    function setUp() public {
+        pool = new MockTydroPool(reserve);
+    }
+
+    function testCompactSelectorsAreIncluded() public {
+        TydroProtectionSuite suite = new TydroProtectionSuite(address(pool), addressesProvider);
+        bytes4[] memory selectors = suite.getMonitoredSelectors();
+
+        assertEq(selectors.length, 10);
+        assertEq(selectors[6], ITydroL2Pool.borrow.selector);
+        assertEq(selectors[7], ITydroL2Pool.withdraw.selector);
+        assertEq(selectors[8], ITydroL2Pool.liquidationCall.selector);
+        assertEq(selectors[9], ITydroL2Pool.setUserUseReserveAsCollateral.selector);
+    }
+
+    function testZeroAmountCompactBorrowPasses() public {
+        bytes memory createData = abi.encodePacked(type(TydroCompactBorrowAssertion).creationCode);
+        cl.assertion(address(pool), createData, TydroCompactBorrowAssertion.assertCompactBorrowIsZeroAmount.selector);
+
+        pool.borrow(bytes32(0));
+    }
+
+    function testNonzeroAmountCompactBorrowTrips() public {
+        bytes memory createData = abi.encodePacked(type(TydroCompactBorrowAssertion).creationCode);
+        cl.assertion(address(pool), createData, TydroCompactBorrowAssertion.assertCompactBorrowIsZeroAmount.selector);
+
+        bytes32 args = bytes32(uint256(1) << 16);
+        vm.expectRevert(bytes("Tydro: compact borrow amount nonzero"));
+        pool.borrow(args);
+    }
+}

--- a/examples/uniswap/src/UniswapV3PoolAssertion.sol
+++ b/examples/uniswap/src/UniswapV3PoolAssertion.sol
@@ -62,20 +62,20 @@ contract UniswapV3PoolAssertion is UniswapV3PoolHelpers {
     function assertSwapPriceMovement() external view {
         PhEvm.TriggerContext memory ctx = ph.context();
         _requireConfiguredPoolIsAdopter();
-        PoolSnapshot memory pre = _snapshotAt(_preCall(ctx.callStart));
-        PoolSnapshot memory post = _snapshotAt(_postCall(ctx.callEnd));
+        Slot0Snapshot memory pre = _slot0At(_preCall(ctx.callStart));
+        Slot0Snapshot memory post = _slot0At(_postCall(ctx.callEnd));
         (, bool zeroForOne,, uint160 sqrtPriceLimitX96,) = _swapArgs(ph.callinputAt(ctx.callStart));
 
-        require(post.slot0.unlocked, "UniswapV3Pool: pool left locked");
-        require(post.slot0.sqrtPriceX96 >= MIN_SQRT_RATIO, "UniswapV3Pool: price below min");
-        require(post.slot0.sqrtPriceX96 < MAX_SQRT_RATIO, "UniswapV3Pool: price above max");
+        require(post.unlocked, "UniswapV3Pool: pool left locked");
+        require(post.sqrtPriceX96 >= MIN_SQRT_RATIO, "UniswapV3Pool: price below min");
+        require(post.sqrtPriceX96 < MAX_SQRT_RATIO, "UniswapV3Pool: price above max");
 
         if (zeroForOne) {
-            require(post.slot0.sqrtPriceX96 <= pre.slot0.sqrtPriceX96, "UniswapV3Pool: zeroForOne price increased");
-            require(post.slot0.sqrtPriceX96 >= sqrtPriceLimitX96, "UniswapV3Pool: zeroForOne crossed limit");
+            require(post.sqrtPriceX96 <= pre.sqrtPriceX96, "UniswapV3Pool: zeroForOne price increased");
+            require(post.sqrtPriceX96 >= sqrtPriceLimitX96, "UniswapV3Pool: zeroForOne crossed limit");
         } else {
-            require(post.slot0.sqrtPriceX96 >= pre.slot0.sqrtPriceX96, "UniswapV3Pool: oneForZero price decreased");
-            require(post.slot0.sqrtPriceX96 <= sqrtPriceLimitX96, "UniswapV3Pool: oneForZero crossed limit");
+            require(post.sqrtPriceX96 >= pre.sqrtPriceX96, "UniswapV3Pool: oneForZero price decreased");
+            require(post.sqrtPriceX96 <= sqrtPriceLimitX96, "UniswapV3Pool: oneForZero crossed limit");
         }
     }
 

--- a/examples/uniswap/test/UniswapV3PoolAssertion.t.sol
+++ b/examples/uniswap/test/UniswapV3PoolAssertion.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {UniswapV3PoolAssertion} from "../src/UniswapV3PoolAssertion.sol";
+
+contract MockUniswapV3Pool {
+    enum SwapMode {
+        Honest,
+        WrongDirection
+    }
+
+    address public immutable token0;
+    address public immutable token1;
+
+    uint160 public sqrtPriceX96;
+    int24 public tick;
+    uint16 public observationIndex;
+    uint16 public observationCardinality = 1;
+    uint16 public observationCardinalityNext = 1;
+    uint8 public feeProtocol;
+    bool public unlocked = true;
+    uint128 public liquidity;
+    uint256 public feeGrowthGlobal0X128;
+    uint256 public feeGrowthGlobal1X128;
+    SwapMode public swapMode;
+
+    constructor(address token0_, address token1_) {
+        token0 = token0_;
+        token1 = token1_;
+    }
+
+    function setSqrtPrice(uint160 sqrtPriceX96_) external {
+        sqrtPriceX96 = sqrtPriceX96_;
+    }
+
+    function setSwapMode(SwapMode swapMode_) external {
+        swapMode = swapMode_;
+    }
+
+    function slot0() external view returns (uint160, int24, uint16, uint16, uint16, uint8, bool) {
+        return (
+            sqrtPriceX96,
+            tick,
+            observationIndex,
+            observationCardinality,
+            observationCardinalityNext,
+            feeProtocol,
+            unlocked
+        );
+    }
+
+    function protocolFees() external pure returns (uint128, uint128) {
+        return (0, 0);
+    }
+
+    function swap(address, bool zeroForOne, int256, uint160, bytes calldata) external returns (int256, int256) {
+        uint160 delta = sqrtPriceX96 / 100;
+        bool moveDown = zeroForOne;
+        if (swapMode == SwapMode.WrongDirection) {
+            moveDown = !moveDown;
+        }
+
+        sqrtPriceX96 = moveDown ? sqrtPriceX96 - delta : sqrtPriceX96 + delta;
+        return (0, 0);
+    }
+}
+
+contract UniswapV3PoolAssertionTest is Test, CredibleTest {
+    uint160 internal constant INITIAL_SQRT_PRICE = 79_228_162_514_264_337_593_543_950_336;
+    uint160 internal constant MIN_SQRT_RATIO = 4_295_128_739;
+
+    ERC20Mock internal token0;
+    ERC20Mock internal token1;
+    MockUniswapV3Pool internal pool;
+
+    function setUp() public {
+        token0 = new ERC20Mock();
+        token1 = new ERC20Mock();
+        pool = new MockUniswapV3Pool(address(token0), address(token1));
+        pool.setSqrtPrice(INITIAL_SQRT_PRICE);
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(
+            type(UniswapV3PoolAssertion).creationCode, abi.encode(address(pool), address(token0), address(token1))
+        );
+        cl.assertion(address(pool), createData, UniswapV3PoolAssertion.assertSwapPriceMovement.selector);
+    }
+
+    function testHonestZeroForOneSwapPasses() public {
+        _arm();
+        pool.swap(address(this), true, 1 ether, MIN_SQRT_RATIO + 1, "");
+    }
+
+    function testHonestOneForZeroSwapPasses() public {
+        _arm();
+        pool.swap(address(this), false, 1 ether, type(uint160).max - 1, "");
+    }
+
+    function testWrongDirectionZeroForOneTrips() public {
+        pool.setSwapMode(MockUniswapV3Pool.SwapMode.WrongDirection);
+
+        _arm();
+        vm.expectRevert(bytes("UniswapV3Pool: zeroForOne price increased"));
+        pool.swap(address(this), true, 1 ether, MIN_SQRT_RATIO + 1, "");
+    }
+}

--- a/examples/veda/test/BoringVaultAssertion.t.sol
+++ b/examples/veda/test/BoringVaultAssertion.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {BoringVaultAssertion} from "../src/BoringVaultAssertion.sol";
+
+contract MockBoringAccountant {
+    uint256 internal rate = 1e18;
+
+    function setRate(uint256 rate_) external {
+        rate = rate_;
+    }
+
+    function getRateInQuote(address) external view returns (uint256) {
+        return rate;
+    }
+}
+
+contract MockBoringVault is ERC20 {
+    constructor() ERC20("Mock Boring Vault", "MBV") {}
+
+    function enter(address from, address asset, uint256 assetAmount, address to, uint256 shareAmount) external {
+        ERC20Mock(asset).transferFrom(from, address(this), assetAmount);
+        _mint(to, shareAmount);
+    }
+
+    function exit(address to, address asset, uint256 assetAmount, address from, uint256 shareAmount) external {
+        _burn(from, shareAmount);
+        ERC20Mock(asset).transfer(to, assetAmount);
+    }
+}
+
+contract BoringVaultAssertionTest is Test, CredibleTest {
+    ERC20Mock internal asset;
+    MockBoringAccountant internal accountant;
+    MockBoringVault internal vault;
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        accountant = new MockBoringAccountant();
+        vault = new MockBoringVault();
+
+        asset.mint(alice, 1_000 ether);
+        vm.prank(alice);
+        asset.approve(address(vault), type(uint256).max);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        address[] memory monitoredAssets = new address[](1);
+        monitoredAssets[0] = address(asset);
+        bytes memory createData = abi.encodePacked(
+            type(BoringVaultAssertion).creationCode,
+            abi.encode(address(vault), address(accountant), uint8(18), monitoredAssets, 0, 0, 2_500, 2_500, 1 days)
+        );
+        cl.assertion(address(vault), createData, fnSelector);
+    }
+
+    function testEnterAccountingPassesWhenSharesMatchAccountantRate() public {
+        _arm(BoringVaultAssertion.assertEnterAccounting.selector);
+
+        vm.prank(alice);
+        vault.enter(alice, address(asset), 100 ether, alice, 100 ether);
+    }
+
+    function testEnterAccountingTripsWhenSharesAreOverMinted() public {
+        _arm(BoringVaultAssertion.assertEnterAccounting.selector);
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("BoringVault: enter over-minted shares"));
+        vault.enter(alice, address(asset), 100 ether, alice, 101 ether);
+    }
+}

--- a/examples/zeroex/test/ZeroExSettlerAssertion.t.sol
+++ b/examples/zeroex/test/ZeroExSettlerAssertion.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {ZeroExSettlerAssertion} from "../src/ZeroExSettlerAssertion.sol";
+import {ZeroExSettlerSlippage} from "../src/ZeroExSettlerInterfaces.sol";
+
+contract MockZeroExRegistry {
+    address public current;
+    address public previous;
+
+    function setCurrent(address current_) external {
+        current = current_;
+    }
+
+    function ownerOf(uint256) external view returns (address) {
+        return current;
+    }
+
+    function prev(uint128) external view returns (address) {
+        return previous;
+    }
+}
+
+contract MockZeroExSettler {
+    uint256 public payout;
+
+    function setPayout(uint256 payout_) external {
+        payout = payout_;
+    }
+
+    function execute(ZeroExSettlerSlippage calldata slippage, bytes[] calldata, bytes32)
+        external
+        payable
+        returns (bool)
+    {
+        ERC20Mock(slippage.buyToken).transfer(slippage.recipient, payout);
+        return true;
+    }
+}
+
+contract ZeroExSettlerAssertionTest is Test, CredibleTest {
+    uint128 internal constant FEATURE_ID = 1;
+
+    ERC20Mock internal buyToken;
+    MockZeroExRegistry internal registry;
+    MockZeroExSettler internal settler;
+    address internal recipient = makeAddr("recipient");
+
+    function setUp() public {
+        buyToken = new ERC20Mock();
+        registry = new MockZeroExRegistry();
+        settler = new MockZeroExSettler();
+        registry.setCurrent(address(settler));
+        buyToken.mint(address(settler), 1_000 ether);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        bytes memory createData = abi.encodePacked(
+            type(ZeroExSettlerAssertion).creationCode, abi.encode(address(settler), address(registry), FEATURE_ID)
+        );
+        cl.assertion(address(settler), createData, fnSelector);
+    }
+
+    function _execute(uint256 minAmountOut) internal {
+        bytes[] memory actions = new bytes[](0);
+        settler.execute(ZeroExSettlerSlippage(payable(recipient), address(buyToken), minAmountOut), actions, bytes32(0));
+    }
+
+    function testRecipientMinimumBuyAmountPasses() public {
+        settler.setPayout(100 ether);
+
+        _arm(ZeroExSettlerAssertion.assertRecipientReceivesMinimumBuyAmount.selector);
+        _execute(100 ether);
+    }
+
+    function testRecipientMinimumBuyAmountTripsWhenCreditedBelowMinimum() public {
+        settler.setPayout(99 ether);
+
+        _arm(ZeroExSettlerAssertion.assertRecipientReceivesMinimumBuyAmount.selector);
+        vm.expectRevert(bytes("0xSettler: recipient credited below minimum"));
+        _execute(100 ether);
+    }
+}

--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -496,7 +496,7 @@ interface PhEvm {
 
     /// @notice Returns the anomaly detector's view of `target` for the
     ///         current transaction.
-    /// @dev Returns a zero-filled context when `target` was not 
+    /// @dev Returns a zero-filled context when `target` was not
     ///      able to be scored, such that it fails open.
     /// @param target The address whose anomaly context to read.
     /// @return ctx The anomaly context for `target` in the current tx.


### PR DESCRIPTION
## Summary

- Add real PCL assertion tests for every consolidated protocol example under `examples/`.
- Cover Aave, Aerodrome, Cap, Curve, Denaria, Euler, Nado, Royco, Safe, Spark, Symbiotic, Tydro, Uniswap, Veda, and ZeroEx.
- Keep tests wired through `CredibleTest` / `cl.assertion` instead of inert mocks.
- Trim Uniswap swap assertion reads to `slot0` snapshots so the real swap PCL tests remain under the assertion gas limit.

## Validation

Ran the full example profile matrix:

```sh
env HOME=/private/tmp FOUNDRY_PROFILE=<profile> pcl test
```

Profiles:

```text
aave aerodrome cap curve denaria euler nado royco safe spark symbiotic tydro uniswap veda zeroex
```

Result: 33 passed, 0 failed, 0 skipped.

Additional checks:

```sh
forge fmt --check
git diff --cached --check
```
