### PR TITLE
Fluid assertions

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -30,3 +30,26 @@ jobs:
 
       - name: Run protection PCL tests
         run: FOUNDRY_PROFILE=ci pcl test --match-path 'test/protection/**'
+
+  # Example assertion suites live under their own foundry profiles (examples/<name>) and also use the
+  # Phorge-only `cl.assertion` cheatcode, so they run under `pcl test` here. Add a profile to the
+  # matrix when its example is ready to be gated on every PR.
+  examples-pcl:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [fluid]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install PCL
+        run: |
+          curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.0/pcl-1.5.0-linux-x86_64.tar.gz | tar -xz
+          sudo install pcl/pcl /usr/local/bin/pcl
+
+      - name: Run ${{ matrix.profile }} example PCL tests
+        run: FOUNDRY_PROFILE=${{ matrix.profile }} pcl test

--- a/examples/fluid/README.md
+++ b/examples/fluid/README.md
@@ -24,6 +24,9 @@ FOUNDRY_PROFILE=fluid forge build
 FOUNDRY_PROFILE=fluid pcl test
 ```
 
+This suite runs on every PR via the `examples-pcl` matrix job in
+`.github/workflows/solidity-test.yml`, so a regression in these assertions fails CI.
+
 ## Assertions
 
 ### `FluidLiquiditySolvencyAssertion` — Liquidity Layer (business logic)

--- a/examples/fluid/README.md
+++ b/examples/fluid/README.md
@@ -1,0 +1,85 @@
+# Fluid (Instadapp) examples
+
+Credible Layer assertion examples for [Fluid](https://instadapp.io/product/fluid)
+([fluid-contracts-public](https://github.com/Instadapp/fluid-contracts-public)).
+
+Fluid is built around a single **Liquidity Layer** that custodies every token for every protocol on
+top of it (the lending **fTokens** and the borrow/collateral **Vaults**). The assertions here cover
+two angles the user asked for:
+
+1. **Business-logic invariants** — the core accounting facts the protocol must never violate.
+2. **Assertions that let Fluid run looser limits / riskier assets safely** — the protocol keeps its
+   generous, capital-efficient on-chain limits and aggressive risk parameters, while the assertion
+   enforces the tighter boundary that actually keeps the system solvent and liquidatable.
+
+## Build
+
+```sh
+FOUNDRY_PROFILE=fluid forge build
+```
+
+## Test
+
+```sh
+FOUNDRY_PROFILE=fluid pcl test
+```
+
+## Assertions
+
+### `FluidLiquiditySolvencyAssertion` — Liquidity Layer (business logic)
+
+Installed on the Liquidity Layer singleton. Two transaction-end invariants, read straight from the
+singleton's packed per-token storage (no resolver trust, no interest-accrual reimplementation):
+
+- **Custody covers net supply** — `balanceOf(Liquidity, token) + totalBorrow >= totalSupply` for
+  every monitored token, i.e. accrued protocol revenue stays non-negative. This is the protocol-wide
+  insolvency condition; the per-operation `require`s never state it against the real ERC20 balance.
+- **Exchange prices are monotonic** — supply and borrow exchange prices only ever accrue interest, so
+  any decrease across the transaction signals corrupted accounting or a malicious config-slot write.
+
+### `FluidLiquidityFlowBreakerAssertion` — Liquidity Layer (looser limits, safely)
+
+A tiered rolling-window outflow circuit breaker (built-in `watchCumulativeOutflow`). Fluid's on-chain
+withdraw/borrow limits auto-expand and are intentionally generous; this assertion lets them stay loose
+while capping the *aggregate* bleed so an exploit cannot drain a market by chaining many individually
+valid `operate` calls:
+
+- **Warning tier (10% / 24h)** — block new borrows of the breached token; suppliers can still
+  withdraw and borrowers can still repay, so honest exit and de-risking stay open.
+- **Critical tier (20% / 24h)** — hard-pause the singleton.
+
+### `FluidVaultRiskConfigAssertion` — Vault (riskier collateral, safely)
+
+Installed on a Fluid Vault. Re-checks the vault's stored risk-parameter ordering at transaction end —
+`collateralFactor < liquidationThreshold < liquidationMaxLimit`,
+`liquidationMaxLimit <= 100%`, and `liquidationMaxLimit + liquidationPenalty <= 99.7%` — regardless of
+how the config was written (setter, faulty upgrade, storage collision). The vault admin module only
+enforces this ordering inside its setters; the assertion guarantees it in the actual stored state.
+That makes it safe to tune aggressive parameters for riskier collateral: governance can push CF/LT
+high, and the invariant that keeps every position liquidatable is enforced on-chain.
+
+### `FluidFTokenSharePriceAssertion` — fToken (business logic)
+
+Installed on an fToken (fUSDC, fWETH, ...). An fToken supplies all of its underlying into the Liquidity
+Layer and its share price is yield-only by construction, so `totalAssets / totalSupply` must never
+decrease across a transaction. A drop signals a loss, mispriced mint/redeem, or accounting bug.
+
+## Files
+
+- `FluidInterfaces.sol` — minimal Fluid surfaces (Liquidity `operate`, vault resolver getter, fToken ERC-4626).
+- `FluidLiquidityHelpers.sol` — `FluidLiquidityBase`: packed-storage decode (slots, BigMath) and calldata helpers.
+- `FluidLiquiditySolvencyAssertion.sol`
+- `FluidLiquidityFlowBreakerAssertion.sol`
+- `FluidVaultRiskConfigAssertion.sol`
+- `FluidFTokenSharePriceAssertion.sol`
+
+## Notes
+
+- Storage slots / bit offsets are from Fluid's `liquiditySlotsLink.sol`, `bigMathMinified.sol`, and the
+  vault admin module. Exchange-price and total-amount totals use the singleton's *stored* prices, which
+  form a self-consistent snapshot against the held balance.
+- `watchCumulativeOutflow`'s live firing is driven by the executor's rolling-window accounting and is
+  not simulated by local `pcl test`, so the flow breaker's warning-tier policy is unit-tested through a
+  pure helper (`_operateBorrowsToken`) rather than an armed `cl.assertion` call.
+- Native-token markets (`0xEeee…EEeE`) are skipped by the ERC20 custody check; the exchange-price check
+  still applies to them.

--- a/examples/fluid/README.md
+++ b/examples/fluid/README.md
@@ -31,9 +31,10 @@ FOUNDRY_PROFILE=fluid pcl test
 Installed on the Liquidity Layer singleton. Two transaction-end invariants, read straight from the
 singleton's packed per-token storage (no resolver trust, no interest-accrual reimplementation):
 
-- **Custody covers net supply** — `balanceOf(Liquidity, token) + totalBorrow >= totalSupply` for
-  every monitored token, i.e. accrued protocol revenue stays non-negative. This is the protocol-wide
-  insolvency condition; the per-operation `require`s never state it against the real ERC20 balance.
+- **Custody covers net supply** — `recognizedCustody(Liquidity, token) + totalBorrow >= totalSupply`
+  for every monitored token, i.e. accrued protocol revenue stays non-negative. Mainnet weETH/weETHs
+  custody includes Fluid's Zircuit balance, matching Fluid's resolver accounting. This is the
+  protocol-wide insolvency condition; the per-operation `require`s never state it against custody.
 - **Exchange prices are monotonic** — supply and borrow exchange prices only ever accrue interest, so
   any decrease across the transaction signals corrupted accounting or a malicious config-slot write.
 
@@ -48,6 +49,9 @@ valid `operate` calls:
   withdraw and borrowers can still repay, so honest exit and de-risking stay open.
 - **Critical tier (20% / 24h)** — hard-pause the singleton.
 
+The breaker intentionally rejects native-token markets and known Fluid external-custody tokens,
+because the built-in ERC20 outflow watcher cannot correctly classify those custody moves.
+
 ### `FluidVaultRiskConfigAssertion` — Vault (riskier collateral, safely)
 
 Installed on a Fluid Vault. Re-checks the vault's stored risk-parameter ordering at transaction end —
@@ -61,8 +65,9 @@ high, and the invariant that keeps every position liquidatable is enforced on-ch
 ### `FluidFTokenSharePriceAssertion` — fToken (business logic)
 
 Installed on an fToken (fUSDC, fWETH, ...). An fToken supplies all of its underlying into the Liquidity
-Layer and its share price is yield-only by construction, so `totalAssets / totalSupply` must never
-decrease across a transaction. A drop signals a loss, mispriced mint/redeem, or accounting bug.
+Layer and its share price is yield-only by construction, so a fixed-share `convertToAssets(1e12)`
+sample must never decrease across a transaction. A drop signals a loss, mispriced mint/redeem, or
+accounting bug.
 
 ## Files
 
@@ -81,5 +86,5 @@ decrease across a transaction. A drop signals a loss, mispriced mint/redeem, or 
 - `watchCumulativeOutflow`'s live firing is driven by the executor's rolling-window accounting and is
   not simulated by local `pcl test`, so the flow breaker's warning-tier policy is unit-tested through a
   pure helper (`_operateBorrowsToken`) rather than an armed `cl.assertion` call.
-- Native-token markets (`0xEeee…EEeE`) are skipped by the ERC20 custody check; the exchange-price check
+- Native-token markets (`0xEeee...EEeE`) are skipped by the ERC20 custody check; the exchange-price check
   still applies to them.

--- a/examples/fluid/src/FluidFTokenSharePriceAssertion.sol
+++ b/examples/fluid/src/FluidFTokenSharePriceAssertion.sol
@@ -16,12 +16,13 @@ import {IFTokenLike} from "./FluidInterfaces.sol";
 ///      flat on principal flows and rises with yield. Any decrease therefore signals a loss,
 ///      mispriced mint/redeem, or accounting bug — exactly what an ERC-4626 holder needs protected.
 ///
-///      Checked at transaction end as `postAssets/postSupply >= preAssets/preSupply` using the
-///      `ratioGe` precompile (no division), with zero tolerance. Empty-vault snapshots are skipped
-///      because share price is undefined with no shares.
+///      Checked at transaction end by sampling `convertToAssets(1e12)`, which is Fluid's underlying
+///      token exchange price scale. This avoids `totalAssets()` floor-rounding differences caused by
+///      supply changes while still checking the holder-facing share price. Empty-vault snapshots are
+///      skipped because share price is undefined with no shares.
 contract FluidFTokenSharePriceAssertion is Assertion {
     /// @notice Strictly non-decreasing: share price may rise (yield) but never fall.
-    uint256 internal constant SHARE_PRICE_TOLERANCE_BPS = 0;
+    uint256 internal constant PRICE_SAMPLE_SHARES = 1e12;
 
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
@@ -32,10 +33,11 @@ contract FluidFTokenSharePriceAssertion is Assertion {
         registerTxEndTrigger(this.assertSharePriceNonDecreasing.selector);
     }
 
-    /// @notice fToken share price (totalAssets / totalSupply) does not decrease over the transaction.
-    /// @dev Reads the fToken's `totalAssets()` and `totalSupply()` at PreTx and PostTx. A failure
-    ///      means the transaction reduced the value backing each share — a yield-only vault must
-    ///      never do this. Snapshots with zero supply are skipped (share price undefined).
+    /// @notice fToken share price sampled with a fixed share amount does not decrease.
+    /// @dev Reads the fToken's `totalSupply()` and `convertToAssets(1e12)` at PreTx and PostTx. A
+    ///      failure means the transaction reduced the value backing a fixed share quantity — a
+    ///      yield-only vault must never do this. Snapshots with zero supply are skipped (share price
+    ///      undefined).
     function assertSharePriceNonDecreasing() external view {
         address fToken = ph.getAssertionAdopter();
 
@@ -43,12 +45,11 @@ contract FluidFTokenSharePriceAssertion is Assertion {
         uint256 postSupply = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalSupply, ()), _postTx());
         if (preSupply == 0 || postSupply == 0) return;
 
-        uint256 preAssets = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalAssets, ()), _preTx());
-        uint256 postAssets = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalAssets, ()), _postTx());
+        uint256 preAssets =
+            _readUintAt(fToken, abi.encodeCall(IFTokenLike.convertToAssets, (PRICE_SAMPLE_SHARES)), _preTx());
+        uint256 postAssets =
+            _readUintAt(fToken, abi.encodeCall(IFTokenLike.convertToAssets, (PRICE_SAMPLE_SHARES)), _postTx());
 
-        require(
-            ph.ratioGe(postAssets, postSupply, preAssets, preSupply, SHARE_PRICE_TOLERANCE_BPS),
-            "Fluid: fToken share price decreased"
-        );
+        require(postAssets >= preAssets, "Fluid: fToken share price decreased");
     }
 }

--- a/examples/fluid/src/FluidFTokenSharePriceAssertion.sol
+++ b/examples/fluid/src/FluidFTokenSharePriceAssertion.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {IFTokenLike} from "./FluidInterfaces.sol";
+
+/// @title FluidFTokenSharePriceAssertion
+/// @author Phylax Systems
+/// @notice fToken (ERC-4626 lending token) share price never decreases across a transaction.
+/// @dev Install on an fToken (fUSDC, fWETH, ...), the assertion adopter. An fToken supplies all of
+///      its underlying into the Liquidity Layer and its share price is yield-only by construction:
+///      the underlying Liquidity exchange price only accrues upward and rewards only add to it.
+///      Deposits and withdrawals scale `totalAssets` and `totalSupply` together, so the ratio is
+///      flat on principal flows and rises with yield. Any decrease therefore signals a loss,
+///      mispriced mint/redeem, or accounting bug — exactly what an ERC-4626 holder needs protected.
+///
+///      Checked at transaction end as `postAssets/postSupply >= preAssets/preSupply` using the
+///      `ratioGe` precompile (no division), with zero tolerance. Empty-vault snapshots are skipped
+///      because share price is undefined with no shares.
+contract FluidFTokenSharePriceAssertion is Assertion {
+    /// @notice Strictly non-decreasing: share price may rise (yield) but never fall.
+    uint256 internal constant SHARE_PRICE_TOLERANCE_BPS = 0;
+
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers the transaction-end share-price check.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertSharePriceNonDecreasing.selector);
+    }
+
+    /// @notice fToken share price (totalAssets / totalSupply) does not decrease over the transaction.
+    /// @dev Reads the fToken's `totalAssets()` and `totalSupply()` at PreTx and PostTx. A failure
+    ///      means the transaction reduced the value backing each share — a yield-only vault must
+    ///      never do this. Snapshots with zero supply are skipped (share price undefined).
+    function assertSharePriceNonDecreasing() external view {
+        address fToken = ph.getAssertionAdopter();
+
+        uint256 preSupply = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalSupply, ()), _preTx());
+        uint256 postSupply = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalSupply, ()), _postTx());
+        if (preSupply == 0 || postSupply == 0) return;
+
+        uint256 preAssets = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalAssets, ()), _preTx());
+        uint256 postAssets = _readUintAt(fToken, abi.encodeCall(IFTokenLike.totalAssets, ()), _postTx());
+
+        require(
+            ph.ratioGe(postAssets, postSupply, preAssets, preSupply, SHARE_PRICE_TOLERANCE_BPS),
+            "Fluid: fToken share price decreased"
+        );
+    }
+}

--- a/examples/fluid/src/FluidInterfaces.sol
+++ b/examples/fluid/src/FluidInterfaces.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title FluidInterfaces
+/// @author Phylax Systems
+/// @notice Minimal Fluid (Instadapp) surfaces needed by the example assertions.
+/// @dev Only the selectors and views the assertions actually use are declared here, to keep the
+///      assertion contracts readable and avoid depending on Fluid's full (large, nested) structs.
+
+/// @notice Liquidity Layer singleton entry point.
+/// @dev `operate` is the single mutation path for every protocol built on the Liquidity Layer.
+///      `supplyAmount_ > 0` supplies, `< 0` withdraws; `borrowAmount_ > 0` borrows, `< 0` repays.
+///      The assertions only need the selector and the calldata layout, never call it.
+interface IFluidLiquidityLike {
+    function operate(
+        address token_,
+        int256 supplyAmount_,
+        int256 borrowAmount_,
+        address withdrawTo_,
+        address borrowTo_,
+        bytes calldata callbackData_
+    ) external payable returns (uint256 supplyExchangePrice_, uint256 borrowExchangePrice_);
+}
+
+/// @notice Subset of the FluidVaultResolver used to read a vault's packed risk config.
+/// @dev `getVaultVariables2Raw` returns the raw `vaultVariables2` storage word, which packs the
+///      vault's collateral factor, liquidation threshold, liquidation max limit and penalty.
+///      Reading through the maintained resolver getter avoids hardcoding the vault storage slot.
+interface IFluidVaultResolverLike {
+    function getVaultVariables2Raw(address vault_) external view returns (uint256 vaultVariables2_);
+}
+
+/// @notice Standard ERC-4626 surface exposed by Fluid fTokens (fUSDC, fWETH, ...).
+/// @dev fTokens supply their underlying into the Liquidity Layer; share price is yield-only.
+interface IFTokenLike {
+    function asset() external view returns (address);
+    function totalAssets() external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+    function convertToAssets(uint256 shares_) external view returns (uint256);
+
+    function deposit(uint256 assets_, address receiver_) external returns (uint256 shares_);
+    function mint(uint256 shares_, address receiver_) external returns (uint256 assets_);
+    function withdraw(uint256 assets_, address receiver_, address owner_) external returns (uint256 shares_);
+    function redeem(uint256 shares_, address receiver_, address owner_) external returns (uint256 assets_);
+}

--- a/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
+++ b/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
@@ -106,7 +106,12 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
     }
 
     function _successfulOperateCalls() internal pure returns (PhEvm.CallFilter memory filter) {
-        filter.callType = 1; // CALL only: ignore failed probes, staticcalls and delegatecalls.
-        filter.successOnly = true;
+        // Start from the shared "successful, any depth" filter (minDepth 0, maxDepth uint32 max) so
+        // `operate` calls routed through a router/proxy (depth > 1) are still scanned, then narrow to
+        // CALL only — ignore failed probes, staticcalls and delegatecalls. Hand-setting only callType
+        // and successOnly would leave maxDepth at its zero default and make coverage depend on
+        // precompile defaults (a depth-0-only read would miss every real, nested `operate`).
+        filter = _successOnlyFilter();
+        filter.callType = 1;
     }
 }

--- a/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
+++ b/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {FluidLiquidityBase} from "./FluidLiquidityHelpers.sol";
+import {IFluidLiquidityLike} from "./FluidInterfaces.sol";
+
+/// @title FluidLiquidityFlowBreakerAssertion
+/// @author Phylax Systems
+/// @notice Rolling-window outflow circuit breaker for the Fluid Liquidity Layer singleton.
+/// @dev Fluid's on-chain per-protocol withdraw/borrow limits auto-expand over time and are kept
+///      generous for capital efficiency. This assertion lets those on-chain limits stay loose while
+///      bounding the *aggregate* token bleed in a rolling window, so a single exploit cannot drain a
+///      market by chaining many individually-valid `operate` calls. The policy is tiered per token:
+///      - Warning tier (10% net outflow / 24h): block new borrows; suppliers may still withdraw and
+///        borrowers may still repay, so honest exit and de-risking stay open.
+///      - Critical tier (20% net outflow / 24h): hard-pause the singleton.
+///      Outflow accounting (TVL snapshot, window bucketing) is handled by the built-in breaker.
+contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
+    uint256 public constant WARN_OUTFLOW_BPS = 1_000; // 10%
+    uint256 public constant CRITICAL_OUTFLOW_BPS = 2_000; // 20%
+    uint256 public constant OUTFLOW_WINDOW = 24 hours;
+
+    /// @notice `operate`'s `token_` is calldata arg 0 and `borrowAmount_` is calldata arg 2.
+    uint256 internal constant OPERATE_TOKEN_ARG = 0;
+    uint256 internal constant OPERATE_BORROW_ARG = 2;
+
+    /// @notice Tokens watched by the breaker.
+    address[] internal tokens;
+
+    /// @param tokens_ Monitored token addresses (the Liquidity Layer markets to rate-limit).
+    constructor(address[] memory tokens_) {
+        tokens = tokens_;
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers the warning and critical outflow watchers for each monitored token.
+    function triggers() external view override {
+        uint256 length = tokens.length;
+        for (uint256 i; i < length; ++i) {
+            address token = tokens[i];
+            watchCumulativeOutflow(
+                token, WARN_OUTFLOW_BPS, OUTFLOW_WINDOW, this.assertNoBorrowAfterLargeOutflow.selector
+            );
+            watchCumulativeOutflow(
+                token, CRITICAL_OUTFLOW_BPS, OUTFLOW_WINDOW, this.assertCriticalOutflowPause.selector
+            );
+        }
+    }
+
+    /// @notice After 10% net outflow of a token in 24h, no new borrow of that token may execute.
+    /// @dev Triggered by the warning-tier breaker. Scans every `operate` call on the singleton and
+    ///      fails if one borrows (`borrowAmount_ > 0`) the token that breached the window. Repays
+    ///      (`borrowAmount_ < 0`), supplies and withdrawals are allowed so the market can de-risk and
+    ///      suppliers can still exit. A failure means a borrow was attempted while the market was
+    ///      already bleeding past the warning threshold.
+    function assertNoBorrowAfterLargeOutflow() external view {
+        PhEvm.OutflowContext memory ctx = ph.outflowContext();
+        require(_isWatched(ctx.token), "Fluid: unwatched outflow token");
+
+        PhEvm.CallInputs[] memory calls = ph.getAllCallInputs(_liquidity(), IFluidLiquidityLike.operate.selector);
+        for (uint256 i; i < calls.length; ++i) {
+            if (_operateBorrowsToken(ph.callinputAt(calls[i].id), ctx.token)) {
+                revert("Fluid: borrow disabled after large outflow");
+            }
+        }
+    }
+
+    /// @notice Pure policy decision: does this `operate` calldata borrow `token`?
+    /// @dev A borrow is `borrowAmount_ > 0` for the breached token; repays (`< 0`), supplies, and
+    ///      operations on other tokens return false. Extracted so the policy is unit-testable without
+    ///      the live outflow trigger context (which local `pcl test` does not simulate).
+    function _operateBorrowsToken(bytes memory input, address token) internal pure returns (bool) {
+        return _addressArg(input, OPERATE_TOKEN_ARG) == token && _int256Arg(input, OPERATE_BORROW_ARG) > 0;
+    }
+
+    /// @notice After 20% net outflow of a token in 24h, hard-pause the Liquidity Layer.
+    /// @dev Triggered by the critical-tier breaker. Reverts the whole transaction; recovery requires
+    ///      the window to slide forward (outflow to subside) or governance to intervene.
+    function assertCriticalOutflowPause() external view {
+        PhEvm.OutflowContext memory ctx = ph.outflowContext();
+        require(_isWatched(ctx.token), "Fluid: unwatched outflow token");
+
+        revert("Fluid: critical liquidity outflow pause");
+    }
+
+    function _isWatched(address token) internal view returns (bool) {
+        uint256 length = tokens.length;
+        for (uint256 i; i < length; ++i) {
+            if (tokens[i] == token) return true;
+        }
+        return false;
+    }
+}

--- a/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
+++ b/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
@@ -77,10 +77,12 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
         }
     }
 
-    /// @notice Pure policy decision: does this `operate` calldata borrow `token`?
-    /// @dev A borrow is `borrowAmount_ > 0` for the breached token; repays (`< 0`), supplies, and
-    ///      operations on other tokens return false. Extracted so the policy is unit-testable without
-    ///      the live outflow trigger context (which local `pcl test` does not simulate).
+    /// @notice Pure policy decision: do these `operate` arguments borrow `token`?
+    /// @dev `input` is the selector-stripped argument tail exactly as `ph.matchingCalls(...).input`
+    ///      yields it (no 4-byte selector — see `_addressArg`/`_int256Arg`). A borrow is
+    ///      `borrowAmount_ > 0` for the breached token; repays (`< 0`), supplies, and operations on
+    ///      other tokens return false. Extracted so the policy is unit-testable without the live
+    ///      outflow trigger context (which local `pcl test` does not simulate).
     function _operateBorrowsToken(bytes memory input, address token) internal pure returns (bool) {
         return _addressArg(input, OPERATE_TOKEN_ARG) == token && _int256Arg(input, OPERATE_BORROW_ARG) > 0;
     }

--- a/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
+++ b/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
@@ -22,6 +22,7 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
     uint256 public constant WARN_OUTFLOW_BPS = 1_000; // 10%
     uint256 public constant CRITICAL_OUTFLOW_BPS = 2_000; // 20%
     uint256 public constant OUTFLOW_WINDOW = 24 hours;
+    uint256 internal constant MAX_SUCCESSFUL_OPERATE_CALLS = 256;
 
     /// @notice `operate`'s `token_` is calldata arg 0 and `borrowAmount_` is calldata arg 2.
     uint256 internal constant OPERATE_TOKEN_ARG = 0;
@@ -32,6 +33,12 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
 
     /// @param tokens_ Monitored token addresses (the Liquidity Layer markets to rate-limit).
     constructor(address[] memory tokens_) {
+        uint256 length = tokens_.length;
+        for (uint256 i; i < length; ++i) {
+            require(tokens_[i] != NATIVE_TOKEN, "Fluid: native token breaker unsupported");
+            require(!_hasFluidExternalCustody(tokens_[i]), "Fluid: external custody breaker unsupported");
+        }
+
         tokens = tokens_;
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
@@ -51,18 +58,20 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
     }
 
     /// @notice After 10% net outflow of a token in 24h, no new borrow of that token may execute.
-    /// @dev Triggered by the warning-tier breaker. Scans every `operate` call on the singleton and
-    ///      fails if one borrows (`borrowAmount_ > 0`) the token that breached the window. Repays
-    ///      (`borrowAmount_ < 0`), supplies and withdrawals are allowed so the market can de-risk and
-    ///      suppliers can still exit. A failure means a borrow was attempted while the market was
-    ///      already bleeding past the warning threshold.
+    /// @dev Triggered by the warning-tier breaker. Scans successful CALLs to `operate` on the
+    ///      singleton and fails if one borrows (`borrowAmount_ > 0`) the token that breached the
+    ///      window. Repays (`borrowAmount_ < 0`), supplies and withdrawals are allowed so the market
+    ///      can de-risk and suppliers can still exit. A failure means a borrow executed while the
+    ///      market was already bleeding past the warning threshold.
     function assertNoBorrowAfterLargeOutflow() external view {
         PhEvm.OutflowContext memory ctx = ph.outflowContext();
         require(_isWatched(ctx.token), "Fluid: unwatched outflow token");
 
-        PhEvm.CallInputs[] memory calls = ph.getAllCallInputs(_liquidity(), IFluidLiquidityLike.operate.selector);
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(
+            _liquidity(), IFluidLiquidityLike.operate.selector, _successfulOperateCalls(), MAX_SUCCESSFUL_OPERATE_CALLS
+        );
         for (uint256 i; i < calls.length; ++i) {
-            if (_operateBorrowsToken(ph.callinputAt(calls[i].id), ctx.token)) {
+            if (_operateBorrowsToken(calls[i].input, ctx.token)) {
                 revert("Fluid: borrow disabled after large outflow");
             }
         }
@@ -92,5 +101,10 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
             if (tokens[i] == token) return true;
         }
         return false;
+    }
+
+    function _successfulOperateCalls() internal pure returns (PhEvm.CallFilter memory filter) {
+        filter.callType = 1; // CALL only: ignore failed probes, staticcalls and delegatecalls.
+        filter.successOnly = true;
     }
 }

--- a/examples/fluid/src/FluidLiquidityHelpers.sol
+++ b/examples/fluid/src/FluidLiquidityHelpers.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.13;
 import {Assertion} from "credible-std/Assertion.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
+interface IZircuitPoolLike {
+    function balance(address token_, address staker_) external view returns (uint256);
+}
+
 /// @title FluidLiquidityBase
 /// @author Phylax Systems
 /// @notice Shared reads for assertions installed on the Fluid Liquidity Layer singleton.
@@ -21,6 +25,11 @@ import {PhEvm} from "credible-std/PhEvm.sol";
 abstract contract FluidLiquidityBase is Assertion {
     /// @notice Native token sentinel; balances of this "token" cannot be read via ERC20 balanceOf.
     address internal constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @notice Mainnet Liquid staking tokens Fluid explicitly counts as external Liquidity custody.
+    address internal constant WEETH = 0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee;
+    address internal constant WEETHS = 0x917ceE801a67f933F2e6b33fC0cD1ED2d5909D88;
+    address internal constant ZIRCUIT = 0xF047ab4c75cebf0eB9ed34Ae2c186f3611aEAfa6;
 
     /// @notice Fluid stores supply/borrow exchange prices scaled by 1e12.
     uint256 internal constant EXCHANGE_PRICES_PRECISION = 1e12;
@@ -91,6 +100,30 @@ abstract contract FluidLiquidityBase is Assertion {
 
     function _readSlot(bytes32 slot, PhEvm.ForkId memory fork) internal view returns (uint256) {
         return uint256(ph.loadStateAt(_liquidity(), slot, fork));
+    }
+
+    /// @notice Reads Fluid-recognized custody for `token`, including mainnet external balances.
+    function _liquidityCustodyBalance(address token, address liquidity, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256 balance)
+    {
+        balance = _readBalanceAt(token, liquidity, fork);
+        balance += _liquidityExternalBalance(token, liquidity, fork);
+    }
+
+    /// @notice Mainnet weETH/weETHs can sit in Zircuit while still backing Liquidity accounting.
+    function _liquidityExternalBalance(address token, address liquidity, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256)
+    {
+        if (block.chainid != 1 || !_hasFluidExternalCustody(token)) return 0;
+        return _readUintAt(ZIRCUIT, abi.encodeCall(IZircuitPoolLike.balance, (token, liquidity)), fork);
+    }
+
+    function _hasFluidExternalCustody(address token) internal pure returns (bool) {
+        return token == WEETH || token == WEETHS;
     }
 
     /// @notice Decodes a 64-bit Fluid BigMath field: value = coefficient << exponent.

--- a/examples/fluid/src/FluidLiquidityHelpers.sol
+++ b/examples/fluid/src/FluidLiquidityHelpers.sol
@@ -90,12 +90,25 @@ abstract contract FluidLiquidityBase is Assertion {
         borrowExchangePrice = (epac >> BITS_BORROW_EXCHANGE_PRICE) & MASK_64;
     }
 
-    function _exchangePricesSlot(address token) internal pure returns (bytes32) {
-        return keccak256(abi.encode(token, SLOT_EXCHANGE_PRICES_AND_CONFIG));
+    /// @dev `mapping(address => ...)` slot is `keccak256(abi.encode(key, baseSlot))`. Both operands
+    ///      are fixed 32-byte words, so we hash them straight from the EVM scratch space (0x00-0x40)
+    ///      instead of allocating an `abi.encode` buffer — identical result, no memory growth, and it
+    ///      clears the `asm-keccak256` lint. `mstore(0x00, token)` left-pads the address exactly as
+    ///      `abi.encode` would.
+    function _exchangePricesSlot(address token) internal pure returns (bytes32 slot) {
+        assembly {
+            mstore(0x00, token)
+            mstore(0x20, SLOT_EXCHANGE_PRICES_AND_CONFIG)
+            slot := keccak256(0x00, 0x40)
+        }
     }
 
-    function _totalAmountsSlot(address token) internal pure returns (bytes32) {
-        return keccak256(abi.encode(token, SLOT_TOTAL_AMOUNTS));
+    function _totalAmountsSlot(address token) internal pure returns (bytes32 slot) {
+        assembly {
+            mstore(0x00, token)
+            mstore(0x20, SLOT_TOTAL_AMOUNTS)
+            slot := keccak256(0x00, 0x40)
+        }
     }
 
     function _readSlot(bytes32 slot, PhEvm.ForkId memory fork) internal view returns (uint256) {
@@ -133,19 +146,24 @@ abstract contract FluidLiquidityBase is Assertion {
         return coefficient << exponent;
     }
 
-    /// @notice Reads the ABI word for `argIndex` of a call's calldata as an `int256`.
-    /// @dev `input` comes from `ph.callinputAt`, which preserves the 4-byte selector.
+    /// @notice Reads the ABI word for `argIndex` of a call's arguments as an `int256`.
+    /// @dev `input` is the selector-stripped argument tail as returned by `ph.matchingCalls(...).input`
+    ///      (and the `ph.get*CallInputs` family): the 4-byte selector is the query key and is NOT
+    ///      present, so arg `argIndex` sits at byte offset `argIndex * 32`. Do not add a 4-byte
+    ///      selector offset here. If a caller ever sources selector-prefixed calldata (e.g.
+    ///      `ph.callinputAt`), it must strip the leading selector before calling this.
     function _int256Arg(bytes memory input, uint256 argIndex) internal pure returns (int256 value) {
-        uint256 offset = 4 + argIndex * 32;
+        uint256 offset = argIndex * 32;
         require(input.length >= offset + 32, "Fluid: malformed calldata");
         assembly {
             value := mload(add(add(input, 0x20), offset))
         }
     }
 
-    /// @notice Reads the ABI word for `argIndex` of a call's calldata as an `address`.
+    /// @notice Reads the ABI word for `argIndex` of a call's arguments as an `address`.
+    /// @dev Same selector-stripped `input` contract as `_int256Arg`.
     function _addressArg(bytes memory input, uint256 argIndex) internal pure returns (address account) {
-        uint256 offset = 4 + argIndex * 32;
+        uint256 offset = argIndex * 32;
         require(input.length >= offset + 32, "Fluid: malformed calldata");
         assembly {
             account := and(mload(add(add(input, 0x20), offset)), 0xffffffffffffffffffffffffffffffffffffffff)

--- a/examples/fluid/src/FluidLiquidityHelpers.sol
+++ b/examples/fluid/src/FluidLiquidityHelpers.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+/// @title FluidLiquidityBase
+/// @author Phylax Systems
+/// @notice Shared reads for assertions installed on the Fluid Liquidity Layer singleton.
+/// @dev The Liquidity Layer is one upgradeable proxy that custodies every token for every Fluid
+///      protocol. These helpers decode its packed per-token accounting directly from storage so an
+///      assertion never has to trust a resolver or re-implement interest accrual:
+///      - `_exchangePricesAndConfig[token]` lives at mapping base slot 5 and packs the supply/borrow
+///        exchange prices (plain 64-bit values scaled by 1e12).
+///      - `_totalAmounts[token]` lives at mapping base slot 7 and packs four BigMath (56|8) fields:
+///        supply-with-interest (raw), supply-interest-free, borrow-with-interest (raw),
+///        borrow-interest-free.
+///      Token amounts with interest are `raw * exchangePrice / 1e12 + interestFree`.
+///      Slot numbers and bit offsets are from Fluid's `liquiditySlotsLink.sol`; BigMath decode is
+///      from `bigMathMinified.sol` (coefficient = field >> 8, exponent = field & 0xFF).
+abstract contract FluidLiquidityBase is Assertion {
+    /// @notice Native token sentinel; balances of this "token" cannot be read via ERC20 balanceOf.
+    address internal constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @notice Fluid stores supply/borrow exchange prices scaled by 1e12.
+    uint256 internal constant EXCHANGE_PRICES_PRECISION = 1e12;
+
+    /// @notice Mapping base slots in the Liquidity Layer storage layout.
+    uint256 internal constant SLOT_EXCHANGE_PRICES_AND_CONFIG = 5;
+    uint256 internal constant SLOT_TOTAL_AMOUNTS = 7;
+
+    /// @notice Bit offsets inside the `_exchangePricesAndConfig[token]` word.
+    uint256 internal constant BITS_SUPPLY_EXCHANGE_PRICE = 91;
+    uint256 internal constant BITS_BORROW_EXCHANGE_PRICE = 155;
+
+    /// @notice Bit offsets inside the `_totalAmounts[token]` word.
+    uint256 internal constant BITS_SUPPLY_WITH_INTEREST = 0;
+    uint256 internal constant BITS_SUPPLY_INTEREST_FREE = 64;
+    uint256 internal constant BITS_BORROW_WITH_INTEREST = 128;
+    uint256 internal constant BITS_BORROW_INTEREST_FREE = 192;
+
+    uint256 internal constant MASK_64 = 0xFFFFFFFFFFFFFFFF;
+    uint256 internal constant BIGMATH_EXPONENT_MASK = 0xFF;
+
+    /// @notice The monitored Liquidity Layer is always the assertion adopter.
+    function _liquidity() internal view returns (address) {
+        return ph.getAssertionAdopter();
+    }
+
+    /// @notice Token-with-interest totals for `token` at a snapshot, using the Liquidity Layer's
+    ///         stored exchange prices (a self-consistent snapshot against the held balance).
+    /// @return totalSupply Total amount owed to suppliers (token units).
+    /// @return totalBorrow Total amount owed by borrowers (token units).
+    function _liquidityTotals(address token, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256 totalSupply, uint256 totalBorrow)
+    {
+        uint256 epac = _readSlot(_exchangePricesSlot(token), fork);
+        uint256 supplyExchangePrice = (epac >> BITS_SUPPLY_EXCHANGE_PRICE) & MASK_64;
+        uint256 borrowExchangePrice = (epac >> BITS_BORROW_EXCHANGE_PRICE) & MASK_64;
+
+        uint256 amounts = _readSlot(_totalAmountsSlot(token), fork);
+        uint256 supplyRaw = _decodeBigMath((amounts >> BITS_SUPPLY_WITH_INTEREST) & MASK_64);
+        uint256 supplyInterestFree = _decodeBigMath((amounts >> BITS_SUPPLY_INTEREST_FREE) & MASK_64);
+        uint256 borrowRaw = _decodeBigMath((amounts >> BITS_BORROW_WITH_INTEREST) & MASK_64);
+        uint256 borrowInterestFree = _decodeBigMath((amounts >> BITS_BORROW_INTEREST_FREE) & MASK_64);
+
+        totalSupply = supplyInterestFree + (supplyRaw * supplyExchangePrice) / EXCHANGE_PRICES_PRECISION;
+        totalBorrow = borrowInterestFree + (borrowRaw * borrowExchangePrice) / EXCHANGE_PRICES_PRECISION;
+    }
+
+    /// @notice Stored supply and borrow exchange prices for `token` at a snapshot.
+    function _liquidityExchangePrices(address token, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256 supplyExchangePrice, uint256 borrowExchangePrice)
+    {
+        uint256 epac = _readSlot(_exchangePricesSlot(token), fork);
+        supplyExchangePrice = (epac >> BITS_SUPPLY_EXCHANGE_PRICE) & MASK_64;
+        borrowExchangePrice = (epac >> BITS_BORROW_EXCHANGE_PRICE) & MASK_64;
+    }
+
+    function _exchangePricesSlot(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(token, SLOT_EXCHANGE_PRICES_AND_CONFIG));
+    }
+
+    function _totalAmountsSlot(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(token, SLOT_TOTAL_AMOUNTS));
+    }
+
+    function _readSlot(bytes32 slot, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        return uint256(ph.loadStateAt(_liquidity(), slot, fork));
+    }
+
+    /// @notice Decodes a 64-bit Fluid BigMath field: value = coefficient << exponent.
+    function _decodeBigMath(uint256 field) internal pure returns (uint256) {
+        uint256 coefficient = field >> 8;
+        uint256 exponent = field & BIGMATH_EXPONENT_MASK;
+        return coefficient << exponent;
+    }
+
+    /// @notice Reads the ABI word for `argIndex` of a call's calldata as an `int256`.
+    /// @dev `input` comes from `ph.callinputAt`, which preserves the 4-byte selector.
+    function _int256Arg(bytes memory input, uint256 argIndex) internal pure returns (int256 value) {
+        uint256 offset = 4 + argIndex * 32;
+        require(input.length >= offset + 32, "Fluid: malformed calldata");
+        assembly {
+            value := mload(add(add(input, 0x20), offset))
+        }
+    }
+
+    /// @notice Reads the ABI word for `argIndex` of a call's calldata as an `address`.
+    function _addressArg(bytes memory input, uint256 argIndex) internal pure returns (address account) {
+        uint256 offset = 4 + argIndex * 32;
+        require(input.length >= offset + 32, "Fluid: malformed calldata");
+        assembly {
+            account := and(mload(add(add(input, 0x20), offset)), 0xffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+}

--- a/examples/fluid/src/FluidLiquiditySolvencyAssertion.sol
+++ b/examples/fluid/src/FluidLiquiditySolvencyAssertion.sol
@@ -16,7 +16,8 @@ import {FluidLiquidityBase} from "./FluidLiquidityHelpers.sol";
 ///      - Custody: the tokens actually held cover what suppliers are owed net of outstanding debt.
 ///      - Monotonicity: supply/borrow exchange prices only accrue interest, never decrease.
 ///      Native-token markets (0xEeee...EEeE) are skipped by the custody check because their balance
-///      is ETH, not an ERC20 balanceOf; the monotonicity check still applies to them.
+///      is ETH, not an ERC20 balanceOf; the monotonicity check still applies to them. Mainnet
+///      weETH/weETHs custody includes Fluid's recognized Zircuit balances.
 contract FluidLiquiditySolvencyAssertion is FluidLiquidityBase {
     /// @notice Allowed solvency shortfall, as a fraction of total supply (1 / 1e6 = 0.0001%).
     /// @dev Absorbs BigMath storage truncation and same-tx revenue-accrual rounding only; far below
@@ -54,7 +55,7 @@ contract FluidLiquiditySolvencyAssertion is FluidLiquidityBase {
             if (token == NATIVE_TOKEN) continue;
 
             (uint256 totalSupply, uint256 totalBorrow) = _liquidityTotals(token, post);
-            uint256 held = _readBalanceAt(token, liquidity, post);
+            uint256 held = _liquidityCustodyBalance(token, liquidity, post);
 
             uint256 tolerance = totalSupply / SOLVENCY_TOLERANCE_DENOM;
             require(held + totalBorrow + tolerance >= totalSupply, "Fluid: liquidity custody below net supply");

--- a/examples/fluid/src/FluidLiquiditySolvencyAssertion.sol
+++ b/examples/fluid/src/FluidLiquiditySolvencyAssertion.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {FluidLiquidityBase} from "./FluidLiquidityHelpers.sol";
+
+/// @title FluidLiquiditySolvencyAssertion
+/// @author Phylax Systems
+/// @notice Core accounting invariants for the Fluid Liquidity Layer singleton.
+/// @dev Install on the Liquidity Layer proxy (the assertion adopter). Reads the singleton's packed
+///      per-token accounting directly from storage via `FluidLiquidityBase`. Protects two
+///      properties that the protocol's per-operation `require`s do not express against external
+///      state at transaction end:
+///      - Custody: the tokens actually held cover what suppliers are owed net of outstanding debt.
+///      - Monotonicity: supply/borrow exchange prices only accrue interest, never decrease.
+///      Native-token markets (0xEeee...EEeE) are skipped by the custody check because their balance
+///      is ETH, not an ERC20 balanceOf; the monotonicity check still applies to them.
+contract FluidLiquiditySolvencyAssertion is FluidLiquidityBase {
+    /// @notice Allowed solvency shortfall, as a fraction of total supply (1 / 1e6 = 0.0001%).
+    /// @dev Absorbs BigMath storage truncation and same-tx revenue-accrual rounding only; far below
+    ///      any meaningful drain.
+    uint256 internal constant SOLVENCY_TOLERANCE_DENOM = 1e6;
+
+    /// @notice Tokens whose Liquidity Layer accounting this assertion protects.
+    address[] internal tokens;
+
+    /// @param tokens_ Monitored token addresses (e.g. USDC, USDT, WETH, wstETH, GHO).
+    constructor(address[] memory tokens_) {
+        tokens = tokens_;
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers both Liquidity Layer envelope checks at transaction end.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertCustodyCoversNetSupply.selector);
+        registerTxEndTrigger(this.assertExchangePricesMonotonic.selector);
+    }
+
+    /// @notice The Liquidity Layer holds enough of each token to cover supplier claims net of debt.
+    /// @dev Property: `balanceOf(Liquidity, token) + totalBorrow >= totalSupply` for every monitored
+    ///      token, i.e. accrued protocol revenue stays non-negative. A failure means a transaction
+    ///      left the singleton unable to back its suppliers from custody plus recoverable debt —
+    ///      the protocol-wide insolvency condition. Checked at transaction end so it holds after all
+    ///      borrows, withdrawals, repayments and revenue movements in the transaction.
+    function assertCustodyCoversNetSupply() external view {
+        PhEvm.ForkId memory post = _postTx();
+        address liquidity = _liquidity();
+
+        uint256 length = tokens.length;
+        for (uint256 i; i < length; ++i) {
+            address token = tokens[i];
+            if (token == NATIVE_TOKEN) continue;
+
+            (uint256 totalSupply, uint256 totalBorrow) = _liquidityTotals(token, post);
+            uint256 held = _readBalanceAt(token, liquidity, post);
+
+            uint256 tolerance = totalSupply / SOLVENCY_TOLERANCE_DENOM;
+            require(held + totalBorrow + tolerance >= totalSupply, "Fluid: liquidity custody below net supply");
+        }
+    }
+
+    /// @notice Supply and borrow exchange prices never decrease across a transaction.
+    /// @dev Fluid exchange prices only ever accrue interest (`+=`), so a decrease from PreTx to
+    ///      PostTx signals corrupted accounting or a malicious write to the packed config slot —
+    ///      which would let withdrawals exceed entitlement or under-charge borrowers. Equality is
+    ///      the normal case (prices are already accrued to the current block at both snapshots).
+    function assertExchangePricesMonotonic() external view {
+        PhEvm.ForkId memory pre = _preTx();
+        PhEvm.ForkId memory post = _postTx();
+
+        uint256 length = tokens.length;
+        for (uint256 i; i < length; ++i) {
+            address token = tokens[i];
+
+            (uint256 preSupply, uint256 preBorrow) = _liquidityExchangePrices(token, pre);
+            (uint256 postSupply, uint256 postBorrow) = _liquidityExchangePrices(token, post);
+
+            require(postSupply >= preSupply, "Fluid: supply exchange price decreased");
+            require(postBorrow >= preBorrow, "Fluid: borrow exchange price decreased");
+        }
+    }
+}

--- a/examples/fluid/src/FluidVaultRiskConfigAssertion.sol
+++ b/examples/fluid/src/FluidVaultRiskConfigAssertion.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {IFluidVaultResolverLike} from "./FluidInterfaces.sol";
+
+/// @title FluidVaultRiskConfigAssertion
+/// @author Phylax Systems
+/// @notice Keeps a Fluid Vault's risk parameters in a liquidatable ordering after any transaction.
+/// @dev Install on a Fluid Vault (the assertion adopter). The vault's admin module enforces
+///      `collateralFactor < liquidationThreshold < liquidationMaxLimit` and
+///      `liquidationMaxLimit + liquidationPenalty <= 99.7%` only inside its setters. This assertion
+///      re-checks the same ordering on the *stored* config after the transaction, regardless of how
+///      it was written (setter, faulty upgrade, storage-collision, delegatecall exploit). That makes
+///      it safe for governance to tune aggressive parameters for riskier collateral: the protocol
+///      can push CF/LT high, and this assertion guarantees the invariant that keeps every position
+///      liquidatable still holds in the actual stored state.
+///
+///      Config is read from the maintained `FluidVaultResolver.getVaultVariables2Raw(vault)` getter
+///      and decoded from the `vaultVariables2` word. Field bit offsets and scales are from Fluid's
+///      vault admin module: collateralFactor/liquidationThreshold/liquidationMaxLimit are stored as
+///      `input / 10` (so 100% = 1000), liquidationPenalty is stored as-is in 1e2 (so 100% = 10000).
+contract FluidVaultRiskConfigAssertion is Assertion {
+    uint256 internal constant CONFIG_MASK = 0x3FF; // X10: 10-bit fields
+
+    uint256 internal constant BITS_COLLATERAL_FACTOR = 32;
+    uint256 internal constant BITS_LIQUIDATION_THRESHOLD = 42;
+    uint256 internal constant BITS_LIQUIDATION_MAX_LIMIT = 52;
+    uint256 internal constant BITS_LIQUIDATION_PENALTY = 72;
+
+    /// @notice 100% for the CF/LT/LML fields in their stored (`input / 10`) scale.
+    uint256 internal constant STORED_HUNDRED_PERCENT = 1_000;
+
+    /// @notice Protocol cap on `liquidationMaxLimit + liquidationPenalty`, in 1e2 scale (99.7%).
+    uint256 internal constant MAX_LML_PLUS_PENALTY_1E2 = 9_970;
+
+    /// @notice FluidVaultResolver used to read the vault's packed config word.
+    address internal immutable VAULT_RESOLVER;
+
+    /// @param vaultResolver_ Address of the deployed FluidVaultResolver.
+    constructor(address vaultResolver_) {
+        VAULT_RESOLVER = vaultResolver_;
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Re-checks the vault risk-config ordering at transaction end.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertRiskConfigOrdering.selector);
+    }
+
+    /// @notice The vault's stored risk parameters keep positions liquidatable.
+    /// @dev Property after the transaction:
+    ///      - `collateralFactor < liquidationThreshold` (borrowers cannot open at the liquidation line),
+    ///      - `liquidationThreshold < liquidationMaxLimit` (a band exists for partial liquidation),
+    ///      - `liquidationMaxLimit <= 100%`,
+    ///      - `liquidationMaxLimit + liquidationPenalty <= 99.7%` (liquidators keep an incentive and
+    ///        seized collateral cannot exceed available value).
+    ///      A failure means the stored config was left in a state where positions could become
+    ///      unliquidatable or liquidations could over-seize — even if no setter `require` was hit.
+    function assertRiskConfigOrdering() external view {
+        uint256 vaultVariables2 = _readUintAt(
+            VAULT_RESOLVER,
+            abi.encodeCall(IFluidVaultResolverLike.getVaultVariables2Raw, (ph.getAssertionAdopter())),
+            _postTx()
+        );
+
+        uint256 collateralFactor = (vaultVariables2 >> BITS_COLLATERAL_FACTOR) & CONFIG_MASK;
+        uint256 liquidationThreshold = (vaultVariables2 >> BITS_LIQUIDATION_THRESHOLD) & CONFIG_MASK;
+        uint256 liquidationMaxLimit = (vaultVariables2 >> BITS_LIQUIDATION_MAX_LIMIT) & CONFIG_MASK;
+        uint256 liquidationPenalty = (vaultVariables2 >> BITS_LIQUIDATION_PENALTY) & CONFIG_MASK;
+
+        require(collateralFactor < liquidationThreshold, "Fluid: collateral factor >= liquidation threshold");
+        require(liquidationThreshold < liquidationMaxLimit, "Fluid: liquidation threshold >= max limit");
+        require(liquidationMaxLimit <= STORED_HUNDRED_PERCENT, "Fluid: liquidation max limit above 100%");
+
+        // CF/LT/LML are stored as input/10; scale LML back to 1e2 to compare against the penalty.
+        require(
+            liquidationMaxLimit * 10 + liquidationPenalty <= MAX_LML_PLUS_PENALTY_1E2,
+            "Fluid: liquidation max limit + penalty above 99.7%"
+        );
+    }
+}

--- a/examples/fluid/test/FluidFTokenSharePriceAssertion.t.sol
+++ b/examples/fluid/test/FluidFTokenSharePriceAssertion.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {FluidFTokenSharePriceAssertion} from "../src/FluidFTokenSharePriceAssertion.sol";
+
+/// @notice Mock fToken exposing ERC-4626 `totalAssets`/`totalSupply` getters.
+contract MockFToken {
+    uint256 public totalAssets;
+    uint256 public totalSupply;
+
+    function setState(uint256 assets_, uint256 supply_) public {
+        totalAssets = assets_;
+        totalSupply = supply_;
+    }
+
+    /// @notice Monitored mutation standing in for a deposit/withdraw/yield update.
+    function operate(uint256 assets_, uint256 supply_) external {
+        setState(assets_, supply_);
+    }
+}
+
+contract FluidFTokenSharePriceAssertionTest is Test, CredibleTest {
+    MockFToken internal fToken;
+
+    function setUp() public {
+        fToken = new MockFToken();
+        // Start at share price 1.0 with a non-trivial supply.
+        fToken.setState(1_000e18, 1_000e18);
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(type(FluidFTokenSharePriceAssertion).creationCode);
+        cl.assertion(address(fToken), createData, FluidFTokenSharePriceAssertion.assertSharePriceNonDecreasing.selector);
+    }
+
+    function testYieldAccrualPasses() public {
+        _arm();
+        // Assets grow faster than supply: share price rises (yield).
+        fToken.operate(1_100e18, 1_050e18);
+    }
+
+    function testProportionalDepositPasses() public {
+        _arm();
+        // Principal flow scales both sides: share price flat.
+        fToken.operate(2_000e18, 2_000e18);
+    }
+
+    function testSharePriceDropTrips() public {
+        _arm();
+        // Assets fall while supply holds: each share is worth less.
+        vm.expectRevert(bytes("Fluid: fToken share price decreased"));
+        fToken.operate(900e18, 1_000e18);
+    }
+}

--- a/examples/fluid/test/FluidFTokenSharePriceAssertion.t.sol
+++ b/examples/fluid/test/FluidFTokenSharePriceAssertion.t.sol
@@ -8,17 +8,25 @@ import {FluidFTokenSharePriceAssertion} from "../src/FluidFTokenSharePriceAssert
 
 /// @notice Mock fToken exposing ERC-4626 `totalAssets`/`totalSupply` getters.
 contract MockFToken {
+    uint256 internal constant EXCHANGE_PRICES_PRECISION = 1e12;
+
+    uint256 public exchangePrice;
     uint256 public totalAssets;
     uint256 public totalSupply;
 
-    function setState(uint256 assets_, uint256 supply_) public {
-        totalAssets = assets_;
+    function setState(uint256 exchangePrice_, uint256 supply_) public {
+        exchangePrice = exchangePrice_;
         totalSupply = supply_;
+        totalAssets = (exchangePrice_ * supply_) / EXCHANGE_PRICES_PRECISION;
     }
 
     /// @notice Monitored mutation standing in for a deposit/withdraw/yield update.
-    function operate(uint256 assets_, uint256 supply_) external {
-        setState(assets_, supply_);
+    function operate(uint256 exchangePrice_, uint256 supply_) external {
+        setState(exchangePrice_, supply_);
+    }
+
+    function convertToAssets(uint256 shares_) external view returns (uint256) {
+        return (shares_ * exchangePrice) / EXCHANGE_PRICES_PRECISION;
     }
 }
 
@@ -28,7 +36,7 @@ contract FluidFTokenSharePriceAssertionTest is Test, CredibleTest {
     function setUp() public {
         fToken = new MockFToken();
         // Start at share price 1.0 with a non-trivial supply.
-        fToken.setState(1_000e18, 1_000e18);
+        fToken.setState(1e12, 1_000e18);
     }
 
     function _arm() internal {
@@ -38,20 +46,28 @@ contract FluidFTokenSharePriceAssertionTest is Test, CredibleTest {
 
     function testYieldAccrualPasses() public {
         _arm();
-        // Assets grow faster than supply: share price rises (yield).
-        fToken.operate(1_100e18, 1_050e18);
+        // Exchange price rises with yield.
+        fToken.operate(1_100_000_000_000, 1_050e18);
     }
 
     function testProportionalDepositPasses() public {
         _arm();
-        // Principal flow scales both sides: share price flat.
-        fToken.operate(2_000e18, 2_000e18);
+        // Principal flow changes supply while share price stays flat.
+        fToken.operate(1e12, 2_000e18);
+    }
+
+    function testSupplyChangeRoundingPassesAtFlatExchangePrice() public {
+        fToken.setState(1_000_000_000_001, 999e18);
+
+        _arm();
+        // Fixed-share sampling is independent of totalAssets floor rounding from a supply change.
+        fToken.operate(1_000_000_000_001, 2_001e18);
     }
 
     function testSharePriceDropTrips() public {
         _arm();
-        // Assets fall while supply holds: each share is worth less.
+        // Exchange price falls: each share is worth less.
         vm.expectRevert(bytes("Fluid: fToken share price decreased"));
-        fToken.operate(900e18, 1_000e18);
+        fToken.operate(900_000_000_000, 1_000e18);
     }
 }

--- a/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {FluidLiquidityFlowBreakerAssertion} from "../src/FluidLiquidityFlowBreakerAssertion.sol";
+import {IFluidLiquidityLike} from "../src/FluidInterfaces.sol";
+
+/// @notice Exposes the breaker's pure borrow-detection policy so it can be exercised directly.
+/// @dev The `watchCumulativeOutflow` trigger that fires the live assertion is driven by the
+///      executor's rolling-window accounting and is not simulated by local `pcl test`, so the
+///      warning-tier policy is validated through `operateBorrowsToken` rather than an armed
+///      `cl.assertion` call (mirroring the Lighter circuit-breaker example).
+contract BreakerHarness is FluidLiquidityFlowBreakerAssertion {
+    constructor(address[] memory tokens_) FluidLiquidityFlowBreakerAssertion(tokens_) {}
+
+    function operateBorrowsToken(bytes memory input, address token) external pure returns (bool) {
+        return _operateBorrowsToken(input, token);
+    }
+}
+
+contract FluidLiquidityFlowBreakerAssertionTest is Test {
+    address internal constant TOKEN = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // USDC
+    address internal constant OTHER = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // USDT
+
+    BreakerHarness internal breaker;
+
+    function setUp() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = TOKEN;
+        breaker = new BreakerHarness(tokens);
+    }
+
+    function _operateCalldata(address token, int256 supplyAmount, int256 borrowAmount)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IFluidLiquidityLike.operate.selector, token, supplyAmount, borrowAmount, address(0), address(0), bytes("")
+        );
+    }
+
+    // --- Warning-tier policy: block new borrows of the breached token ----
+
+    function testBorrowOfBreachedTokenIsBlocked() public view {
+        assertTrue(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(0), int256(100e6)), TOKEN));
+    }
+
+    function testRepayOfBreachedTokenIsAllowed() public view {
+        assertFalse(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(0), -int256(100e6)), TOKEN));
+    }
+
+    function testSupplyOnlyIsAllowed() public view {
+        assertFalse(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(100e6), int256(0)), TOKEN));
+    }
+
+    function testBorrowOfOtherTokenIsAllowed() public view {
+        assertFalse(breaker.operateBorrowsToken(_operateCalldata(OTHER, int256(0), int256(100e6)), TOKEN));
+    }
+
+    // --- Deployment smoke -------------------------------------------------
+
+    function testDeploys() public {
+        address[] memory tokens = new address[](2);
+        tokens[0] = TOKEN;
+        tokens[1] = OTHER;
+        FluidLiquidityFlowBreakerAssertion deployed = new FluidLiquidityFlowBreakerAssertion(tokens);
+        assertEq(deployed.WARN_OUTFLOW_BPS(), 1_000);
+        assertEq(deployed.CRITICAL_OUTFLOW_BPS(), 2_000);
+    }
+}

--- a/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
+import {PhEvm} from "../../../src/PhEvm.sol";
 import {FluidLiquidityFlowBreakerAssertion} from "../src/FluidLiquidityFlowBreakerAssertion.sol";
 import {IFluidLiquidityLike} from "../src/FluidInterfaces.sol";
 
@@ -17,11 +18,18 @@ contract BreakerHarness is FluidLiquidityFlowBreakerAssertion {
     function operateBorrowsToken(bytes memory input, address token) external pure returns (bool) {
         return _operateBorrowsToken(input, token);
     }
+
+    function successfulOperateFilter() external pure returns (uint8 callType, bool successOnly) {
+        PhEvm.CallFilter memory filter = _successfulOperateCalls();
+        return (filter.callType, filter.successOnly);
+    }
 }
 
 contract FluidLiquidityFlowBreakerAssertionTest is Test {
     address internal constant TOKEN = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // USDC
     address internal constant OTHER = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // USDT
+    address internal constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address internal constant WEETH = 0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee;
 
     BreakerHarness internal breaker;
 
@@ -59,6 +67,12 @@ contract FluidLiquidityFlowBreakerAssertionTest is Test {
         assertFalse(breaker.operateBorrowsToken(_operateCalldata(OTHER, int256(0), int256(100e6)), TOKEN));
     }
 
+    function testWarningTierUsesSuccessfulCallFilter() public view {
+        (uint8 callType, bool successOnly) = breaker.successfulOperateFilter();
+        assertEq(callType, 1);
+        assertTrue(successOnly);
+    }
+
     // --- Deployment smoke -------------------------------------------------
 
     function testDeploys() public {
@@ -68,5 +82,21 @@ contract FluidLiquidityFlowBreakerAssertionTest is Test {
         FluidLiquidityFlowBreakerAssertion deployed = new FluidLiquidityFlowBreakerAssertion(tokens);
         assertEq(deployed.WARN_OUTFLOW_BPS(), 1_000);
         assertEq(deployed.CRITICAL_OUTFLOW_BPS(), 2_000);
+    }
+
+    function testRejectsNativeToken() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = NATIVE_TOKEN;
+
+        vm.expectRevert(bytes("Fluid: native token breaker unsupported"));
+        new FluidLiquidityFlowBreakerAssertion(tokens);
+    }
+
+    function testRejectsExternalCustodyToken() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = WEETH;
+
+        vm.expectRevert(bytes("Fluid: external custody breaker unsupported"));
+        new FluidLiquidityFlowBreakerAssertion(tokens);
     }
 }

--- a/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
@@ -22,9 +22,13 @@ contract BreakerHarness is FluidLiquidityFlowBreakerAssertion {
         return _operateBorrowsToken(input, token);
     }
 
-    function successfulOperateFilter() external pure returns (uint8 callType, bool successOnly) {
+    function successfulOperateFilter()
+        external
+        pure
+        returns (uint8 callType, uint32 minDepth, uint32 maxDepth, bool topLevelOnly, bool successOnly)
+    {
         PhEvm.CallFilter memory filter = _successfulOperateCalls();
-        return (filter.callType, filter.successOnly);
+        return (filter.callType, filter.minDepth, filter.maxDepth, filter.topLevelOnly, filter.successOnly);
     }
 }
 
@@ -102,9 +106,15 @@ contract FluidLiquidityFlowBreakerAssertionTest is Test {
     }
 
     function testWarningTierUsesSuccessfulCallFilter() public view {
-        (uint8 callType, bool successOnly) = breaker.successfulOperateFilter();
-        assertEq(callType, 1);
+        (uint8 callType, uint32 minDepth, uint32 maxDepth, bool topLevelOnly, bool successOnly) =
+            breaker.successfulOperateFilter();
+        assertEq(callType, 1); // CALL only
         assertTrue(successOnly);
+        // Scan `operate` at ANY depth so router/proxy-routed borrows of the breached token are not
+        // missed — depth must not be left to precompile defaults.
+        assertEq(minDepth, 0);
+        assertEq(maxDepth, type(uint32).max);
+        assertFalse(topLevelOnly);
     }
 
     // --- Deployment smoke -------------------------------------------------

--- a/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
@@ -8,10 +8,13 @@ import {FluidLiquidityFlowBreakerAssertion} from "../src/FluidLiquidityFlowBreak
 import {IFluidLiquidityLike} from "../src/FluidInterfaces.sol";
 
 /// @notice Exposes the breaker's pure borrow-detection policy so it can be exercised directly.
-/// @dev The `watchCumulativeOutflow` trigger that fires the live assertion is driven by the
-///      executor's rolling-window accounting and is not simulated by local `pcl test`, so the
-///      warning-tier policy is validated through `operateBorrowsToken` rather than an armed
-///      `cl.assertion` call (mirroring the Lighter circuit-breaker example).
+/// @dev The `watchCumulativeOutflow` trigger that fires the live assertion, and the `ph.matchingCalls`
+///      query it feeds on, are driven by the executor's rolling-window accounting and are not
+///      simulated by local `pcl test`, so the warning-tier policy is validated through
+///      `operateBorrowsToken` rather than an armed `cl.assertion` call (mirroring the Lighter
+///      circuit-breaker example). Critically, the policy is exercised against the exact
+///      selector-stripped argument tail that `ph.matchingCalls(...).input` returns in production — see
+///      `_matchingCallsInput` — so the selector-offset regression this fix addresses is caught here.
 contract BreakerHarness is FluidLiquidityFlowBreakerAssertion {
     constructor(address[] memory tokens_) FluidLiquidityFlowBreakerAssertion(tokens_) {}
 
@@ -39,32 +42,63 @@ contract FluidLiquidityFlowBreakerAssertionTest is Test {
         breaker = new BreakerHarness(tokens);
     }
 
-    function _operateCalldata(address token, int256 supplyAmount, int256 borrowAmount)
+    /// @notice Builds the input the breaker actually decodes in production.
+    /// @dev `ph.matchingCalls(...).input` returns the ABI argument tail with the 4-byte selector (the
+    ///      query key) stripped, so the policy must be tested against that shape, NOT against full
+    ///      selector-prefixed calldata. `abi.encode(args)` is byte-identical to
+    ///      `abi.encodeWithSelector(sel, args)[4:]` (asserted by
+    ///      `testMatchingCallsInputIsSelectorStripped`). Feeding selector-prefixed calldata here is
+    ///      what masked the original decode bug.
+    function _matchingCallsInput(address token, int256 supplyAmount, int256 borrowAmount)
         internal
         pure
         returns (bytes memory)
     {
-        return abi.encodeWithSelector(
-            IFluidLiquidityLike.operate.selector, token, supplyAmount, borrowAmount, address(0), address(0), bytes("")
-        );
+        return abi.encode(token, supplyAmount, borrowAmount, address(0), address(0), bytes(""));
     }
 
     // --- Warning-tier policy: block new borrows of the breached token ----
 
     function testBorrowOfBreachedTokenIsBlocked() public view {
-        assertTrue(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(0), int256(100e6)), TOKEN));
+        assertTrue(breaker.operateBorrowsToken(_matchingCallsInput(TOKEN, int256(0), int256(100e6)), TOKEN));
     }
 
     function testRepayOfBreachedTokenIsAllowed() public view {
-        assertFalse(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(0), -int256(100e6)), TOKEN));
+        assertFalse(breaker.operateBorrowsToken(_matchingCallsInput(TOKEN, int256(0), -int256(100e6)), TOKEN));
     }
 
     function testSupplyOnlyIsAllowed() public view {
-        assertFalse(breaker.operateBorrowsToken(_operateCalldata(TOKEN, int256(100e6), int256(0)), TOKEN));
+        assertFalse(breaker.operateBorrowsToken(_matchingCallsInput(TOKEN, int256(100e6), int256(0)), TOKEN));
     }
 
     function testBorrowOfOtherTokenIsAllowed() public view {
-        assertFalse(breaker.operateBorrowsToken(_operateCalldata(OTHER, int256(0), int256(100e6)), TOKEN));
+        assertFalse(breaker.operateBorrowsToken(_matchingCallsInput(OTHER, int256(0), int256(100e6)), TOKEN));
+    }
+
+    // --- Regression guards for the selector-stripped input contract ------
+
+    /// @dev Pins the production input shape: the args-only encoding the policy decodes must equal the
+    ///      selector-prefixed operate calldata with its leading 4 bytes removed — exactly what
+    ///      `ph.matchingCalls(...).input` yields. Breaks if `_matchingCallsInput` drifts from reality.
+    function testMatchingCallsInputIsSelectorStripped() public pure {
+        bytes memory full = abi.encodeWithSelector(
+            IFluidLiquidityLike.operate.selector, TOKEN, int256(0), int256(100e6), address(0), address(0), bytes("")
+        );
+        bytes memory stripped = new bytes(full.length - 4);
+        for (uint256 i; i < stripped.length; ++i) {
+            stripped[i] = full[i + 4];
+        }
+        assertEq(keccak256(stripped), keccak256(_matchingCallsInput(TOKEN, int256(0), int256(100e6))));
+    }
+
+    /// @dev If the 4-byte selector offset is ever re-added to the arg decoders, full selector-prefixed
+    ///      calldata would decode as a borrow of TOKEN and this would flip to a (spurious) detection.
+    ///      With the correct args-only decode the selector shifts the token word, so no match.
+    function testSelectorPrefixedCalldataIsNotDecodedAsBorrow() public view {
+        bytes memory full = abi.encodeWithSelector(
+            IFluidLiquidityLike.operate.selector, TOKEN, int256(0), int256(100e6), address(0), address(0), bytes("")
+        );
+        assertFalse(breaker.operateBorrowsToken(full, TOKEN));
     }
 
     function testWarningTierUsesSuccessfulCallFilter() public view {

--- a/examples/fluid/test/FluidLiquiditySolvencyAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquiditySolvencyAssertion.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {FluidLiquiditySolvencyAssertion} from "../src/FluidLiquiditySolvencyAssertion.sol";
+
+/// @notice Minimal ERC20 whose `balanceOf` the assertion reads as the singleton's custody.
+contract MockToken {
+    mapping(address => uint256) public balanceOf;
+
+    function setBalance(address account, uint256 amount) external {
+        balanceOf[account] = amount;
+    }
+}
+
+/// @notice Mock Fluid Liquidity Layer that stores packed accounting at the real mapping slots.
+/// @dev Encodes interest-free supply/borrow as BigMath with exponent 0 (value << 8), leaving the
+///      with-interest "raw" fields zero so the decode reduces to the plain amounts.
+contract MockFluidLiquidity {
+    uint256 internal constant SLOT_EXCHANGE_PRICES = 5;
+    uint256 internal constant SLOT_TOTAL_AMOUNTS = 7;
+
+    function setTotals(address token, uint256 totalSupply, uint256 totalBorrow) public {
+        uint256 packed = ((totalSupply << 8) << 64) | ((totalBorrow << 8) << 192);
+        bytes32 slot = keccak256(abi.encode(token, SLOT_TOTAL_AMOUNTS));
+        assembly {
+            sstore(slot, packed)
+        }
+    }
+
+    function setExchangePrices(address token, uint256 supplyExchangePrice, uint256 borrowExchangePrice) public {
+        uint256 packed = (supplyExchangePrice << 91) | (borrowExchangePrice << 155);
+        bytes32 slot = keccak256(abi.encode(token, SLOT_EXCHANGE_PRICES));
+        assembly {
+            sstore(slot, packed)
+        }
+    }
+
+    /// @notice Monitored mutation standing in for `operate`: rewrites the token's totals.
+    function operate(address token, uint256 totalSupply, uint256 totalBorrow) external {
+        setTotals(token, totalSupply, totalBorrow);
+    }
+
+    /// @notice Monitored mutation standing in for an interest update: rewrites exchange prices.
+    function updatePrices(address token, uint256 supplyExchangePrice, uint256 borrowExchangePrice) external {
+        setExchangePrices(token, supplyExchangePrice, borrowExchangePrice);
+    }
+}
+
+contract FluidLiquiditySolvencyAssertionTest is Test, CredibleTest {
+    MockFluidLiquidity internal liquidity;
+    MockToken internal token;
+    address[] internal tokens;
+
+    uint256 internal constant SUPPLY = 1_000e6;
+    uint256 internal constant BORROW = 400e6;
+    uint256 internal constant HELD = 600e6; // = SUPPLY - BORROW, exactly solvent
+
+    uint256 internal constant EP = 1e12; // initial exchange price
+
+    function setUp() public {
+        liquidity = new MockFluidLiquidity();
+        token = new MockToken();
+
+        token.setBalance(address(liquidity), HELD);
+        liquidity.setTotals(address(token), SUPPLY, BORROW);
+        liquidity.setExchangePrices(address(token), EP, EP);
+
+        tokens.push(address(token));
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        bytes memory createData =
+            abi.encodePacked(type(FluidLiquiditySolvencyAssertion).creationCode, abi.encode(tokens));
+        cl.assertion(address(liquidity), createData, fnSelector);
+    }
+
+    // --- Custody covers net supply ---------------------------------------
+
+    function testCustodyHonestPasses() public {
+        _arm(FluidLiquiditySolvencyAssertion.assertCustodyCoversNetSupply.selector);
+        // Stays exactly solvent: held + borrow == supply.
+        liquidity.operate(address(token), SUPPLY, BORROW);
+    }
+
+    function testCustodyInsolventTrips() public {
+        _arm(FluidLiquiditySolvencyAssertion.assertCustodyCoversNetSupply.selector);
+        // Supply inflated far beyond what custody + debt can back.
+        vm.expectRevert(bytes("Fluid: liquidity custody below net supply"));
+        liquidity.operate(address(token), 2_000e6, BORROW);
+    }
+
+    // --- Exchange price monotonicity -------------------------------------
+
+    function testExchangePriceIncreasePasses() public {
+        _arm(FluidLiquiditySolvencyAssertion.assertExchangePricesMonotonic.selector);
+        // Interest accrual raises prices: allowed.
+        liquidity.updatePrices(address(token), EP + 1, EP + 2);
+    }
+
+    function testExchangePriceDecreaseTrips() public {
+        _arm(FluidLiquiditySolvencyAssertion.assertExchangePricesMonotonic.selector);
+        // A drop in the stored supply exchange price signals corrupted accounting.
+        vm.expectRevert(bytes("Fluid: supply exchange price decreased"));
+        liquidity.updatePrices(address(token), EP - 1, EP);
+    }
+}

--- a/examples/fluid/test/FluidLiquiditySolvencyAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquiditySolvencyAssertion.t.sol
@@ -15,6 +15,15 @@ contract MockToken {
     }
 }
 
+/// @notice Mock of the Zircuit balance surface Fluid counts as mainnet external custody.
+contract MockZircuit {
+    mapping(address => mapping(address => uint256)) public balance;
+
+    function setBalance(address token, address staker, uint256 amount) external {
+        balance[token][staker] = amount;
+    }
+}
+
 /// @notice Mock Fluid Liquidity Layer that stores packed accounting at the real mapping slots.
 /// @dev Encodes interest-free supply/borrow as BigMath with exponent 0 (value << 8), leaving the
 ///      with-interest "raw" fields zero so the decode reduces to the plain amounts.
@@ -50,6 +59,9 @@ contract MockFluidLiquidity {
 }
 
 contract FluidLiquiditySolvencyAssertionTest is Test, CredibleTest {
+    address internal constant WEETH = 0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee;
+    address internal constant ZIRCUIT = 0xF047ab4c75cebf0eB9ed34Ae2c186f3611aEAfa6;
+
     MockFluidLiquidity internal liquidity;
     MockToken internal token;
     address[] internal tokens;
@@ -77,6 +89,12 @@ contract FluidLiquiditySolvencyAssertionTest is Test, CredibleTest {
         cl.assertion(address(liquidity), createData, fnSelector);
     }
 
+    function _armWith(address[] memory tokens_, bytes4 fnSelector) internal {
+        bytes memory createData =
+            abi.encodePacked(type(FluidLiquiditySolvencyAssertion).creationCode, abi.encode(tokens_));
+        cl.assertion(address(liquidity), createData, fnSelector);
+    }
+
     // --- Custody covers net supply ---------------------------------------
 
     function testCustodyHonestPasses() public {
@@ -90,6 +108,27 @@ contract FluidLiquiditySolvencyAssertionTest is Test, CredibleTest {
         // Supply inflated far beyond what custody + debt can back.
         vm.expectRevert(bytes("Fluid: liquidity custody below net supply"));
         liquidity.operate(address(token), 2_000e6, BORROW);
+    }
+
+    function testCustodyIncludesMainnetExternalBalances() public {
+        vm.chainId(1);
+
+        MockToken tokenImpl = new MockToken();
+        vm.etch(WEETH, address(tokenImpl).code);
+        MockZircuit zircuitImpl = new MockZircuit();
+        vm.etch(ZIRCUIT, address(zircuitImpl).code);
+
+        uint256 externalHeld = 100e6;
+        MockToken(WEETH).setBalance(address(liquidity), HELD - externalHeld);
+        MockZircuit(ZIRCUIT).setBalance(WEETH, address(liquidity), externalHeld);
+        liquidity.setTotals(WEETH, SUPPLY, BORROW);
+        liquidity.setExchangePrices(WEETH, EP, EP);
+
+        address[] memory monitoredTokens = new address[](1);
+        monitoredTokens[0] = WEETH;
+
+        _armWith(monitoredTokens, FluidLiquiditySolvencyAssertion.assertCustodyCoversNetSupply.selector);
+        liquidity.operate(WEETH, SUPPLY, BORROW);
     }
 
     // --- Exchange price monotonicity -------------------------------------

--- a/examples/fluid/test/FluidVaultRiskConfigAssertion.t.sol
+++ b/examples/fluid/test/FluidVaultRiskConfigAssertion.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {FluidVaultRiskConfigAssertion} from "../src/FluidVaultRiskConfigAssertion.sol";
+
+/// @notice Mock FluidVaultResolver returning a single packed `vaultVariables2` word.
+contract MockVaultResolver {
+    uint256 internal packed;
+
+    function set(uint256 vaultVariables2_) external {
+        packed = vaultVariables2_;
+    }
+
+    function getVaultVariables2Raw(address) external view returns (uint256) {
+        return packed;
+    }
+}
+
+/// @notice Mock vault adopter; any call fires the tx-end config check.
+contract MockVault {
+    function poke() external {}
+}
+
+contract FluidVaultRiskConfigAssertionTest is Test, CredibleTest {
+    MockVaultResolver internal resolver;
+    MockVault internal vault;
+
+    function setUp() public {
+        resolver = new MockVaultResolver();
+        vault = new MockVault();
+        // Healthy ordering: CF 75% (750), LT 85% (850), LML 90% (900) stored as input/10;
+        // penalty 5% (500) stored in 1e2. 9000 + 500 = 9500 <= 9970.
+        resolver.set(_pack(750, 850, 900, 500));
+    }
+
+    function _pack(uint256 cf, uint256 lt, uint256 lml, uint256 penalty) internal pure returns (uint256) {
+        return (cf << 32) | (lt << 42) | (lml << 52) | (penalty << 72);
+    }
+
+    function _arm() internal {
+        bytes memory createData =
+            abi.encodePacked(type(FluidVaultRiskConfigAssertion).creationCode, abi.encode(address(resolver)));
+        cl.assertion(address(vault), createData, FluidVaultRiskConfigAssertion.assertRiskConfigOrdering.selector);
+    }
+
+    function testHealthyConfigPasses() public {
+        _arm();
+        vault.poke();
+    }
+
+    function testInvertedOrderingTrips() public {
+        // CF (900) >= LT (850): positions could open at/above the liquidation line.
+        resolver.set(_pack(900, 850, 950, 500));
+        _arm();
+        vm.expectRevert(bytes("Fluid: collateral factor >= liquidation threshold"));
+        vault.poke();
+    }
+
+    function testPenaltyOverConsumesCollateralTrips() public {
+        // LML 95% (950 -> 9500 in 1e2) + penalty 5% (500) = 10000 > 9970.
+        resolver.set(_pack(750, 850, 950, 500));
+        _arm();
+        vm.expectRevert(bytes("Fluid: liquidation max limit + penalty above 99.7%"));
+        vault.poke();
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -123,6 +123,14 @@ cache_path = "examples/lido/cache"
 libs = ["lib"]
 remappings = ["credible-std/=src/"]
 
+[profile.fluid]
+src = "examples/fluid/src"
+test = "examples/fluid/test"
+out = "examples/fluid/out"
+cache_path = "examples/fluid/cache"
+libs = ["lib"]
+remappings = ["credible-std/=src/"]
+
 [profile.lighter]
 src = "examples/lighter/src"
 test = "examples/lighter/test"


### PR DESCRIPTION
## Summary

- Count Fluid-recognized mainnet Zircuit custody for weETH/weETHs in the Liquidity solvency assertion.
- Make the Fluid fToken share-price assertion compare a fixed-share `convertToAssets(1e12)` sample instead of `totalAssets / totalSupply`.
- Tighten the Fluid flow breaker by filtering to successful CALLs and rejecting unsupported native/external-custody token configs.
- Update Fluid example tests and docs for the corrected assumptions.

## Validation

- `FOUNDRY_PROFILE=fluid pcl test`