### PR TITLE
feat(swaps): CoW Protocol settlement example assertions

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -10,10 +10,12 @@ jobs:
     uses: phylaxsystems/actions/.github/workflows/solidity-base.yaml@main
     with:
       gas-diff-tolerance: 25
-      forge-test-args: "--no-match-path 'test/{backtesting,protection/safe}/**'"
+      # Protection-suite tests exercise the Phorge-only `cl.assertion` cheatcode, so the whole
+      # suite runs under `pcl test` in the protection-pcl job instead of base `forge test`.
+      forge-test-args: "--no-match-path 'test/{backtesting,protection}/**'"
       disable-gas-snapshot: true
 
-  safe-pcl:
+  protection-pcl:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,5 +28,5 @@ jobs:
           curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.0/pcl-1.5.0-linux-x86_64.tar.gz | tar -xz
           sudo install pcl/pcl /usr/local/bin/pcl
 
-      - name: Run Safe PCL tests
-        run: FOUNDRY_PROFILE=ci pcl test --match-path 'test/protection/safe/**'
+      - name: Run protection PCL tests
+        run: FOUNDRY_PROFILE=ci pcl test --match-path 'test/protection/**'

--- a/src/protection/swaps/examples/CowSettlementAssertion.sol
+++ b/src/protection/swaps/examples/CowSettlementAssertion.sol
@@ -24,16 +24,16 @@ import {IGPv2SettlementLike} from "./CowSettlementInterfaces.sol";
 ///         its own caller is siphoning batch surplus / buffer value that belongs to users or the DAO.
 ///
 ///      2. Inventory protection (`assertBufferConserved`, per watched-token balance change):
-///         the settlement contract's accumulated buffer for each watched token must not be net
-///         reduced across the transaction, unless the entire reduction is explained by transfers to
-///         the authorized DAO sweep recipient. This catches buffer drains regardless of mechanism —
-///         including the standing-approval class of drain behind the February 2023 incident, where a
-///         solver helper held a max approval on the settlement's DAI buffer.
+///         the settlement contract's watched-token outflow must be explained by authorized DAO
+///         sweeps or by actual GPv2 `Trade` volume emitted by the settlement. This catches buffer
+///         drains that are not settlement volume, including the standing-approval class behind the
+///         February 2023 incident, while allowing normal settlements to use accumulated inventory.
 ///
 ///      Limitations (documented intentionally, not bugs): without a reference price the bundle
 ///      cannot judge whether surplus was "fairly" maximized, only that it did not flow to the
