### PR TITLE
fix(perpetual): prepend selector in PerpetualBaseAssertion._resolveTriggeredCall

### DIFF
--- a/examples/royco/src/RoycoHelpers.sol
+++ b/examples/royco/src/RoycoHelpers.sol
@@ -445,8 +445,11 @@ abstract contract RoycoVaultTrancheHelpers is RoycoHelpers {
                 continue;
             }
 
+            // `matchingCalls` returns calldata args WITHOUT the 4-byte selector (it is the query
+            // key), so decode the args tuple directly — unlike the `ph.callinputAt(...)` paths,
+            // whose raw calldata still carries the selector and needs `_stripSelector`.
             (uint256 kernelShares, address kernelReceiver, bool bypassRestrictions) =
-                abi.decode(_stripSelector(calls[i].input), (uint256, address, bool));
+                abi.decode(calls[i].input, (uint256, address, bool));
             if (kernelShares != shares || kernelReceiver != receiver || bypassRestrictions) {
                 continue;
             }

--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -30,7 +30,13 @@ interface PhEvm {
     /// @notice Represents the inputs to a call made during transaction execution
     /// @dev Used by getCallInputs() and related functions to inspect call details
     struct CallInputs {
-        /// @notice The calldata of the call
+        /// @notice The ABI-encoded call arguments, WITHOUT the 4-byte function selector.
+        /// @dev The `get*CallInputs` queries (getAllCallInputs/getCallInputs/getStaticCallInputs/
+        ///      getDelegateCallInputs/getCallCodeInputs) key on `selector`, so it is stripped from
+        ///      this field and only the argument tail remains. To rebuild full calldata, prepend the
+        ///      selector: `bytes.concat(selector, input)`. Do NOT slice `input[4:]` — the selector is
+        ///      already gone, and slicing would drop the first argument word. Contrast `callinputAt`,
+        ///      which returns the raw selector-prefixed calldata.
         bytes input;
         /// @notice The gas limit of the call
         uint64 gas_limit;
@@ -130,6 +136,10 @@ interface PhEvm {
         uint8 callType;
         bool success;
         uint256 value;
+        /// @notice The ABI-encoded call arguments, WITHOUT the 4-byte function selector.
+        /// @dev Same shape as `CallInputs.input`: `matchingCalls` keys on `selector`, so it is
+        ///      stripped here. Prepend `selector` (`bytes.concat(selector, input)`) before decoding;
+        ///      do not slice `input[4:]`.
         bytes input;
     }
 
@@ -229,7 +239,11 @@ interface PhEvm {
     function getLogs() external returns (Log[] memory logs);
 
     /// @notice Get all call inputs for a target and selector (all call types)
-    /// @dev Includes CALL, STATICCALL, DELEGATECALL, and CALLCODE
+    /// @dev Includes CALL, STATICCALL, DELEGATECALL, and CALLCODE.
+    ///      Each returned `CallInputs.input` is the ABI-encoded arguments WITHOUT the 4-byte
+    ///      selector (the selector is the query key here). Prepend it with
+    ///      `bytes.concat(selector, calls[i].input)` to reconstruct full calldata before decoding;
+    ///      do not slice `input[4:]`. See the `CallInputs.input` field docs.
     /// @param target The target contract address
     /// @param selector The function selector to filter by
     /// @return calls Array of CallInputs matching the criteria
@@ -313,6 +327,8 @@ interface PhEvm {
     // ---------------------------------------------------------------
 
     /// @notice Returns calls matching the given target, selector, and filter criteria.
+    /// @dev Each returned `TriggerCall.input` is the ABI-encoded arguments WITHOUT the 4-byte
+    ///      selector — prepend `selector` before decoding (see the `TriggerCall.input` field docs).
     /// @param target The target contract address.
     /// @param selector The function selector to filter by.
     /// @param filter Filtering criteria (call type, depth, success).

--- a/src/protection/perpetual/PerpetualBaseAssertion.sol
+++ b/src/protection/perpetual/PerpetualBaseAssertion.sol
@@ -496,11 +496,13 @@ abstract contract PerpetualBaseAssertion is Assertion {
 
         for (uint256 i; i < calls.length; ++i) {
             if (calls[i].id == context.callStart) {
+                // `getAllCallInputs` returns calldata args WITHOUT the 4-byte selector (it is the
+                // query key), but `decodeOperation` expects selector-prefixed calldata. Prepend it.
                 return IPerpetualProtectionSuite.TriggeredCall({
                     selector: context.selector,
                     caller: calls[i].caller,
                     target: calls[i].target_address,
-                    input: calls[i].input,
+                    input: bytes.concat(context.selector, calls[i].input),
                     callStart: context.callStart,
                     callEnd: context.callEnd
                 });

--- a/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
+++ b/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {PhEvm} from "../../../src/PhEvm.sol";
+import {AssertionSpec} from "../../../src/SpecRecorder.sol";
+import {IPerpetualProtectionSuite} from "../../../src/protection/perpetual/IPerpetualProtectionSuite.sol";
+import {PerpetualBaseAssertion} from "../../../src/protection/perpetual/PerpetualBaseAssertion.sol";
+
+interface ITestPerp {
+    function op(address account) external;
+    function equityOf(address account) external view returns (int256);
+}
+
+/// @notice Minimal perp: a single risk-reducing `op(address)` plus a per-account equity getter.
+contract MockPerp is ITestPerp {
+    mapping(address => int256) internal equity;
+    mapping(address => int256) internal pending;
+
+    function setEquity(address account, int256 value) external {
+        equity[account] = value;
+    }
+
+    function setPending(address account, int256 value) external {
+        pending[account] = value;
+    }
+
+    function op(address account) external override {
+        equity[account] = pending[account];
+    }
+
+    function equityOf(address account) external view override returns (int256) {
+        return equity[account];
+    }
+}
+
+/// @notice Minimal combined suite + perpetual base, returning itself as the suite. Implements the
+///         `IPerpetualProtectionSuite` surface directly (rather than via `PerpetualProtectionSuiteBase`)
+///         to stay under the contract-size limit, so the assertion actually deploys and exercises the
+///         generic per-call decode + post-mutation risk path — including the getAllCallInputs
+///         selector-prepend in `PerpetualBaseAssertion._resolveTriggeredCall`. Without that prepend,
+///         `decodeOperation`'s `triggered.input[4:]` strips four bytes of the real first argument and
+///         reads a corrupted account, so an honest op would no longer decode `borrower`.
+contract TestPerpRiskAssertion is PerpetualBaseAssertion, IPerpetualProtectionSuite {
+    address internal immutable PERP;
+
+    constructor(address perp_) {
+        PERP = perp_;
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function _suite() internal view override returns (IPerpetualProtectionSuite) {
+        return IPerpetualProtectionSuite(address(this));
+    }
+
+    function getMonitoredSelectors() external pure override returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = ITestPerp.op.selector;
+    }
+
+    /// @dev Disable every optional check family so the assertion runs decode + the post-mutation gate.
+    function enabledCheckKinds() external pure override returns (EnabledCheckKinds memory enabled) {
+        enabled;
+    }
+
+    function decodeOperation(TriggeredCall calldata triggered)
+        external
+        pure
+        override
+        returns (OperationContext memory operation)
+    {
+        operation.selector = triggered.selector;
+        operation.caller = triggered.caller;
+        operation.kind = OperationKind.IncreasePosition;
+        operation.account = abi.decode(triggered.input[4:], (address));
+        operation.reducesAccountSafety = true;
+    }
+
+    function shouldCheckPostMutationRisk(OperationContext calldata operation) external pure override returns (bool) {
+        return operation.account != address(0) && operation.reducesAccountSafety;
+    }
+
+    /// @dev Reads the post-call equity for the decoded account and gates on `equity >= 0`.
+    function getPostMutationSnapshot(
+        TriggeredCall calldata,
+        OperationContext calldata operation,
+        PhEvm.ForkId calldata fork
+    ) external view override returns (AccountSnapshot memory snapshot) {
+        int256 equity = abi.decode(_viewAt(PERP, abi.encodeCall(ITestPerp.equityOf, (operation.account)), fork), (int256));
+        snapshot.risk.equity = equity;
+        snapshot.risk.hasBadDebt = equity < 0;
+        snapshot.risk.isHealthy = equity >= 0;
+    }
+
+    // --- Unused interface surface (the assertion never reaches these in this test) ---------------
+
+    function getExecutionPriceChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (ExecutionPriceCheck[] memory) {}
+
+    function getLiquidityCoverageChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (LiquidityCoverageCheck[] memory) {}
+
+    function getFundingDeltaChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (FundingDeltaCheck[] memory) {}
+
+    function getLiquidationChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (LiquidationCheck[] memory) {}
+
+    function getOracleAnchorChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (OracleAnchorCheck[] memory) {}
+
+    function getAccountingConservationChecks(
+        TriggeredCall calldata,
+        OperationContext calldata,
+        PhEvm.ForkId calldata,
+        PhEvm.ForkId calldata
+    ) external pure override returns (AccountingConservationCheck[] memory) {}
+
+    function getAccountSnapshot(address, PhEvm.ForkId calldata) external pure override returns (AccountSnapshot memory) {}
+
+    function getAccountState(address, PhEvm.ForkId calldata) external pure override returns (AccountState memory) {}
+
+    function getAccountPositions(address, PhEvm.ForkId calldata)
+        external
+        pure
+        override
+        returns (PositionState[] memory)
+    {}
+
+    function evaluateRisk(AccountState calldata, PositionState[] calldata, PhEvm.ForkId calldata)
+        external
+        pure
+        override
+        returns (RiskState memory)
+    {}
+}
+
+contract PerpetualOperationSafetyPerCallTest is Test, CredibleTest {
+    MockPerp internal perp;
+    address internal borrower = makeAddr("borrower");
+
+    function setUp() public {
+        perp = new MockPerp();
+    }
+
+    function _arm() internal {
+        bytes memory createData = abi.encodePacked(type(TestPerpRiskAssertion).creationCode, abi.encode(address(perp)));
+        cl.assertion(address(perp), createData, PerpetualBaseAssertion.assertOperationSafety.selector);
+    }
+
+    function testPerpHonestOpPasses() public {
+        perp.setPending(borrower, 1); // ends healthy
+
+        // Passing requires decoding `borrower` correctly, which only holds when the triggered
+        // calldata is selector-prefixed. A double-strip would corrupt the decoded account.
+        _arm();
+        perp.op(borrower);
+    }
+
+    function testPerpBadDebtOpTrips() public {
+        // Decoding the correct account is essential: the op names `borrower`, whose equity goes
+        // negative at PostCall, creating self bad debt.
+        perp.setPending(borrower, -1);
+
+        _arm();
+        vm.expectRevert();
+        perp.op(borrower);
+    }
+
+    function testDecodeOperationUsesSelectorPrefixedInput() public {
+        // `decodeOperation` expects selector-prefixed calldata (the base re-prepends the selector
+        // that getAllCallInputs strips). Feeding it that shape must decode the account back exactly.
+        TestPerpRiskAssertion suite = new TestPerpRiskAssertion(address(perp));
+        IPerpetualProtectionSuite.OperationContext memory op = suite.decodeOperation(
+            IPerpetualProtectionSuite.TriggeredCall({
+                selector: ITestPerp.op.selector,
+                caller: borrower,
+                target: address(perp),
+                input: abi.encodeCall(ITestPerp.op, (borrower)),
+                callStart: 1,
+                callEnd: 2
+            })
+        );
+
+        assertEq(op.account, borrower);
+        assertEq(op.selector, ITestPerp.op.selector);
+    }
+}

--- a/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
+++ b/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
@@ -174,6 +174,11 @@ contract PerpetualOperationSafetyPerCallTest is Test, CredibleTest {
 
     function _arm() internal {
         bytes memory createData = abi.encodePacked(type(TestPerpRiskAssertion).creationCode, abi.encode(address(perp)));
+        // `assertOperationSafety()` is declared on the abstract `PerpetualBaseAssertion` and inherited
+        // (not redeclared) by `TestPerpRiskAssertion`, so the selector must be referenced through the
+        // base — `TestPerpRiskAssertion.assertOperationSafety.selector` does not compile. The selector
+        // value is identical either way and the harness resolves it against the deployed contract.
+        // Mirrors the sibling lending suite (test/protection/lending/LendingSolvencyPerCall.t.sol).
         cl.assertion(address(perp), createData, PerpetualBaseAssertion.assertOperationSafety.selector);
     }
 

--- a/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
+++ b/test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol
@@ -88,7 +88,9 @@ contract TestPerpRiskAssertion is PerpetualBaseAssertion, IPerpetualProtectionSu
         OperationContext calldata operation,
         PhEvm.ForkId calldata fork
     ) external view override returns (AccountSnapshot memory snapshot) {
-        int256 equity = abi.decode(_viewAt(PERP, abi.encodeCall(ITestPerp.equityOf, (operation.account)), fork), (int256));
+        int256 equity = abi.decode(
+            _viewAt(PERP, abi.encodeCall(ITestPerp.equityOf, (operation.account)), fork), (int256)
+        );
         snapshot.risk.equity = equity;
         snapshot.risk.hasBadDebt = equity < 0;
         snapshot.risk.isHealthy = equity >= 0;
@@ -138,7 +140,12 @@ contract TestPerpRiskAssertion is PerpetualBaseAssertion, IPerpetualProtectionSu
         PhEvm.ForkId calldata
     ) external pure override returns (AccountingConservationCheck[] memory) {}
 
-    function getAccountSnapshot(address, PhEvm.ForkId calldata) external pure override returns (AccountSnapshot memory) {}
+    function getAccountSnapshot(address, PhEvm.ForkId calldata)
+        external
+        pure
+        override
+        returns (AccountSnapshot memory)
+    {}
 
     function getAccountState(address, PhEvm.ForkId calldata) external pure override returns (AccountState memory) {}
 


### PR DESCRIPTION
## Problem

`ph.getAllCallInputs(...).input` returns calldata args **without** the 4-byte selector, but `decodeOperation` consumers expect selector-prefixed calldata (they use `triggered.input[4:]`). `LendingBaseAssertion._resolveTriggeredCall` re-prepends the selector (added in #72), but **`PerpetualBaseAssertion._resolveTriggeredCall` was missed** — it forwarded `calls[i].input` raw.

So in production the Denaria suite's `triggered.input[4:]` stripped four bytes of the real first argument and decoded a **corrupted account**. The decode unit tests didn't catch it because they feed `decodeOperation` selector-prefixed `abi.encodeCall(...)` input directly — masking the test-harness-vs-production divergence flagged in #72.

## Fix

- **`PerpetualBaseAssertion.sol`** — prepend the selector in `_resolveTriggeredCall` (`bytes.concat(context.selector, calls[i].input)`), mirroring `LendingBaseAssertion`. This makes the perpetual `TriggeredCall.input` contract match the lending one. **No Denaria source change needed** — its `[4:]` was correct against the intended contract.
- **`examples/royco/src/RoycoHelpers.sol`** — fix a separate double-strip in `_resolveTriggeredKernelRedeemCall`: `ph.matchingCalls(...).input` also has the selector already stripped, so decode it directly. The `callinputAt`-based decoders there correctly keep `_stripSelector`.
- **`test/protection/perpetual/PerpetualOperationSafetyPerCall.t.sol`** (new) — minimal combined-suite assertion (kept under the 24 KB limit) that exercises the real `getAllCallInputs → prepend → decode` path through `cl.assertion`. Verified it **fails without the prepend** and passes with it.

## Not changed (and why)

**Tydro is not buggy.** It flows through `LendingBaseAssertion` (which already prepends), so its `triggered.input[4:]` is correct — identical to the `AaveV3LikeOperationSafety` reference. Dropping `[4:]` there would have broken it.

## Verification

- `pcl test --match-path 'test/protection/**'` → **83 passed, 0 failed** (incl. 3 new tests + existing lending per-call suite).
- Royco example compiles cleanly.
- One caveat: `ph.matchingCalls` isn't implemented in the local SDK / `pcl test` yet, so the Royco fix can't be exercised E2E locally — it relies on the `TriggerCall` struct's separate `selector` field and consistency with the rest of the `getAllCallInputs` family.

Refs: surfaced during review of #75; same selector-stripping class as #72.