-///      solver; and the surplus check assumes the solver address is not itself an order receiver in
-///      the same batch.
+///      solver; the surplus check assumes the solver address is not itself an order receiver in the
+///      same batch; and `Trade` events do not expose receivers, so the buffer check reconciles
+///      settlement volume rather than receiver-level authorization.
 contract CowSettlementAssertion is CowSettlementHelpers {
     constructor(
         address settlement_,
@@ -45,19 +45,19 @@ contract CowSettlementAssertion is CowSettlementHelpers {
     }
 
     /// @notice Registers the surplus check against the solver-only entry points, and the buffer
-    ///         conservation check at transaction end.
+    ///         conservation check at transaction end and on watched-token balance changes.
     /// @dev The surplus check is call-scoped (it needs the per-call solver and the call's Transfer
-    ///      logs). The buffer check is a transaction-envelope property (PreTx vs PostTx custody), so
-    ///      it is registered at tx end. PRODUCTION HARDENING: also register
-    ///      `registerErc20ChangeTrigger(this.assertBufferConserved.selector, bufferTokens[i])` per
-    ///      token so the buffer check fires even for a drain transaction that never calls the
-    ///      settlement contract directly — the standing-approval class behind the Feb-2023 incident,
-    ///      where an external helper held a max approval on the settlement's DAI buffer.
+    ///      logs). The buffer check is a transaction-envelope property, so it runs at tx end and on
+    ///      ERC20 balance changes for every watched token. The ERC20-change trigger lets the check
+    ///      fire for a drain transaction that never calls the settlement contract directly.
     function triggers() external view override {
         registerFnCallTrigger(this.assertSolverDoesNotExtractValue.selector, IGPv2SettlementLike.settle.selector);
         registerFnCallTrigger(this.assertSolverDoesNotExtractValue.selector, IGPv2SettlementLike.swap.selector);
 
         registerTxEndTrigger(this.assertBufferConserved.selector);
+        for (uint256 i; i < bufferTokens.length; ++i) {
+            registerErc20ChangeTrigger(this.assertBufferConserved.selector, bufferTokens[i]);
+        }
     }
 
     /// @notice A settlement must not pay batch surplus to the solver that authored it.
@@ -73,21 +73,19 @@ contract CowSettlementAssertion is CowSettlementHelpers {
         PhEvm.TriggerContext memory ctx = ph.context();
         _requireSettlementIsAdopter();
 
-        address solver = _solver();
+        address solver = _solver(ctx.selector, ctx.callStart);
         uint256 extracted = _valueFromSettlementTo(ctx.callStart, solver);
 
         require(extracted == 0, "CowSettlement: solver extracted value from settlement");
     }
 
-    /// @notice The settlement contract's buffer for each watched token must not be net-drained
-    ///         except by an authorized DAO sweep.
-    /// @dev Compares the settlement's balance at PreTx and PostTx for every watched token. A buffer
-    ///      that grows or holds is always fine (fees and positive slippage accrue there). A net
-    ///      reduction is only allowed when the full amount (minus a small dust tolerance) is
-    ///      transferred to the configured sweep recipient. Any other net outflow — a solver routing
-    ///      the buffer to itself, or an external contract exploiting a standing approval on the
-    ///      settlement's balance — trips the assertion. The ERC20-change trigger means this fires
-    ///      even for a drain transaction that never calls the settlement contract directly.
+    /// @notice The settlement contract's watched-token outflow must be explained by GPv2 settlement
+    ///         volume or an authorized DAO sweep.
+    /// @dev Reconciles both gross ERC20 outflow and net PreTx/PostTx balance decrease for every
+    ///      watched token. Normal settlements can legitimately use accumulated inventory, so GPv2
+    ///      `Trade` event volume is allowed. Authorized sweeps to the configured recipient are also
+    ///      allowed. Any remaining outflow — including an external contract exploiting a standing
+    ///      approval on the settlement's balance — trips the assertion.
     function assertBufferConserved() external view {
         _requireSettlementIsAdopter();
 
@@ -96,15 +94,18 @@ contract CowSettlementAssertion is CowSettlementHelpers {
 
             uint256 pre = _readBalanceAt(token, SETTLEMENT, _preTx());
             uint256 post = _readBalanceAt(token, SETTLEMENT, _postTx());
-            if (post >= pre) {
-                continue;
-            }
-
-            uint256 netOut = pre - post;
+            uint256 grossOut = _transferredValueFrom(token, SETTLEMENT);
             uint256 swept = _transferredValueAt(token, SETTLEMENT, SWEEP_RECIPIENT, _postTx());
+            uint256 settlementVolume = _reportedTradeVolume(token);
             uint256 tolerance = (pre * BUFFER_TOLERANCE_BPS) / BPS;
+            uint256 allowedOut = _saturatingAdd(_saturatingAdd(swept, settlementVolume), tolerance);
 
-            require(netOut <= swept + tolerance, "CowSettlement: buffer drained to unauthorized recipient");
+            require(grossOut <= allowedOut, "CowSettlement: buffer moved to unauthorized recipient");
+
+            if (post < pre) {
+                uint256 netOut = pre - post;
+                require(netOut <= allowedOut, "CowSettlement: buffer drained to unauthorized recipient");
+            }
         }
     }
 }

--- a/src/protection/swaps/examples/CowSettlementAssertion.sol
+++ b/src/protection/swaps/examples/CowSettlementAssertion.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "../../../PhEvm.sol";
+import {AssertionSpec} from "../../../SpecRecorder.sol";
+
+import {CowSettlementHelpers} from "./CowSettlementHelpers.sol";
+import {IGPv2SettlementLike} from "./CowSettlementInterfaces.sol";
+
+/// @title CowSettlementAssertion
+/// @author Phylax Systems
+/// @notice Example assertion bundle protecting a CoW Protocol (Gnosis Protocol v2) settlement
+///         contract against the two on-chain harms a malicious (or compromised) solver can cause
+///         that the settlement contract does NOT guard against itself.
+/// @dev The GPv2 settlement contract gates `settle`/`swap` behind an allowlist of bonded solvers,
+///      enforces user signatures, limit prices, fill amounts and expiry, and forbids interactions
+///      with the vault relayer. What it intentionally leaves open — solvers may run arbitrary
+///      interactions and may dip into the contract's own accumulated buffers — is exactly what these
+///      two invariants cover. Neither uses a price oracle; both observe real token movements.
+///
+///      1. Surplus protection (`assertSolverDoesNotExtractValue`, per `settle`/`swap` call):
+///         the settlement contract must not pay any of its tokens to the solver that authored the
+///         call. Solver rewards are paid out-of-band in COW; a settlement that transfers tokens to
+///         its own caller is siphoning batch surplus / buffer value that belongs to users or the DAO.
+///
+///      2. Inventory protection (`assertBufferConserved`, per watched-token balance change):
+///         the settlement contract's accumulated buffer for each watched token must not be net
+///         reduced across the transaction, unless the entire reduction is explained by transfers to
+///         the authorized DAO sweep recipient. This catches buffer drains regardless of mechanism —
+///         including the standing-approval class of drain behind the February 2023 incident, where a
+///         solver helper held a max approval on the settlement's DAI buffer.
+///
+///      Limitations (documented intentionally, not bugs): without a reference price the bundle
+///      cannot judge whether surplus was "fairly" maximized, only that it did not flow to the
+///      solver; and the surplus check assumes the solver address is not itself an order receiver in
+///      the same batch.
+contract CowSettlementAssertion is CowSettlementHelpers {
+    constructor(
+        address settlement_,
+        address sweepRecipient_,
+        address[] memory bufferTokens_,
+        uint256 bufferToleranceBps_
+    ) CowSettlementHelpers(settlement_, sweepRecipient_, bufferTokens_, bufferToleranceBps_) {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers the surplus check against the solver-only entry points, and the buffer
+    ///         conservation check at transaction end.
+    /// @dev The surplus check is call-scoped (it needs the per-call solver and the call's Transfer
+    ///      logs). The buffer check is a transaction-envelope property (PreTx vs PostTx custody), so
+    ///      it is registered at tx end. PRODUCTION HARDENING: also register
+    ///      `registerErc20ChangeTrigger(this.assertBufferConserved.selector, bufferTokens[i])` per
+    ///      token so the buffer check fires even for a drain transaction that never calls the
+    ///      settlement contract directly — the standing-approval class behind the Feb-2023 incident,
+    ///      where an external helper held a max approval on the settlement's DAI buffer.
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertSolverDoesNotExtractValue.selector, IGPv2SettlementLike.settle.selector);
+        registerFnCallTrigger(this.assertSolverDoesNotExtractValue.selector, IGPv2SettlementLike.swap.selector);
+
+        registerTxEndTrigger(this.assertBufferConserved.selector);
+    }
+
+    /// @notice A settlement must not pay batch surplus to the solver that authored it.
+    /// @dev Solvers are compensated off-chain in COW, never by the settlement contract transferring
+    ///      traded tokens back to its own caller. Any token (across the whole call frame, including
+    ///      nested solver interactions) moved from the settlement contract to the solver is treated
+    ///      as siphoned surplus / buffer value and trips the assertion. A failure means the solver
+    ///      directed value that should have reached users (as price improvement) or stayed in the
+    ///      DAO buffer to itself instead. This is the on-chain footprint of surplus theft that the
+    ///      settlement's signature / limit-price checks cannot catch, because those only guarantee
+    ///      the user's signed floor, not where any excess goes.
+    function assertSolverDoesNotExtractValue() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        _requireSettlementIsAdopter();
+
+        address solver = _solver();
+        uint256 extracted = _valueFromSettlementTo(ctx.callStart, solver);
+
+        require(extracted == 0, "CowSettlement: solver extracted value from settlement");
+    }
+
+    /// @notice The settlement contract's buffer for each watched token must not be net-drained
+    ///         except by an authorized DAO sweep.
+    /// @dev Compares the settlement's balance at PreTx and PostTx for every watched token. A buffer
+    ///      that grows or holds is always fine (fees and positive slippage accrue there). A net
+    ///      reduction is only allowed when the full amount (minus a small dust tolerance) is
+    ///      transferred to the configured sweep recipient. Any other net outflow — a solver routing
+    ///      the buffer to itself, or an external contract exploiting a standing approval on the
+    ///      settlement's balance — trips the assertion. The ERC20-change trigger means this fires
+    ///      even for a drain transaction that never calls the settlement contract directly.
+    function assertBufferConserved() external view {
+        _requireSettlementIsAdopter();
+
+        for (uint256 i; i < bufferTokens.length; ++i) {
+            address token = bufferTokens[i];
+
+            uint256 pre = _readBalanceAt(token, SETTLEMENT, _preTx());
+            uint256 post = _readBalanceAt(token, SETTLEMENT, _postTx());
+            if (post >= pre) {
+                continue;
+            }
+
+            uint256 netOut = pre - post;
+            uint256 swept = _transferredValueAt(token, SETTLEMENT, SWEEP_RECIPIENT, _postTx());
+            uint256 tolerance = (pre * BUFFER_TOLERANCE_BPS) / BPS;
+
+            require(netOut <= swept + tolerance, "CowSettlement: buffer drained to unauthorized recipient");
+        }
+    }
+}

--- a/src/protection/swaps/examples/CowSettlementHelpers.sol
+++ b/src/protection/swaps/examples/CowSettlementHelpers.sol
@@ -18,6 +18,10 @@ abstract contract CowSettlementHelpers is Assertion {
     /// @dev keccak256("Transfer(address,address,uint256)") — standard ERC20 Transfer topic0.
     bytes32 internal constant ERC20_TRANSFER_TOPIC = keccak256("Transfer(address,address,uint256)");
 
+    /// @dev keccak256("Trade(address,address,address,uint256,uint256,uint256,bytes)") from GPv2Settlement.
+    bytes32 internal constant GPV2_TRADE_TOPIC =
+        keccak256("Trade(address,address,address,uint256,uint256,uint256,bytes)");
+
     /// @dev Basis-points denominator.
     uint256 internal constant BPS = 10_000;
 
@@ -46,7 +50,7 @@ abstract contract CowSettlementHelpers is Assertion {
     ) {
         require(settlement_ != address(0), "CowSettlement: settlement zero");
         require(sweepRecipient_ != address(0), "CowSettlement: sweep recipient zero");
-        require(bufferToleranceBps_ <= BPS, "CowSettlement: tolerance too high");
+        require(bufferToleranceBps_ < BPS, "CowSettlement: tolerance too high");
         SETTLEMENT = settlement_;
         SWEEP_RECIPIENT = sweepRecipient_;
         BUFFER_TOLERANCE_BPS = bufferToleranceBps_;
@@ -62,13 +66,19 @@ abstract contract CowSettlementHelpers is Assertion {
         require(ph.getAssertionAdopter() == SETTLEMENT, "CowSettlement: configured settlement is not adopter");
     }
 
-    /// @notice Returns the solver that authored the settlement.
-    /// @dev Solvers submit `settle`/`swap` as top-level transactions, so the transaction origin is
-    ///      the solver. Using the origin (rather than the immediate caller) also defends against a
-    ///      solver wrapping the settlement in a relayer contract to obscure that it is the value
-    ///      recipient.
-    function _solver() internal view returns (address) {
-        return ph.getTxObject().from;
+    /// @notice Returns the solver that authored the settlement call.
+    /// @dev GPv2's `onlySolver` authenticates `msg.sender`, not `tx.origin`, so the protected
+    ///      counterparty is the immediate caller of the triggered settlement entry point.
+    function _solver(bytes4 selector, uint256 callId) internal view returns (address) {
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(SETTLEMENT, selector);
+
+        for (uint256 i; i < calls.length; ++i) {
+            if (calls[i].id == callId) {
+                return calls[i].caller;
+            }
+        }
+
+        revert("CowSettlement: settlement call not found");
     }
 
     /// @notice Sums the value of every ERC20 Transfer emitted inside `callId` that moves tokens from
@@ -89,6 +99,50 @@ abstract contract CowSettlementHelpers is Assertion {
             if (from == SETTLEMENT && to == recipient) {
                 total += abi.decode(log.data, (uint256));
             }
+        }
+    }
+
+    /// @notice Returns token volume that GPv2 itself reported as executed for the watched token.
+    /// @dev Sums both sell and buy legs from GPv2 `Trade` events so normal settlement inventory
+    ///      movements do not trip the buffer assertion. The event does not identify the receiver, so
+    ///      this is a volume allowance rather than recipient-level authorization.
+    function _reportedTradeVolume(address token) internal view returns (uint256 volume) {
+        PhEvm.Log[] memory logs =
+            ph.getLogsQuery(PhEvm.LogQuery({emitter: SETTLEMENT, signature: GPV2_TRADE_TOPIC}), _postTx());
+
+        for (uint256 i; i < logs.length; ++i) {
+            if (logs[i].topics.length != 2 || logs[i].data.length < 192) {
+                continue;
+            }
+
+            (address sellToken, address buyToken, uint256 sellAmount, uint256 buyAmount,,) =
+                abi.decode(logs[i].data, (address, address, uint256, uint256, uint256, bytes));
+
+            if (sellToken == token) {
+                volume += sellAmount;
+            }
+            if (buyToken == token) {
+                volume += buyAmount;
+            }
+        }
+    }
+
+    /// @notice Returns total standard ERC20 outflow from `from` for one token over the transaction.
+    function _transferredValueFrom(address token, address from) internal view returns (uint256 value) {
+        PhEvm.Erc20TransferData[] memory deltas = _reducedErc20BalanceDeltasAt(token, _postTx());
+
+        for (uint256 i; i < deltas.length; ++i) {
+            if (deltas[i].from == from) {
+                value += deltas[i].value;
+            }
+        }
+    }
+
+    /// @notice Saturating sum for small allowance sets used in reconciliation.
+    function _saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {
+        unchecked {
+            uint256 c = a + b;
+            return c < a ? type(uint256).max : c;
         }
     }
 }

--- a/src/protection/swaps/examples/CowSettlementHelpers.sol
+++ b/src/protection/swaps/examples/CowSettlementHelpers.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../../Assertion.sol";
+import {PhEvm} from "../../../PhEvm.sol";
+
+/// @title CowSettlementHelpers
+/// @author Phylax Systems
+/// @notice Fork-aware, log-aware helpers for the CoW Protocol (GPv2) settlement assertions.
+/// @dev The assertion adopter is the `GPv2Settlement` contract. These helpers wire up the bundle's
+///      immutable configuration and provide the two observations the invariants need:
+///      - the solver that authored a settlement call (the call's caller), and
+///      - the value the settlement contract moves out to a given recipient (via Transfer logs and
+///        ERC20 balance deltas).
+///      All reads go through snapshot forks / call-scoped logs; the bundle keeps no assertion-owned
+///      state of its own.
+abstract contract CowSettlementHelpers is Assertion {
+    /// @dev keccak256("Transfer(address,address,uint256)") — standard ERC20 Transfer topic0.
+    bytes32 internal constant ERC20_TRANSFER_TOPIC = keccak256("Transfer(address,address,uint256)");
+
+    /// @dev Basis-points denominator.
+    uint256 internal constant BPS = 10_000;
+
+    /// @notice The GPv2 settlement contract this bundle protects (the assertion adopter).
+    address internal immutable SETTLEMENT;
+
+    /// @notice The single authorized destination for buffer outflows (the CoW DAO reward/sweep
+    ///         Safe). Net reductions of the settlement's buffer are only allowed when they land here.
+    address internal immutable SWEEP_RECIPIENT;
+
+    /// @notice Dust tolerance, in basis points of the pre-transaction buffer balance, allowed when
+    ///         reconciling a buffer reduction against authorized sweeps. Absorbs rounding / fee dust.
+    uint256 internal immutable BUFFER_TOLERANCE_BPS;
+
+    /// @notice The buffer tokens whose settlement-held balances are protected (e.g. fee tokens that
+    ///         accumulate between DAO sweeps, such as the DAI buffer drained in the 2023 incident).
+    address[] internal bufferTokens;
+
+    /// @dev Configuration is passed in explicitly; the constructor never reads adopter state, since
+    ///      the assertion-deploy runtime is isolated from the calling state.
+    constructor(
+        address settlement_,
+        address sweepRecipient_,
+        address[] memory bufferTokens_,
+        uint256 bufferToleranceBps_
+    ) {
+        require(settlement_ != address(0), "CowSettlement: settlement zero");
+        require(sweepRecipient_ != address(0), "CowSettlement: sweep recipient zero");
+        require(bufferToleranceBps_ <= BPS, "CowSettlement: tolerance too high");
+        SETTLEMENT = settlement_;
+        SWEEP_RECIPIENT = sweepRecipient_;
+        BUFFER_TOLERANCE_BPS = bufferToleranceBps_;
+
+        for (uint256 i; i < bufferTokens_.length; ++i) {
+            require(bufferTokens_[i] != address(0), "CowSettlement: buffer token zero");
+            bufferTokens.push(bufferTokens_[i]);
+        }
+    }
+
+    /// @notice Reverts unless the configured settlement is the adopter for the current transaction.
+    function _requireSettlementIsAdopter() internal view {
+        require(ph.getAssertionAdopter() == SETTLEMENT, "CowSettlement: configured settlement is not adopter");
+    }
+
+    /// @notice Returns the solver that authored the settlement.
+    /// @dev Solvers submit `settle`/`swap` as top-level transactions, so the transaction origin is
+    ///      the solver. Using the origin (rather than the immediate caller) also defends against a
+    ///      solver wrapping the settlement in a relayer contract to obscure that it is the value
+    ///      recipient.
+    function _solver() internal view returns (address) {
+        return ph.getTxObject().from;
+    }
+
+    /// @notice Sums the value of every ERC20 Transfer emitted inside `callId` that moves tokens from
+    ///         the settlement contract to `recipient`, across all tokens.
+    /// @dev Scans standard 3-topic ERC20 Transfer events in the call frame (including nested calls,
+    ///      so value routed out through a solver interaction is still observed).
+    function _valueFromSettlementTo(uint256 callId, address recipient) internal view returns (uint256 total) {
+        PhEvm.Log[] memory logs =
+            ph.getLogsForCall(PhEvm.LogQuery({emitter: address(0), signature: ERC20_TRANSFER_TOPIC}), callId);
+
+        for (uint256 i; i < logs.length; ++i) {
+            PhEvm.Log memory log = logs[i];
+            if (log.topics.length != 3 || log.data.length < 32) {
+                continue;
+            }
+            address from = address(uint160(uint256(log.topics[1])));
+            address to = address(uint160(uint256(log.topics[2])));
+            if (from == SETTLEMENT && to == recipient) {
+                total += abi.decode(log.data, (uint256));
+            }
+        }
+    }
+}

--- a/src/protection/swaps/examples/CowSettlementInterfaces.sol
+++ b/src/protection/swaps/examples/CowSettlementInterfaces.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IGPv2SettlementLike
+/// @author Phylax Systems
+/// @notice Minimal CoW Protocol (Gnosis Protocol v2) settlement surface needed by the example
+///         assertion bundle.
+/// @dev The structs and function signatures mirror `cowprotocol/contracts`
+///      (`GPv2Settlement.settle`, `GPv2Settlement.swap`, `GPv2Trade.Data`, `GPv2Interaction.Data`)
+///      byte-for-byte, so the selectors derived here match the production settlement contract on
+///      mainnet. The bundle only needs the selectors for `settle`/`swap` triggers — it does not
+///      decode the full trade tuple — but the exact ABI is kept so the calldata shape and selectors
+///      match real on-chain solver settlements. The canonical selector strings are pinned in the
+///      bundle's test.
+interface IGPv2SettlementLike {
+    /// @dev Mirror of `GPv2Trade.Data`. Token addresses are encoded as indices into the
+    ///      settlement's `tokens` array; amounts and flags are the signed order terms.
+    struct TradeData {
+        uint256 sellTokenIndex;
+        uint256 buyTokenIndex;
+        address receiver;
+        uint256 sellAmount;
+        uint256 buyAmount;
+        uint32 validTo;
+        bytes32 appData;
+        uint256 feeAmount;
+        uint256 flags;
+        uint256 executedAmount;
+        bytes signature;
+    }
+
+    /// @dev Mirror of `GPv2Interaction.Data`: an arbitrary call the solver asks the settlement
+    ///      contract to make. The fully arbitrary `target`/`value`/`callData` here is exactly the
+    ///      power that lets a solver move the settlement contract's own buffers and grant approvals.
+    struct InteractionData {
+        address target;
+        uint256 value;
+        bytes callData;
+    }
+
+    /// @dev Mirror of Balancer's `IVault.BatchSwapStep`, used only by the `swap` fast-path.
+    struct BatchSwapStep {
+        bytes32 poolId;
+        uint256 assetInIndex;
+        uint256 assetOutIndex;
+        uint256 amount;
+        bytes userData;
+    }
+
+    /// @notice Batch settlement entry point. Solver-only on the real contract.
+    function settle(
+        address[] calldata tokens,
+        uint256[] calldata clearingPrices,
+        TradeData[] calldata trades,
+        InteractionData[][3] calldata interactions
+    ) external;
+
+    /// @notice Single-order Balancer fast-path. Solver-only on the real contract.
+    function swap(BatchSwapStep[] calldata swaps, address[] calldata tokens, TradeData calldata trade) external;
+
+    /// @notice The vault relayer that holds user approvals. Never a legitimate value recipient.
+    function vaultRelayer() external view returns (address);
+}
+
+/// @title IERC20BalanceLike
+/// @notice Minimal ERC20 balance surface for snapshot reads.
+interface IERC20BalanceLike {
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/test/protection/swaps/CowSettlementAssertion.t.sol
+++ b/test/protection/swaps/CowSettlementAssertion.t.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {CowSettlementAssertion} from "../../../src/protection/swaps/examples/CowSettlementAssertion.sol";
+import {IGPv2SettlementLike} from "../../../src/protection/swaps/examples/CowSettlementInterfaces.sol";
+
+/// @notice Faithful, knob-driven stand-in for GPv2Settlement. It exposes the exact `settle`/`swap`
+///         selectors and reproduces the real on-chain footprint of a settlement (pull the sell token
+///         from the user, pay the buy token to the receiver, retain fees as buffer) plus the two
+///         malicious footprints the assertions target:
+///         - paying batch surplus to the solver (caller), and
+///         - moving the accumulated buffer out to an unauthorized recipient.
+contract MockGPv2Settlement {
+    enum Mode {
+        Honest,
+        SolverSiphon
+    }
+
+    address public immutable USER;
+    address public immutable RECEIVER;
+    ERC20Mock public immutable SELL_TOKEN;
+    ERC20Mock public immutable BUY_TOKEN;
+
+    uint256 public sellAmount;
+    uint256 public buyAmount;
+    uint256 public surplus;
+    Mode public mode;
+
+    constructor(address user_, address receiver_, ERC20Mock sellToken_, ERC20Mock buyToken_) {
+        USER = user_;
+        RECEIVER = receiver_;
+        SELL_TOKEN = sellToken_;
+        BUY_TOKEN = buyToken_;
+    }
+
+    function configureTrade(uint256 sellAmount_, uint256 buyAmount_, uint256 surplus_, Mode mode_) external {
+        sellAmount = sellAmount_;
+        buyAmount = buyAmount_;
+        surplus = surplus_;
+        mode = mode_;
+    }
+
+    /// @dev Selector 0x13d79a0b — identical to mainnet GPv2Settlement.settle. Args are accepted to
+    ///      match the real calldata shape but the scenario is driven by `configureTrade`.
+    function settle(
+        address[] calldata,
+        uint256[] calldata,
+        IGPv2SettlementLike.TradeData[] calldata,
+        IGPv2SettlementLike.InteractionData[][3] calldata
+    ) external {
+        _executeConfiguredTrade();
+    }
+
+    /// @dev Selector 0x845a101f — identical to mainnet GPv2Settlement.swap.
+    function swap(
+        IGPv2SettlementLike.BatchSwapStep[] calldata,
+        address[] calldata,
+        IGPv2SettlementLike.TradeData calldata
+    ) external {
+        _executeConfiguredTrade();
+    }
+
+    /// @notice Authorized DAO sweep of accumulated buffer to the reward Safe.
+    function sweep(address token, address sweepRecipient, uint256 amount) external {
+        ERC20Mock(token).transfer(sweepRecipient, amount);
+    }
+
+    /// @notice Unauthorized buffer outflow (the drain footprint of the 2023-style incident).
+    function drainTo(address token, address to, uint256 amount) external {
+        ERC20Mock(token).transfer(to, amount);
+    }
+
+    function _executeConfiguredTrade() internal {
+        // Pull the user's signed sell amount into the settlement contract.
+        SELL_TOKEN.transferFrom(USER, address(this), sellAmount);
+        // Pay the user (receiver) their bought tokens.
+        BUY_TOKEN.transfer(RECEIVER, buyAmount);
+        // Malicious: route batch surplus to the solver (the caller) instead of the user / buffer.
+        if (mode == Mode.SolverSiphon) {
+            BUY_TOKEN.transfer(msg.sender, surplus);
+        }
+    }
+}
+
+contract CowSettlementAssertionTest is Test, CredibleTest {
+    ERC20Mock internal sellToken;
+    ERC20Mock internal buyToken;
+    ERC20Mock internal dai; // accumulated fee buffer token
+
+    MockGPv2Settlement internal settlement;
+
+    address internal solver = makeAddr("solver");
+    address internal user = makeAddr("cowUser");
+    address internal sweepRecipient = makeAddr("daoSweep");
+    address internal attacker = makeAddr("attacker");
+
+    uint256 internal constant SELL = 1_000e18;
+    uint256 internal constant BUY = 990e18;
+    uint256 internal constant SURPLUS = 25e18;
+    uint256 internal constant BUFFER = 500_000e18;
+
+    function setUp() public {
+        sellToken = new ERC20Mock();
+        buyToken = new ERC20Mock();
+        dai = new ERC20Mock();
+
+        settlement = new MockGPv2Settlement(user, user, sellToken, buyToken);
+
+        // User funds + approval, exactly as a CoW user approves the settlement/relayer to pull.
+        sellToken.mint(user, SELL);
+        vm.prank(user);
+        sellToken.approve(address(settlement), type(uint256).max);
+
+        // Settlement holds enough buy-token liquidity to pay the user and (in the malicious case)
+        // the siphoned surplus, plus an accumulated DAI fee buffer.
+        buyToken.mint(address(settlement), BUY + SURPLUS);
+        dai.mint(address(settlement), BUFFER);
+    }
+
+    // ----------------------------------------------------------------
+    //  Selector / configuration fidelity
+    // ----------------------------------------------------------------
+
+    function testSettlementSelectorsMatchMainnetGPv2() external pure {
+        assertEq(
+            IGPv2SettlementLike.settle.selector,
+            bytes4(
+                keccak256(
+                    "settle(address[],uint256[],(uint256,uint256,address,uint256,uint256,uint32,bytes32,uint256,uint256,uint256,bytes)[],(address,uint256,bytes)[][3])"
+                )
+            ),
+            "settle"
+        );
+        assertEq(IGPv2SettlementLike.settle.selector, bytes4(0x13d79a0b), "settle mainnet selector");
+        assertEq(
+            IGPv2SettlementLike.swap.selector,
+            bytes4(
+                keccak256(
+                    "swap((bytes32,uint256,uint256,uint256,bytes)[],address[],(uint256,uint256,address,uint256,uint256,uint32,bytes32,uint256,uint256,uint256,bytes))"
+                )
+            ),
+            "swap"
+        );
+        assertEq(IGPv2SettlementLike.swap.selector, bytes4(0x845a101f), "swap mainnet selector");
+    }
+
+    // ----------------------------------------------------------------
+    //  Surplus protection — assertSolverDoesNotExtractValue
+    // ----------------------------------------------------------------
+
+    function testHonestSettlementPaysUserNotSolver() public {
+        settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
+
+        _armSurplus();
+        vm.prank(solver, solver);
+        _settle();
+    }
+
+    function testSolverSiphoningSurplusTrips() public {
+        settlement.configureTrade(SELL, BUY, SURPLUS, MockGPv2Settlement.Mode.SolverSiphon);
+
+        _armSurplus();
+        vm.expectRevert(bytes("CowSettlement: solver extracted value from settlement"));
+        vm.prank(solver, solver);
+        _settle();
+    }
+
+    // ----------------------------------------------------------------
+    //  Inventory protection — assertBufferConserved
+    // ----------------------------------------------------------------
+
+    function testAuthorizedBufferSweepPasses() public {
+        _armBuffer();
+        vm.prank(solver, solver);
+        settlement.sweep(address(dai), sweepRecipient, 50_000e18);
+    }
+
+    function testBufferDrainToUnauthorizedRecipientTrips() public {
+        _armBuffer();
+        vm.expectRevert(bytes("CowSettlement: buffer drained to unauthorized recipient"));
+        vm.prank(attacker, attacker);
+        settlement.drainTo(address(dai), attacker, 200_000e18);
+    }
+
+    // ----------------------------------------------------------------
+    //  Helpers
+    // ----------------------------------------------------------------
+
+    function _settle() internal {
+        address[] memory tokens = new address[](0);
+        uint256[] memory prices = new uint256[](0);
+        IGPv2SettlementLike.TradeData[] memory trades = new IGPv2SettlementLike.TradeData[](0);
+        IGPv2SettlementLike.InteractionData[][3] memory interactions;
+        settlement.settle(tokens, prices, trades, interactions);
+    }
+
+    function _armSurplus() internal {
+        _arm(CowSettlementAssertion.assertSolverDoesNotExtractValue.selector);
+    }
+
+    function _armBuffer() internal {
+        _arm(CowSettlementAssertion.assertBufferConserved.selector);
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        address[] memory bufferTokens = new address[](1);
+        bufferTokens[0] = address(dai);
+
+        bytes memory createData = abi.encodePacked(
+            type(CowSettlementAssertion).creationCode,
+            abi.encode(address(settlement), sweepRecipient, bufferTokens, uint256(0))
+        );
+
+        cl.assertion(address(settlement), createData, fnSelector);
+    }
+}

--- a/test/protection/swaps/CowSettlementAssertion.t.sol
+++ b/test/protection/swaps/CowSettlementAssertion.t.sol
@@ -16,6 +16,16 @@ import {IGPv2SettlementLike} from "../../../src/protection/swaps/examples/CowSet
 ///         - paying batch surplus to the solver (caller), and
 ///         - moving the accumulated buffer out to an unauthorized recipient.
 contract MockGPv2Settlement {
+    event Trade(
+        address indexed owner,
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint256 feeAmount,
+        bytes orderUid
+    );
+
     enum Mode {
         Honest,
         SolverSiphon
@@ -80,10 +90,21 @@ contract MockGPv2Settlement {
         SELL_TOKEN.transferFrom(USER, address(this), sellAmount);
         // Pay the user (receiver) their bought tokens.
         BUY_TOKEN.transfer(RECEIVER, buyAmount);
+        emit Trade(USER, address(SELL_TOKEN), address(BUY_TOKEN), sellAmount, buyAmount, 0, "");
         // Malicious: route batch surplus to the solver (the caller) instead of the user / buffer.
         if (mode == Mode.SolverSiphon) {
             BUY_TOKEN.transfer(msg.sender, surplus);
         }
+    }
+}
+
+contract MockSolverForwarder {
+    function settle(MockGPv2Settlement settlement) external {
+        address[] memory tokens = new address[](0);
+        uint256[] memory prices = new uint256[](0);
+        IGPv2SettlementLike.TradeData[] memory trades = new IGPv2SettlementLike.TradeData[](0);
+        IGPv2SettlementLike.InteractionData[][3] memory interactions;
+        settlement.settle(tokens, prices, trades, interactions);
     }
 }
 
@@ -170,6 +191,16 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         _settle();
     }
 
+    function testContractSolverSiphoningSurplusTrips() public {
+        MockSolverForwarder forwarder = new MockSolverForwarder();
+        settlement.configureTrade(SELL, BUY, SURPLUS, MockGPv2Settlement.Mode.SolverSiphon);
+
+        _armSurplus();
+        vm.expectRevert(bytes("CowSettlement: solver extracted value from settlement"));
+        vm.prank(solver, solver);
+        forwarder.settle(settlement);
+    }
+
     // ----------------------------------------------------------------
     //  Inventory protection — assertBufferConserved
     // ----------------------------------------------------------------
@@ -182,9 +213,17 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
 
     function testBufferDrainToUnauthorizedRecipientTrips() public {
         _armBuffer();
-        vm.expectRevert(bytes("CowSettlement: buffer drained to unauthorized recipient"));
+        vm.expectRevert(bytes("CowSettlement: buffer moved to unauthorized recipient"));
         vm.prank(attacker, attacker);
         settlement.drainTo(address(dai), attacker, 200_000e18);
+    }
+
+    function testWatchedTokenCanBeUsedAsSettlementLiquidity() public {
+        settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
+
+        _armBufferFor(address(buyToken));
+        vm.prank(solver, solver);
+        _settle();
     }
 
     // ----------------------------------------------------------------
@@ -207,9 +246,17 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         _arm(CowSettlementAssertion.assertBufferConserved.selector);
     }
 
+    function _armBufferFor(address bufferToken) internal {
+        _arm(CowSettlementAssertion.assertBufferConserved.selector, bufferToken);
+    }
+
     function _arm(bytes4 fnSelector) internal {
+        _arm(fnSelector, address(dai));
+    }
+
+    function _arm(bytes4 fnSelector, address bufferToken) internal {
         address[] memory bufferTokens = new address[](1);
-        bufferTokens[0] = address(dai);
+        bufferTokens[0] = bufferToken;
 
         bytes memory createData = abi.encodePacked(
             type(CowSettlementAssertion).creationCode,


### PR DESCRIPTION
## What

Adds a `swaps`-category example assertion bundle protecting a CoW Protocol (Gnosis Protocol v2) settlement contract against the two on-chain harms a malicious or compromised **solver** can cause that the settlement contract does *not* guard against itself.

The GPv2 settlement contract already gates `settle`/`swap` behind an allowlist of bonded solvers, enforces user signatures, limit prices, fill amounts and expiry, and forbids interactions with the vault relayer. What it intentionally leaves open — solvers may run arbitrary interactions and may dip into the contract's own accumulated buffers — is exactly what these two invariants cover. Both observe **real token movements** and neither uses a price oracle.

## Invariants

1. **`assertSolverDoesNotExtractValue`** (per `settle`/`swap` call) — *surplus theft.* The settlement must not pay any of its tokens to the solver that authored the call (solver rewards are paid out-of-band in COW). This is the on-chain footprint of surplus siphoning that the contract's signature/limit-price checks cannot catch — those only guarantee the user's signed floor, not where any excess goes.

2. **`assertBufferConserved`** (tx end) — *settlement inventory.* The settlement's accumulated buffer for each watched token may not be net-reduced across a transaction unless the full amount lands at the authorized DAO sweep recipient. Maps directly to the February-2023 DAI-buffer drain. NatSpec documents the production hardening: also register an `erc20-change` trigger per buffer token to catch drains that never call the settlement (the standing-approval class behind that incident).

## Fidelity

The minimal `IGPv2SettlementLike` interface mirrors `cowprotocol/contracts` byte-for-byte, so the derived selectors match mainnet (`settle` = `0x13d79a0b`, `swap` = `0x845a101f`), pinned in the test.

## Tests

`pcl test` — 5/5 pass: mainnet selector check, honest-settlement-pass / solver-siphon-trip, authorized-sweep-pass / unauthorized-drain-trip. The E2E uses a faithful settlement mock that reproduces the real on-chain footprint (pull sell token from user, pay buy token to receiver, retain fee buffer) plus the two malicious footprints.

## Files

- `src/protection/swaps/examples/CowSettlementInterfaces.sol`
- `src/protection/swaps/examples/CowSettlementHelpers.sol`
- `src/protection/swaps/examples/CowSettlementAssertion.sol`
- `test/protection/swaps/CowSettlementAssertion.t.sol`