### PR TITLE
feat(lido): add stETH vault flow assertion suite

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ FOUNDRY_PROFILE=<protocol> forge build
 | `curve/` | `curve` | crvUSD controller, LlamaLend, CurveLlamma, StableSwap-NG, TriCrypto-NG |
 | `denaria/` | `all-protection-suites` | Denaria perpetual operation safety |
 | `euler/` | `eulerv2` | EVault, circuit breaker, sandwich detection |
+| `lido/` | `lido` | Lido stETH vaults (generic): withdrawable-stETH buffer floor + outflow breaker, position risk regime, depeg gates, rate-vs-NAV |
 | `nado/` | `ink/assertions` | Nado perpetual clearinghouse |
 | `royco/` | `royco-dawn` | Royco kernel accounting, cumulative flow, vault tranche |
 | `safe/` | `safe-protection-suite` | Safe config lock + tx-shape assertions |

--- a/examples/lido/README.md
+++ b/examples/lido/README.md
@@ -10,11 +10,18 @@ without binding to any one stack's function selectors. Every invariant is expres
 boundaries (`registerTxEndTrigger` + pre/post-tx fork reads) or as a rolling cumulative-flow
 trigger, so the suite only needs addresses and thresholds to deploy against a concrete vault.
 
-## Build
+## Build & test
 
 ```sh
 FOUNDRY_PROFILE=lido forge build
+FOUNDRY_PROFILE=lido pcl test
 ```
+
+Requires `pcl` >= 1.4.0. The suite registers `registerTxEndTrigger` assertions and reads protocol
+state through `ph.staticcallAt` at pre/post-tx forks; every invariant below ships with pass-and-trip
+`CredibleTest` coverage under `test/` (mock pool / oracle / feed / rate-source / token knobs that
+trip one invariant at a time). The `watchCumulativeOutflow` breaker is executor-driven and not
+simulated by local `pcl test`, so its hard-revert decision is exercised directly.
 
 ## The headline ask: keep stETH withdrawable back to Lido
 
@@ -87,7 +94,7 @@ For the full "never fully deployed and never drained" guarantee, configure both.
 
 | Invariant | Failure point covered |
 |---|---|
-| Reduce-only regime: when the pre-tx health factor is below the comfort band, stETH trades off peg, the rate source can't report a rate, or the collateral reserve is no longer liquid enough for the vault to exit, a transaction may not grow debt or lower the health factor — and under market-condition triggers (shaky pricing, illiquid collateral) it may not grow the supplied position either | no new allocations into unhealthy positions; reduce-only when oracles are shaky |
+| Reduce-only regime: when the pre-tx health factor is below the comfort band, stETH trades off peg (or the stETH/ETH feed is stale, incomplete, or unreadable — fail-closed), the rate source can't report a rate, or the collateral reserve is no longer liquid enough for the vault to exit, a transaction may not grow debt or lower the health factor — and under market-condition triggers (shaky pricing, illiquid collateral) it may not grow the supplied position either | no new allocations into unhealthy positions; reduce-only when oracles are shaky |
 | Exit-liquidity guard: a transaction that grows debt must leave the borrowed reserve holding ≥ a configured multiple of the vault's debt | underlying market health (the vault can always repay and unwind) |
 | Collateral withdrawability guard: a transaction that deepens the supplied position must leave the collateral reserve holding ≥ a configured fraction of the vault's supplied collateral in un-borrowed form | the deployed leg stays withdrawable at execution time — distinct from the vault-held buffer floor above |
 | Position envelope: the health factor ends every transaction above a hard floor, may only decline while staying inside the comfort band, and the raw collateral/debt ratio holds a minimum | health factor must not degrade; collateral ratio maintained |
@@ -96,7 +103,7 @@ For the full "never fully deployed and never drained" guarantee, configure both.
 
 | Invariant | Failure point covered |
 |---|---|
-| Supply-change depeg gate: any transaction that changes share supply — a mint or burn through any path (teller, queue, solver, direct) — reverts while the stETH/ETH market price is outside the peg band | underlying asset depeg — users cannot enter/exit at a fictional parity rate |
+| Supply-change depeg gate: any transaction that changes share supply — a mint or burn through any path (teller, queue, solver, direct) — reverts while the stETH/ETH market price is outside the peg band, or while the feed is stale, reports an incomplete round, or carries an unanswered round (fail-closed, so an oracle outage cannot hold the gate open on a stale on-peg price) | underlying asset depeg — users cannot enter/exit at a fictional parity rate |
 | wstETH rate integrity: `stEthPerToken()` must not decrease within a transaction, and the vault's wstETH rate provider (if configured) must match it within tolerance | rate-provider substitution/manipulation while shares are priced |
 
 ### `LidoStEthVaultNavAssertion` — adopter: the contract that reports the share rate
@@ -133,11 +140,16 @@ Everything protocol-specific is constructor configuration:
   for the withdrawability guard (e.g. wstETH / awstETH / awstETH; on Aave the reserve custody and
   the receipt token are the same contract)
 - `stEthEthFeed` — a Chainlink-style stETH/ETH feed (mainnet: `0x86392dC19c0b719886221c68AC0C1F0e8DB4eF14`, 18 decimals)
+- `maxFeedStalenessSecs` — how old the feed answer may be before the depeg gate fails closed and
+  treats the price as off peg. Set it to the feed's heartbeat plus a margin (the mainnet stETH/ETH
+  feed heartbeat is ~24h). Independent of this bound, an incomplete round (`updatedAt == 0`) or a
+  carried-over answer (`answeredInRound < roundId`) always fails closed.
 
-Optional signals disable cleanly: a zero feed disables depeg detection, a zero `rateSource`
-disables the pricing-health signal, zero `minCollateralRatioBps` / `minExitLiquidityBps` /
-`minBufferBps` / `outflowThresholdBps` disable those guards, a zero `aavePool` drops the position
-leg from NAV, a zero `deployedStEthReceipt` sizes the buffer floor against idle holdings only.
+Optional signals disable cleanly: a zero feed disables depeg detection, a zero `maxFeedStalenessSecs`
+keeps only the round-integrity checks (no age bound), a zero `rateSource` disables the pricing-health
+signal, zero `minCollateralRatioBps` / `minExitLiquidityBps` / `minBufferBps` / `outflowThresholdBps`
+disable those guards, a zero `aavePool` drops the position leg from NAV, a zero `deployedStEthReceipt`
+sizes the buffer floor against idle holdings only.
 
 Suggested starting thresholds for a looped stETH vault on Aave:
 
@@ -148,7 +160,8 @@ Suggested starting thresholds for a looped stETH vault on Aave:
 - **Risk:** `minHealthFactor = 1.01e18` (the floor Lido itself codified in its GGV migrator),
   `reduceOnlyHealthFactor = 1.05e18`, `minExitLiquidityBps = 10_000` (full unwind must be possible),
   `minCollateralLiquidityBps = 10_000`.
-- **Peg / NAV:** `maxDepegBps = 100` (1%), `rateToleranceBps = 50`.
+- **Peg / NAV:** `maxDepegBps = 100` (1%), `maxFeedStalenessSecs = 90_000` (~25h, the stETH/ETH
+  feed heartbeat plus a margin), `rateToleranceBps = 50`.
 
 ## Scope and limitations
 
@@ -170,15 +183,19 @@ Suggested starting thresholds for a looped stETH vault on Aave:
 
 ## Files
 
-- LidoStEthExitBufferAssertion.sol
-- LidoStEthVaultRiskAssertion.sol
-- LidoStEthVaultPegAssertion.sol
-- LidoStEthVaultNavAssertion.sol
-- LidoVaultHelpers.sol
-- LidoVaultInterfaces.sol
+- src/LidoStEthExitBufferAssertion.sol
+- src/LidoStEthVaultRiskAssertion.sol
+- src/LidoStEthVaultPegAssertion.sol
+- src/LidoStEthVaultNavAssertion.sol
+- src/LidoVaultHelpers.sol
+- src/LidoVaultInterfaces.sol
+- test/LidoMocks.sol — shared mocks (pool / oracle / feed / rate source / tokens / vault adopter)
+- test/LidoStEthExitBufferAssertion.t.sol
+- test/LidoStEthVaultRiskAssertion.t.sol
+- test/LidoStEthVaultPegAssertion.t.sol
+- test/LidoStEthVaultNavAssertion.t.sol
 
 ## Next steps
 
-- `CredibleTest` E2E coverage (mock pool/rate-source/feed/token knobs that trip one invariant at a time)
 - Destination-aware outflow breaker (exempt transfers to Lido's `WithdrawalQueueERC721`)
 - Morpho/Euler position legs for the NAV and health checks

--- a/examples/lido/README.md
+++ b/examples/lido/README.md
@@ -1,0 +1,184 @@
+# lido examples
+
+Generic Credible Layer assertions for **Lido stETH vaults** — any vault that custodies
+ETH/stETH/wstETH, optionally allocates it into an Aave v3-like lending market (typically a looped
+wstETH-collateral / WETH-debt position), and prices its shares through some rate source.
+
+This covers the whole family of stETH vaults — Lido Earn's GGV (Veda BoringVault), its EarnETH
+successor (Mellow flexible-vaults), comparable third-party stETH loopers, and Lido V3 stVaults —
+without binding to any one stack's function selectors. Every invariant is expressed at transaction
+boundaries (`registerTxEndTrigger` + pre/post-tx fork reads) or as a rolling cumulative-flow
+trigger, so the suite only needs addresses and thresholds to deploy against a concrete vault.
+
+## Build
+
+```sh
+FOUNDRY_PROFILE=lido forge build
+```
+
+## The headline ask: keep stETH withdrawable back to Lido
+
+The concrete thing Lido asked for is a flow restriction: **some share of a vault's stETH must
+always stay in a state where it can be withdrawn back to Lido — never fully locked or deployed.**
+`LidoStEthExitBufferAssertion` is that invariant. Before reading it, two facts about Lido
+withdrawals bound what any on-chain assertion can honestly promise:
+
+### Requestable vs claimable — what "withdrawable at any time" can actually guarantee
+
+Unstaking stETH is a two-step, non-atomic process:
+
+1. **Request** — burn stETH/wstETH against Lido's `WithdrawalQueueERC721`, receive an NFT. This is
+   permissionless and available any time, but **capped at 1,000 ETH per request** (min 100 wei);
+   larger exits must be split into batched requests, and a request **cannot be canceled**.
+2. **Claim** — once the request is finalized, redeem the NFT for ETH. Finalization is bounded by
+   the **Ethereum validator exit queue** plus Lido's own buffer — on the order of tens of thousands
+   of ETH/day protocol-wide, varying with network conditions. It is *not* instant.
+
+So "withdrawable back to Lido at any time" can be guaranteed only in the **requestable** sense:
+the vault always holds enough stETH-equivalent in idle (un-deployed) form to *submit* to the queue
+immediately. **Claimable-instantly cannot be guaranteed by a per-vault assertion** — claim
+throughput is a Lido-protocol-global property, not something a vault's state can promise. This
+suite enforces requestability and is explicit about that boundary; pretending otherwise would be
+dishonest to the adopter.
+
+The assertion therefore protects two things, configurable independently:
+
+- a **standing buffer floor** — idle stETH-equivalent (idle stETH + idle wstETH at `stEthPerToken`)
+  must stay above a floor on *every* transaction, so the vault is provably never fully deployed and
+  always has a position to request against;
+- a **cumulative outflow circuit breaker** — stETH/wstETH cannot leave the vault faster than a
+  configured fraction of balance per rolling window. This is the **Safe last-mile defense**: even
+  if the vault's entire signer pipeline is compromised (the Bybit failure mode), a burst drain
+  trips the breaker and the transaction is never included.
+
+### How existing stETH vaults reserve exit liquidity (survey)
+
+The buffer-floor design follows established practice for vaults whose underlying is non-atomic to
+exit:
+
+| Pattern | How it reserves exit liquidity | Relevance |
+|---|---|---|
+| **ERC-4626** (`maxWithdraw`/`maxRedeem`) | Assumes *atomic* underlying liquidity; `maxWithdraw` returns whatever is currently idle, silently capping large exits | Works only while a buffer happens to exist — there's no *floor*, which is the gap this assertion fills |
+| **ERC-7540** async request/claim | Models exactly the stETH case: a `requestRedeem` → `claim` two-step for non-atomic underlyings | The on-chain analogue of Lido's request/claim; the "requestable" semantics here mirror it |
+| **Yearn v3, Morpho, Pendle** withdrawal buffers | Hold an explicit idle reserve (a % of TVL) sized so routine redemptions never touch deployed positions | This is the buffer floor, made into an enforced invariant rather than a strategist convention |
+| **Aave stETH markets** | No vault-level buffer; exit liquidity is the reserve's un-borrowed balance, drainable by any borrower | Why the risk suite's exit-liquidity guard checks the reserve *and* the vault keeps its own floor |
+
+The takeaway: production stETH vaults already reserve exit liquidity, but as an off-chain policy a
+compromised or careless strategist can erode. The buffer floor turns that policy into an invariant
+the block builder enforces at inclusion time.
+
+## Assertions
+
+### `LidoStEthExitBufferAssertion` — adopter: the vault (the account custodying stETH/wstETH)
+
+| Invariant | Failure point covered |
+|---|---|
+| Buffer floor: after every transaction the vault's idle, requestable stETH-equivalent (idle stETH + idle wstETH at the Lido rate) must be ≥ the larger of an absolute minimum and a configured fraction of total stETH-equivalent (idle + deployed) | stETH is provably never fully locked/deployed — a withdrawal request to Lido can always be submitted |
+| Outflow circuit breaker: cumulative stETH and wstETH outflow from the vault may not exceed a configured fraction of balance within a rolling window (`watchCumulativeOutflow`, hard breaker) | burst drains — a compromised signer pipeline (Safe last-mile) cannot move stETH out faster than the rate limit |
+
+The floor caps the absolute minimum at the vault's total stETH-equivalent, so a vault smaller than
+the floor is required to keep *everything* idle rather than being bricked. The two layers compose:
+the floor stops over-*deployment* while stETH is held, the breaker stops *draining* it out entirely.
+For the full "never fully deployed and never drained" guarantee, configure both.
+
+### `LidoStEthVaultRiskAssertion` — adopter: the contract that moves the position
+
+(the vault itself, or its manager/strategy executor when allocations run through one)
+
+| Invariant | Failure point covered |
+|---|---|
+| Reduce-only regime: when the pre-tx health factor is below the comfort band, stETH trades off peg, the rate source can't report a rate, or the collateral reserve is no longer liquid enough for the vault to exit, a transaction may not grow debt or lower the health factor — and under market-condition triggers (shaky pricing, illiquid collateral) it may not grow the supplied position either | no new allocations into unhealthy positions; reduce-only when oracles are shaky |
+| Exit-liquidity guard: a transaction that grows debt must leave the borrowed reserve holding ≥ a configured multiple of the vault's debt | underlying market health (the vault can always repay and unwind) |
+| Collateral withdrawability guard: a transaction that deepens the supplied position must leave the collateral reserve holding ≥ a configured fraction of the vault's supplied collateral in un-borrowed form | the deployed leg stays withdrawable at execution time — distinct from the vault-held buffer floor above |
+| Position envelope: the health factor ends every transaction above a hard floor, may only decline while staying inside the comfort band, and the raw collateral/debt ratio holds a minimum | health factor must not degrade; collateral ratio maintained |
+
+### `LidoStEthVaultPegAssertion` — adopter: the share token (or whatever mints/burns shares)
+
+| Invariant | Failure point covered |
+|---|---|
+| Supply-change depeg gate: any transaction that changes share supply — a mint or burn through any path (teller, queue, solver, direct) — reverts while the stETH/ETH market price is outside the peg band | underlying asset depeg — users cannot enter/exit at a fictional parity rate |
+| wstETH rate integrity: `stEthPerToken()` must not decrease within a transaction, and the vault's wstETH rate provider (if configured) must match it within tolerance | rate-provider substitution/manipulation while shares are priced |
+
+### `LidoStEthVaultNavAssertion` — adopter: the contract that reports the share rate
+
+| Invariant | Failure point covered |
+|---|---|
+| Rate-vs-NAV: after every transaction touching the rate reporter, its `getRate()` must sit within tolerance of NAV recomputed from on-chain state (idle base asset + stETH at parity + wstETH at the Lido rate + net Aave-like position), in both directions | compromised/buggy rate updater draining value a bounded step at a time |
+
+## How this maps to capital efficiency
+
+Idle buffers exist because unwind-ability is normally uncertain. This suite makes unwind-ability
+*provable* at execution time: the exit-buffer floor proves a withdrawal to Lido can always be
+requested, the risk suite's exit-liquidity and withdrawability guards prove each new allocation is
+unwindable, and the position deepens only while a reserve is liquid. With those proofs in place,
+buffer sizing becomes a policy choice — a small enforced floor — instead of a worst-case guess.
+The honest tail: the floor guarantees *requestable*, not *instantly claimable*; if Lido's queue is
+deep, a small operational reserve above the floor still smooths same-block redemptions.
+
+## Binding to a concrete deployment
+
+Everything protocol-specific is constructor configuration:
+
+- `vault` — the custody account holding idle assets and any lending position
+- `stEth` / `wstEth` — the Lido tokens; wstETH is valued through `stEthPerToken()`
+- `deployedStEthReceipt` — optional receipt token for stETH-equivalent deployed out of idle custody
+  (e.g. Aave `awstETH`); lets the buffer floor size against total exposure, not just idle holdings
+- `aavePool` / `aaveOracle` — any Aave v3-compatible market (`getUserAccountData` / `getAssetPrice`)
+- `rateSource` — anything exposing `getRate()`: a Veda accountant, a Balancer-style rate provider,
+  a Mellow-style oracle adapter
+- `shareToken` — the vault share ERC-20 (for BoringVaults, the vault itself)
+- `borrowedAsset` / `borrowedAssetReserve` / `borrowedAssetDebtToken` — the borrowed leg for the
+  exit-liquidity guard (e.g. WETH / aWETH / variable-debt WETH)
+- `collateralAsset` / `collateralAssetReserve` / `collateralAssetSupplyToken` — the supplied leg
+  for the withdrawability guard (e.g. wstETH / awstETH / awstETH; on Aave the reserve custody and
+  the receipt token are the same contract)
+- `stEthEthFeed` — a Chainlink-style stETH/ETH feed (mainnet: `0x86392dC19c0b719886221c68AC0C1F0e8DB4eF14`, 18 decimals)
+
+Optional signals disable cleanly: a zero feed disables depeg detection, a zero `rateSource`
+disables the pricing-health signal, zero `minCollateralRatioBps` / `minExitLiquidityBps` /
+`minBufferBps` / `outflowThresholdBps` disable those guards, a zero `aavePool` drops the position
+leg from NAV, a zero `deployedStEthReceipt` sizes the buffer floor against idle holdings only.
+
+Suggested starting thresholds for a looped stETH vault on Aave:
+
+- **Exit buffer:** `minBufferBps = 500` (keep ≥5% requestable), `outflowThresholdBps = 5_000` with
+  `outflowWindowDuration = 1 days` (no more than half the balance may leave per day — generous
+  enough for routine operations, tight enough to stop a burst drain). Set `minIdleStEthEq` to a hard
+  floor in stETH wei if the vault has a known minimum size.
+- **Risk:** `minHealthFactor = 1.01e18` (the floor Lido itself codified in its GGV migrator),
+  `reduceOnlyHealthFactor = 1.05e18`, `minExitLiquidityBps = 10_000` (full unwind must be possible),
+  `minCollateralLiquidityBps = 10_000`.
+- **Peg / NAV:** `maxDepegBps = 100` (1%), `rateToleranceBps = 50`.
+
+## Scope and limitations
+
+- **Requestable, not claimable.** The exit buffer guarantees stETH can be *submitted* to Lido's
+  WithdrawalQueue at any time; finalization is bounded by the validator exit queue and the 1,000
+  ETH/request cap, which no per-vault assertion controls.
+- **Outflow breaker is destination-blind.** The v1 breaker is a hard rate limit on stETH/wstETH
+  leaving the vault — it does not yet distinguish a legitimate large unstake-to-Lido from a drain.
+  Set the window threshold generously, or split large planned exits. A destination-aware variant
+  (exempt transfers to the WithdrawalQueue) is a documented next step.
+- **NAV coverage.** The NAV assertion counts idle base-asset/stETH/wstETH and one Aave-like
+  position. Vaults with extra legs (Morpho/Euler positions, L2-bridged capital) need either a wider
+  `rateToleranceBps` or an extended `_vaultNavInBaseAt`.
+- **Adopter scope.** Assertions only fire for transactions that touch their adopter. Third-party
+  liquidations call the lending pool directly — pair this suite with the lending-suite assertions
+  on the pool if that path matters.
+- **One market per instance.** The risk assertion reads a single Aave-like pool; deploy one
+  instance per market for multi-market vaults.
+
+## Files
+
+- LidoStEthExitBufferAssertion.sol
+- LidoStEthVaultRiskAssertion.sol
+- LidoStEthVaultPegAssertion.sol
+- LidoStEthVaultNavAssertion.sol
+- LidoVaultHelpers.sol
+- LidoVaultInterfaces.sol
+
+## Next steps
+
+- `CredibleTest` E2E coverage (mock pool/rate-source/feed/token knobs that trip one invariant at a time)
+- Destination-aware outflow breaker (exempt transfers to Lido's `WithdrawalQueueERC721`)
+- Morpho/Euler position legs for the NAV and health checks

--- a/examples/lido/src/LidoStEthExitBufferAssertion.sol
+++ b/examples/lido/src/LidoStEthExitBufferAssertion.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {LidoVaultHelpers} from "./LidoVaultHelpers.sol";
+import {IWstETHLike} from "./LidoVaultInterfaces.sol";
+
+/// @title LidoStEthExitBufferAssertion
+/// @author Phylax Systems
+/// @notice Keeps a Lido stETH vault's stETH withdrawable back to Lido: a standing buffer floor
+///         plus a flow circuit breaker on stETH/wstETH outflows.
+/// @dev Apply to the vault — the account that custodies the stETH/wstETH and deploys it.
+///
+///      This is the assertion Lido actually asked for: "some share of stETH always remains in a
+///      state where it can be unstaked via Lido, never fully locked/deployed." On-chain that can
+///      only be guaranteed in the REQUESTABLE sense — stETH a vault holds idle can be submitted to
+///      Lido's WithdrawalQueue at any time. It cannot be guaranteed CLAIMABLE-instantly: claiming
+///      is bounded by the Ethereum validator exit queue and Lido's own buffer, and each withdrawal
+///      request is capped (≤ 1,000 ETH/request, larger amounts batch). So this assertion enforces
+///      requestability, and leaves claim throughput where it actually lives — at the Lido protocol.
+///
+///      Two layers, configurable independently:
+///      - **Buffer floor** (every transaction): the vault's idle, requestable stETH-equivalent —
+///        idle stETH plus idle wstETH valued at `stEthPerToken()` — must stay above a floor. The
+///        floor is the larger of an absolute minimum and a fraction of the vault's total
+///        stETH-equivalent (idle + deployed), so the vault is provably never fully deployed.
+///      - **Outflow circuit breaker** (rolling window): stETH and wstETH cannot leave the vault
+///        faster than a configured fraction of balance per window. This is the Safe last-mile
+///        defense — even if the vault's signer pipeline is fully compromised, a burst drain trips
+///        the breaker and the transaction is never included.
+contract LidoStEthExitBufferAssertion is LidoVaultHelpers {
+    /// @notice Account custodying the vault's stETH/wstETH (the address whose buffer is protected).
+    address public immutable vault;
+
+    /// @notice stETH token. Counted at parity (1 stETH = 1 stETH-equivalent), requestable as-is.
+    address public immutable stEth;
+
+    /// @notice wstETH token. Valued through Lido's `stEthPerToken()`; unwraps to stETH atomically.
+    address public immutable wstEth;
+
+    /// @notice Receipt token for stETH-equivalent deployed out of idle custody (e.g. Aave awstETH).
+    ///         Valued at `stEthPerToken()` to size total exposure. Zero counts only idle holdings.
+    address public immutable deployedStEthReceipt;
+
+    /// @notice Absolute floor of idle, requestable stETH-equivalent (stETH wei). Zero disables.
+    ///         Capped at the vault's total stETH-equivalent so a small vault is never bricked.
+    uint256 public immutable minIdleStEthEq;
+
+    /// @notice Relative floor: idle stETH-equivalent must be at least this many bps of the vault's
+    ///         total stETH-equivalent (idle + deployed). 500 = keep ≥5% requestable. Zero disables.
+    uint256 public immutable minBufferBps;
+
+    /// @notice Cumulative outflow cap for stETH/wstETH, in bps of the balance at window start.
+    ///         1000 = at most 10% may leave per window. Zero disables the breaker entirely.
+    uint256 public immutable outflowThresholdBps;
+
+    /// @notice Rolling window length for the outflow breaker, in seconds.
+    uint256 public immutable outflowWindowDuration;
+
+    constructor(
+        address vault_,
+        address stEth_,
+        address wstEth_,
+        address deployedStEthReceipt_,
+        uint256 minIdleStEthEq_,
+        uint256 minBufferBps_,
+        uint256 outflowThresholdBps_,
+        uint256 outflowWindowDuration_
+    ) {
+        require(vault_ != address(0), "LidoVault: zero vault");
+        require(stEth_ != address(0), "LidoVault: zero stETH");
+        require(wstEth_ != address(0), "LidoVault: zero wstETH");
+        require(minBufferBps_ <= 10_000, "LidoVault: buffer bps too large");
+        require(outflowThresholdBps_ <= 10_000, "LidoVault: outflow bps too large");
+        require(outflowThresholdBps_ == 0 || outflowWindowDuration_ != 0, "LidoVault: zero outflow window");
+
+        vault = vault_;
+        stEth = stEth_;
+        wstEth = wstEth_;
+        deployedStEthReceipt = deployedStEthReceipt_;
+        minIdleStEthEq = minIdleStEthEq_;
+        minBufferBps = minBufferBps_;
+        outflowThresholdBps = outflowThresholdBps_;
+        outflowWindowDuration = outflowWindowDuration_;
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Wires the per-transaction buffer floor and the rolling-window outflow breakers.
+    /// @dev The buffer floor fires on every transaction touching the vault. The breakers register
+    ///      only when configured; the executor tracks the rolling outflow and invokes the
+    ///      assertion function solely when a token's outflow crosses the threshold.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertWithdrawableBufferFloor.selector);
+
+        if (outflowThresholdBps != 0) {
+            watchCumulativeOutflow(
+                stEth, outflowThresholdBps, outflowWindowDuration, this.assertOutflowWithinLimit.selector
+            );
+            watchCumulativeOutflow(
+                wstEth, outflowThresholdBps, outflowWindowDuration, this.assertOutflowWithinLimit.selector
+            );
+        }
+    }
+
+    /// @notice Requires the vault to end every transaction holding enough idle stETH-equivalent to
+    ///         remain requestable to Lido.
+    /// @dev Evaluated on post-transaction state. Idle (requestable) holdings are idle stETH plus
+    ///      idle wstETH at the Lido rate; total exposure adds the deployed receipt at the same
+    ///      rate. The required floor is the larger of the absolute minimum (capped at total, so it
+    ///      can never demand more stETH than the vault holds) and the relative fraction of total.
+    ///      A vault holding no stETH at all has nothing to reserve and passes — draining the last
+    ///      of it is the outflow breaker's job, not the floor's. A failure means the transaction
+    ///      left the vault more deployed than its exit policy allows.
+    function assertWithdrawableBufferFloor() external view {
+        PhEvm.ForkId memory fork = _postTx();
+
+        uint256 rate = _readUintAt(wstEth, abi.encodeCall(IWstETHLike.stEthPerToken, ()), fork);
+        require(rate != 0, "LidoVault: zero Lido rate");
+
+        uint256 idle =
+            _readBalanceAt(stEth, vault, fork) + ph.mulDivDown(_readBalanceAt(wstEth, vault, fork), rate, 1e18);
+
+        uint256 total = idle;
+        if (deployedStEthReceipt != address(0)) {
+            total += ph.mulDivDown(_readBalanceAt(deployedStEthReceipt, vault, fork), rate, 1e18);
+        }
+
+        if (total == 0) {
+            return;
+        }
+
+        uint256 requiredAbsolute = minIdleStEthEq < total ? minIdleStEthEq : total;
+        uint256 requiredRelative = ph.mulDivUp(total, minBufferBps, 10_000);
+        uint256 required = requiredAbsolute > requiredRelative ? requiredAbsolute : requiredRelative;
+
+        require(idle >= required, "LidoVault: withdrawable stETH buffer below floor");
+    }
+
+    /// @notice Hard circuit breaker for stETH/wstETH outflows from the vault.
+    /// @dev Invoked by the executor only once cumulative outflow of the watched token has crossed
+    ///      `outflowThresholdBps` of the window-start balance — so reaching this function already
+    ///      means the rate limit was breached. The breaker reverts unconditionally, so the
+    ///      offending transaction is never included and the team is alerted to triage. Set the
+    ///      window threshold generously: a legitimate planned unstake above it must be split or the
+    ///      limit temporarily raised. A destination-aware variant (exempt transfers to Lido's
+    ///      WithdrawalQueue, gate the rest) is a natural extension once transfer introspection is
+    ///      wired in — `ph.outflowContext()` exposes the breaching token and the window totals.
+    function assertOutflowWithinLimit() external pure {
+        revert("LidoVault: stETH outflow circuit breaker tripped");
+    }
+}

--- a/examples/lido/src/LidoStEthVaultNavAssertion.sol
+++ b/examples/lido/src/LidoStEthVaultNavAssertion.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {LidoVaultHelpers} from "./LidoVaultHelpers.sol";
+import {IAaveOracleLike, IERC20Like, IRateProviderLike, IWstETHLike} from "./LidoVaultInterfaces.sol";
+
+/// @title LidoStEthVaultNavAssertion
+/// @author Phylax Systems
+/// @notice Verifies a Lido stETH vault's reported share rate against on-chain NAV.
+/// @dev Apply to the contract that reports the share rate (accountant, oracle, or vault).
+///
+///      stETH vault share prices are typically computed off-chain and pushed on-chain, with
+///      bounds that are only RELATIVE to the previous rate (e.g. ±1% per update). A compromised
+///      or buggy updater can still walk the rate several percent per day in either direction.
+///      This assertion recomputes NAV from on-chain verifiable components — idle base-asset/
+///      stETH/wstETH custody plus the net Aave-like position — and requires the reported rate
+///      to sit within tolerance of it after every transaction touching the rate reporter,
+///      turning the off-chain pricing oracle from trusted into verified.
+contract LidoStEthVaultNavAssertion is LidoVaultHelpers {
+    /// @notice Account custodying the vault's idle assets and lending-market position.
+    address public immutable vault;
+
+    /// @notice Share token whose supply divides NAV into the per-share rate.
+    address public immutable shareToken;
+
+    /// @notice Rate source reporting base-asset units per share (`getRate()`).
+    address public immutable rateSource;
+
+    /// @notice Aave v3-like pool holding the vault's position. Zero skips the position leg.
+    address public immutable aavePool;
+
+    /// @notice Aave v3-like oracle used to convert base-currency position values.
+    address public immutable aaveOracle;
+
+    /// @notice The vault's base/quote asset (e.g. WETH). NAV is denominated in it.
+    address public immutable baseAsset;
+
+    /// @notice stETH, counted at parity with the base asset (the usual pricing convention).
+    address public immutable stEth;
+
+    /// @notice wstETH, valued through Lido's `stEthPerToken()` rate.
+    address public immutable wstEth;
+
+    /// @notice One full share, scaled to the share-token decimals.
+    uint256 public immutable ONE_SHARE;
+
+    /// @notice Max tolerated deviation between the reported rate and on-chain NAV, in bps.
+    uint256 public immutable rateToleranceBps;
+
+    constructor(
+        address vault_,
+        address shareToken_,
+        address rateSource_,
+        address aavePool_,
+        address aaveOracle_,
+        address baseAsset_,
+        address stEth_,
+        address wstEth_,
+        uint8 shareDecimals_,
+        uint256 rateToleranceBps_
+    ) {
+        require(vault_ != address(0), "LidoVault: zero vault");
+        require(shareToken_ != address(0), "LidoVault: zero share token");
+        require(rateSource_ != address(0), "LidoVault: zero rate source");
+        require(aavePool_ == address(0) || aaveOracle_ != address(0), "LidoVault: zero aave oracle");
+        require(baseAsset_ != address(0), "LidoVault: zero base asset");
+        require(stEth_ != address(0), "LidoVault: zero stETH");
+        require(wstEth_ != address(0), "LidoVault: zero wstETH");
+        require(rateToleranceBps_ <= 10_000, "LidoVault: tolerance too large");
+
+        vault = vault_;
+        shareToken = shareToken_;
+        rateSource = rateSource_;
+        aavePool = aavePool_;
+        aaveOracle = aaveOracle_;
+        baseAsset = baseAsset_;
+        stEth = stEth_;
+        wstEth = wstEth_;
+        ONE_SHARE = 10 ** uint256(shareDecimals_);
+        rateToleranceBps = rateToleranceBps_;
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Wires the NAV consistency check to every transaction touching the rate reporter.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertShareRateMatchesNav.selector);
+    }
+
+    /// @notice Checks the reported share rate against NAV recomputed from on-chain state.
+    /// @dev Triggered at transaction end, so every rate push (and any other mutation of the
+    ///      reporter) is validated in post-state. NAV counts idle base asset + idle stETH (at
+    ///      parity) + idle wstETH (at the Lido rate) + the net Aave-like position converted to
+    ///      base-asset terms, divided by total shares. A failure means the reporter holds a
+    ///      share price that on-chain state cannot support — in either direction, since a
+    ///      low-balled rate harms exiting holders too.
+    function assertShareRateMatchesNav() external view {
+        PhEvm.ForkId memory fork = _postTx();
+
+        uint256 supply = _readUintAt(shareToken, abi.encodeCall(IERC20Like.totalSupply, ()), fork);
+        if (supply == 0) {
+            return;
+        }
+
+        uint256 reportedRate = _readUintAt(rateSource, abi.encodeCall(IRateProviderLike.getRate, ()), fork);
+        uint256 navPerShare = ph.mulDivDown(_vaultNavInBaseAt(fork), ONE_SHARE, supply);
+        uint256 tolerance = ph.mulDivUp(navPerShare, rateToleranceBps, 10_000);
+
+        require(reportedRate <= navPerShare + tolerance, "LidoVault: reported rate above on-chain NAV");
+        require(reportedRate >= navPerShare - tolerance, "LidoVault: reported rate below on-chain NAV");
+    }
+
+    /// @notice Computes the vault's NAV in base-asset terms at a snapshot fork.
+    /// @dev Counts idle custody plus the net lending-market position. stETH is valued at parity
+    ///      with the base asset to match the usual stETH vault pricing convention; peg stress is
+    ///      the peg assertion's job, not this one's. Reverts when debt exceeds total assets —
+    ///      no positive rate is defensible for an insolvent book.
+    function _vaultNavInBaseAt(PhEvm.ForkId memory fork) internal view returns (uint256 nav) {
+        nav = _readBalanceAt(baseAsset, vault, fork) + _readBalanceAt(stEth, vault, fork);
+
+        uint256 wstEthBalance = _readBalanceAt(wstEth, vault, fork);
+        if (wstEthBalance != 0) {
+            uint256 lidoRate = _readUintAt(wstEth, abi.encodeCall(IWstETHLike.stEthPerToken, ()), fork);
+            nav += ph.mulDivDown(wstEthBalance, lidoRate, 1e18);
+        }
+
+        if (aavePool == address(0)) {
+            return nav;
+        }
+
+        (uint256 collateralBase, uint256 debtBase,) = _aaveAccountDataAt(aavePool, vault, fork);
+        if (collateralBase != 0 || debtBase != 0) {
+            uint256 basePrice =
+                _readUintAt(aaveOracle, abi.encodeCall(IAaveOracleLike.getAssetPrice, (baseAsset)), fork);
+            require(basePrice != 0, "LidoVault: zero base asset price");
+
+            uint256 collateralInBase = ph.mulDivDown(collateralBase, 1e18, basePrice);
+            uint256 debtInBase = ph.mulDivUp(debtBase, 1e18, basePrice);
+
+            nav += collateralInBase;
+            require(nav >= debtInBase, "LidoVault: vault book is insolvent");
+            nav -= debtInBase;
+        }
+    }
+}

--- a/examples/lido/src/LidoStEthVaultPegAssertion.sol
+++ b/examples/lido/src/LidoStEthVaultPegAssertion.sol
@@ -34,6 +34,10 @@ contract LidoStEthVaultPegAssertion is LidoVaultHelpers {
     /// @notice Max tolerated stETH/ETH deviation from peg, in bps, for entries and exits.
     uint256 public immutable maxEntryDepegBps;
 
+    /// @notice Max age, in seconds, the stETH/ETH feed answer may have before entries and exits are
+    ///         gated as a depeg (fails closed). Zero keeps only the round-integrity checks.
+    uint256 public immutable maxFeedStalenessSecs;
+
     /// @notice wstETH token, the source of Lido's protocol exchange rate.
     address public immutable wstEth;
 
@@ -48,6 +52,7 @@ contract LidoStEthVaultPegAssertion is LidoVaultHelpers {
         address stEthEthFeed_,
         uint8 stEthEthFeedDecimals_,
         uint256 maxEntryDepegBps_,
+        uint256 maxFeedStalenessSecs_,
         address wstEth_,
         address wstEthRateProvider_,
         uint256 maxProviderMismatchBps_
@@ -59,6 +64,7 @@ contract LidoStEthVaultPegAssertion is LidoVaultHelpers {
         stEthEthFeed = stEthEthFeed_;
         pegUnit = 10 ** uint256(stEthEthFeedDecimals_);
         maxEntryDepegBps = maxEntryDepegBps_;
+        maxFeedStalenessSecs = maxFeedStalenessSecs_;
         wstEth = wstEth_;
         wstEthRateProvider = wstEthRateProvider_;
         maxProviderMismatchBps = maxProviderMismatchBps_;
@@ -89,8 +95,8 @@ contract LidoStEthVaultPegAssertion is LidoVaultHelpers {
         }
 
         require(
-            !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, preFork)
-                && !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, postFork),
+            !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, maxFeedStalenessSecs, preFork)
+                && !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, maxFeedStalenessSecs, postFork),
             "LidoVault: stETH off peg, share pricing unsafe"
         );
     }

--- a/examples/lido/src/LidoStEthVaultPegAssertion.sol
+++ b/examples/lido/src/LidoStEthVaultPegAssertion.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {LidoVaultHelpers} from "./LidoVaultHelpers.sol";
+import {IERC20Like, IRateProviderLike, IWstETHLike} from "./LidoVaultInterfaces.sol";
+
+/// @title LidoStEthVaultPegAssertion
+/// @author Phylax Systems
+/// @notice Entry/exit pricing safety for a Lido stETH vault during peg stress.
+/// @dev Apply to the vault share token (or whichever contract mints and burns shares).
+///
+///      Most stETH vault stacks price stETH at parity with ETH and value wstETH purely from
+///      Lido's `stEthPerToken()` — no market price enters the share-pricing path. During a
+///      market depeg shares keep minting and burning at a fictional parity price, mispricing
+///      depositors and exiters against remaining holders. Instead of watching stack-specific
+///      deposit selectors, this assertion observes the share supply itself:
+///      - any transaction that changes share supply (a mint or burn through any path) reverts
+///        while the stETH/ETH market price is outside the peg band;
+///      - the wstETH pricing source must match Lido's protocol rate and must not decrease
+///        within a transaction (manipulation guard — `stEthPerToken` only drops on slashing).
+contract LidoStEthVaultPegAssertion is LidoVaultHelpers {
+    /// @notice Share token whose supply changes mark entries and exits.
+    address public immutable shareToken;
+
+    /// @notice Chainlink stETH/ETH market-price feed. Zero address disables depeg gating.
+    address public immutable stEthEthFeed;
+
+    /// @notice One unit of the stETH/ETH feed answer (10^feedDecimals).
+    uint256 public immutable pegUnit;
+
+    /// @notice Max tolerated stETH/ETH deviation from peg, in bps, for entries and exits.
+    uint256 public immutable maxEntryDepegBps;
+
+    /// @notice wstETH token, the source of Lido's protocol exchange rate.
+    address public immutable wstEth;
+
+    /// @notice Rate provider the vault uses to price wstETH. Zero disables the mismatch check.
+    address public immutable wstEthRateProvider;
+
+    /// @notice Max tolerated provider-vs-protocol rate mismatch in bps. Zero requires equality.
+    uint256 public immutable maxProviderMismatchBps;
+
+    constructor(
+        address shareToken_,
+        address stEthEthFeed_,
+        uint8 stEthEthFeedDecimals_,
+        uint256 maxEntryDepegBps_,
+        address wstEth_,
+        address wstEthRateProvider_,
+        uint256 maxProviderMismatchBps_
+    ) {
+        require(shareToken_ != address(0), "LidoVault: zero share token");
+        require(wstEth_ != address(0), "LidoVault: zero wstETH");
+
+        shareToken = shareToken_;
+        stEthEthFeed = stEthEthFeed_;
+        pegUnit = 10 ** uint256(stEthEthFeedDecimals_);
+        maxEntryDepegBps = maxEntryDepegBps_;
+        wstEth = wstEth_;
+        wstEthRateProvider = wstEthRateProvider_;
+        maxProviderMismatchBps = maxProviderMismatchBps_;
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Wires the supply-change depeg gate and the wstETH rate-integrity check.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertMintBurnPegSafety.selector);
+        registerTxEndTrigger(this.assertWstEthRateIntegrity.selector);
+    }
+
+    /// @notice Checks that shares are not minted or burned while stETH trades off peg.
+    /// @dev Triggered at transaction end. Watching the share supply instead of deposit/withdraw
+    ///      selectors covers every entry and exit path — tellers, queues, solvers, or direct
+    ///      mint/burn — on any vault stack. A failure means someone entered or exited the vault
+    ///      at a parity-marked share price during a market depeg.
+    function assertMintBurnPegSafety() external view {
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
+
+        uint256 preSupply = _readUintAt(shareToken, abi.encodeCall(IERC20Like.totalSupply, ()), preFork);
+        uint256 postSupply = _readUintAt(shareToken, abi.encodeCall(IERC20Like.totalSupply, ()), postFork);
+
+        if (preSupply == postSupply) {
+            return;
+        }
+
+        require(
+            !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, preFork)
+                && !_isStEthDepeggedAt(stEthEthFeed, pegUnit, maxEntryDepegBps, postFork),
+            "LidoVault: stETH off peg, share pricing unsafe"
+        );
+    }
+
+    /// @notice Checks the vault's wstETH pricing source against Lido's protocol rate.
+    /// @dev Triggered at transaction end. The provider rate must match `stEthPerToken()` within
+    ///      tolerance and must not decrease within the transaction — `stEthPerToken` only drops
+    ///      on slashing, never as a side effect of a vault interaction. A failure means the
+    ///      rate provider was substituted, manipulated, or desynced from the Lido rate while
+    ///      shares were being priced.
+    function assertWstEthRateIntegrity() external view {
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
+
+        uint256 preProtocolRate = _readUintAt(wstEth, abi.encodeCall(IWstETHLike.stEthPerToken, ()), preFork);
+        uint256 postProtocolRate = _readUintAt(wstEth, abi.encodeCall(IWstETHLike.stEthPerToken, ()), postFork);
+
+        require(postProtocolRate >= preProtocolRate, "LidoVault: wstETH rate decreased in transaction");
+        require(postProtocolRate != 0, "LidoVault: zero protocol rate");
+
+        if (wstEthRateProvider == address(0)) {
+            return;
+        }
+
+        uint256 providerRate = _readUintAt(wstEthRateProvider, abi.encodeCall(IRateProviderLike.getRate, ()), postFork);
+        uint256 mismatch =
+            providerRate > postProtocolRate ? providerRate - postProtocolRate : postProtocolRate - providerRate;
+        require(
+            mismatch * 10_000 <= postProtocolRate * maxProviderMismatchBps,
+            "LidoVault: rate provider desynced from Lido rate"
+        );
+    }
+}

--- a/examples/lido/src/LidoStEthVaultRiskAssertion.sol
+++ b/examples/lido/src/LidoStEthVaultRiskAssertion.sol
@@ -46,6 +46,10 @@ contract LidoStEthVaultRiskAssertion is LidoVaultHelpers {
     /// @notice Max tolerated stETH/ETH deviation from peg, in bps, before reduce-only mode.
     uint256 public immutable maxDepegBps;
 
+    /// @notice Max age, in seconds, the stETH/ETH feed answer may have before it is treated as a
+    ///         depeg (fails closed into reduce-only). Zero keeps only the round-integrity checks.
+    uint256 public immutable maxFeedStalenessSecs;
+
     /// @notice Share-pricing rate source; unreadable rate forces reduce-only. Zero disables.
     address public immutable rateSource;
 
@@ -92,6 +96,7 @@ contract LidoStEthVaultRiskAssertion is LidoVaultHelpers {
         address stEthEthFeed;
         uint8 stEthEthFeedDecimals;
         uint256 maxDepegBps;
+        uint256 maxFeedStalenessSecs;
         address rateSource;
         address borrowedAsset;
         address borrowedAssetReserve;
@@ -111,26 +116,23 @@ contract LidoStEthVaultRiskAssertion is LidoVaultHelpers {
         require(config.aavePool != address(0), "LidoVault: zero pool");
         require(config.minHealthFactor >= 1e18, "LidoVault: floor below liquidation");
         require(config.reduceOnlyHealthFactor >= config.minHealthFactor, "LidoVault: band below floor");
-        require(
-            config.minExitLiquidityBps == 0
-                || (config.borrowedAsset != address(0)
-                    && config.borrowedAssetReserve != address(0)
-                    && config.borrowedAssetDebtToken != address(0)),
-            "LidoVault: zero exit-liquidity token"
-        );
-        require(
-            config.minCollateralLiquidityBps == 0
-                || (config.collateralAsset != address(0)
-                    && config.collateralAssetReserve != address(0)
-                    && config.collateralAssetSupplyToken != address(0)),
-            "LidoVault: zero collateral-liquidity token"
-        );
+        if (config.minExitLiquidityBps != 0) {
+            require(config.borrowedAsset != address(0), "LidoVault: zero borrowed asset");
+            require(config.borrowedAssetReserve != address(0), "LidoVault: zero borrowed reserve");
+            require(config.borrowedAssetDebtToken != address(0), "LidoVault: zero borrowed debt token");
+        }
+        if (config.minCollateralLiquidityBps != 0) {
+            require(config.collateralAsset != address(0), "LidoVault: zero collateral asset");
+            require(config.collateralAssetReserve != address(0), "LidoVault: zero collateral reserve");
+            require(config.collateralAssetSupplyToken != address(0), "LidoVault: zero collateral supply token");
+        }
 
         vault = config.vault;
         aavePool = config.aavePool;
         stEthEthFeed = config.stEthEthFeed;
         pegUnit = 10 ** uint256(config.stEthEthFeedDecimals);
         maxDepegBps = config.maxDepegBps;
+        maxFeedStalenessSecs = config.maxFeedStalenessSecs;
         rateSource = config.rateSource;
         borrowedAsset = config.borrowedAsset;
         borrowedAssetReserve = config.borrowedAssetReserve;
@@ -175,8 +177,8 @@ contract LidoStEthVaultRiskAssertion is LidoVaultHelpers {
         (, uint256 postDebt, uint256 postHf) = _aaveAccountDataAt(aavePool, vault, postFork);
 
         bool unhealthy = preDebt != 0 && preHf < reduceOnlyHealthFactor;
-        bool shaky =
-            _isStEthDepeggedAt(stEthEthFeed, pegUnit, maxDepegBps, preFork) || !_canReadRateAt(rateSource, preFork);
+        bool shaky = _isStEthDepeggedAt(stEthEthFeed, pegUnit, maxDepegBps, maxFeedStalenessSecs, preFork)
+            || !_canReadRateAt(rateSource, preFork);
         bool illiquid = _collateralIlliquidAt(preFork);
 
         if (unhealthy || shaky || illiquid) {

--- a/examples/lido/src/LidoStEthVaultRiskAssertion.sol
+++ b/examples/lido/src/LidoStEthVaultRiskAssertion.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {LidoVaultHelpers} from "./LidoVaultHelpers.sol";
+
+/// @title LidoStEthVaultRiskAssertion
+/// @author Phylax Systems
+/// @notice Position risk policy for a Lido stETH vault looping through an Aave v3-like market.
+/// @dev Apply to the contract whose transactions move the vault's position — the vault itself,
+///      or its manager/strategy executor when allocations run through a separate contract.
+///
+///      Lending-market whitelists and vault permission systems constrain WHICH calls a strategist
+///      may make; nothing on-chain constrains the STATE those calls are made into. This assertion
+///      adds that layer, entirely at transaction boundaries so it works on any vault stack:
+///      - reduce-only regime: when the position is already below the comfort band, stETH trades
+///        off peg, or the share-pricing source cannot report a rate, a transaction may not grow
+///        debt or lower the health factor;
+///      - exit-liquidity guard: a transaction that grows debt must leave the borrowed reserve
+///        liquid enough for the vault to unwind (market-health check at allocation time);
+///      - collateral withdrawability guard: a transaction that deepens the supplied position
+///        must leave the collateral reserve holding enough un-borrowed collateral for the
+///        vault to pull its stETH back out on demand, and an already-illiquid collateral
+///        reserve forces the same reduce-only regime as a depeg;
+///      - position envelope: the health factor ends every transaction above a hard floor, may
+///        only decline while staying inside the comfort band, and the raw collateral/debt
+///        ratio holds a minimum.
+///
+///      Together these are what justify running the vault with thinner idle buffers: every
+///      allocation carries an on-chain proof, at execution time, that it can be unwound.
+contract LidoStEthVaultRiskAssertion is LidoVaultHelpers {
+    /// @notice Account holding the lending-market position (the vault's custody address).
+    address public immutable vault;
+
+    /// @notice Aave v3-like pool holding the vault's looped position.
+    address public immutable aavePool;
+
+    /// @notice Chainlink stETH/ETH market-price feed. Zero address disables depeg detection.
+    address public immutable stEthEthFeed;
+
+    /// @notice One unit of the stETH/ETH feed answer (10^feedDecimals).
+    uint256 public immutable pegUnit;
+
+    /// @notice Max tolerated stETH/ETH deviation from peg, in bps, before reduce-only mode.
+    uint256 public immutable maxDepegBps;
+
+    /// @notice Share-pricing rate source; unreadable rate forces reduce-only. Zero disables.
+    address public immutable rateSource;
+
+    /// @notice Asset of the vault's borrowed leg. Zero disables the exit-liquidity guard.
+    address public immutable borrowedAsset;
+
+    /// @notice Reserve custody of the borrowed asset (e.g. the aToken); its underlying balance
+    ///         is the liquidity available for the vault to unwind against.
+    address public immutable borrowedAssetReserve;
+
+    /// @notice Debt token tracking the vault's borrowed amount (e.g. the variable-debt token).
+    address public immutable borrowedAssetDebtToken;
+
+    /// @notice Asset supplied as collateral (e.g. wstETH). Zero disables the withdrawability guard.
+    address public immutable collateralAsset;
+
+    /// @notice Reserve custody of the collateral asset; its underlying balance is the
+    ///         un-borrowed collateral available for the vault to withdraw (for Aave, the aToken).
+    address public immutable collateralAssetReserve;
+
+    /// @notice Receipt token tracking the vault's supplied collateral (for Aave, also the aToken).
+    address public immutable collateralAssetSupplyToken;
+
+    /// @notice Hard health-factor floor the vault may never end a transaction below (1e18 scale).
+    uint256 public immutable minHealthFactor;
+
+    /// @notice Comfort band: below this health factor the position is reduce-only (1e18 scale).
+    uint256 public immutable reduceOnlyHealthFactor;
+
+    /// @notice Minimum collateral/debt ratio in bps of 1e4 (e.g. 10_500 = 1.05x). Zero disables.
+    uint256 public immutable minCollateralRatioBps;
+
+    /// @notice Required reserve liquidity for new debt, in bps of the vault's debt. Zero disables.
+    uint256 public immutable minExitLiquidityBps;
+
+    /// @notice Required withdrawable collateral, in bps of the vault's supplied collateral.
+    ///         Zero disables the withdrawability guard.
+    uint256 public immutable minCollateralLiquidityBps;
+
+    /// @notice Deployment configuration; see the matching immutables for field semantics.
+    struct RiskConfig {
+        address vault;
+        address aavePool;
+        address stEthEthFeed;
+        uint8 stEthEthFeedDecimals;
+        uint256 maxDepegBps;
+        address rateSource;
+        address borrowedAsset;
+        address borrowedAssetReserve;
+        address borrowedAssetDebtToken;
+        address collateralAsset;
+        address collateralAssetReserve;
+        address collateralAssetSupplyToken;
+        uint256 minHealthFactor;
+        uint256 reduceOnlyHealthFactor;
+        uint256 minCollateralRatioBps;
+        uint256 minExitLiquidityBps;
+        uint256 minCollateralLiquidityBps;
+    }
+
+    constructor(RiskConfig memory config) {
+        require(config.vault != address(0), "LidoVault: zero vault");
+        require(config.aavePool != address(0), "LidoVault: zero pool");
+        require(config.minHealthFactor >= 1e18, "LidoVault: floor below liquidation");
+        require(config.reduceOnlyHealthFactor >= config.minHealthFactor, "LidoVault: band below floor");
+        require(
+            config.minExitLiquidityBps == 0
+                || (config.borrowedAsset != address(0)
+                    && config.borrowedAssetReserve != address(0)
+                    && config.borrowedAssetDebtToken != address(0)),
+            "LidoVault: zero exit-liquidity token"
+        );
+        require(
+            config.minCollateralLiquidityBps == 0
+                || (config.collateralAsset != address(0)
+                    && config.collateralAssetReserve != address(0)
+                    && config.collateralAssetSupplyToken != address(0)),
+            "LidoVault: zero collateral-liquidity token"
+        );
+
+        vault = config.vault;
+        aavePool = config.aavePool;
+        stEthEthFeed = config.stEthEthFeed;
+        pegUnit = 10 ** uint256(config.stEthEthFeedDecimals);
+        maxDepegBps = config.maxDepegBps;
+        rateSource = config.rateSource;
+        borrowedAsset = config.borrowedAsset;
+        borrowedAssetReserve = config.borrowedAssetReserve;
+        borrowedAssetDebtToken = config.borrowedAssetDebtToken;
+        collateralAsset = config.collateralAsset;
+        collateralAssetReserve = config.collateralAssetReserve;
+        collateralAssetSupplyToken = config.collateralAssetSupplyToken;
+        minHealthFactor = config.minHealthFactor;
+        reduceOnlyHealthFactor = config.reduceOnlyHealthFactor;
+        minCollateralRatioBps = config.minCollateralRatioBps;
+        minExitLiquidityBps = config.minExitLiquidityBps;
+        minCollateralLiquidityBps = config.minCollateralLiquidityBps;
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Wires the tx-wide risk regime and position envelope checks.
+    function triggers() external view override {
+        registerTxEndTrigger(this.assertRiskRegime.selector);
+        registerTxEndTrigger(this.assertPositionEnvelope.selector);
+    }
+
+    /// @notice Checks that risk only grows in a healthy position under trustworthy pricing
+    ///         and that every position deepening keeps the collateral withdrawable on demand.
+    /// @dev Triggered at transaction end. Reduce-only mode is entered when the pre-transaction
+    ///      health factor sits below the comfort band, the stETH/ETH market price has left the
+    ///      peg band, the rate source cannot price shares, or the collateral reserve no longer
+    ///      holds enough un-borrowed collateral for the vault to withdraw. In that regime debt
+    ///      must not grow and the health factor must not decline; when the trigger is market
+    ///      conditions (shaky pricing or illiquid collateral) rather than the vault's own
+    ///      health, the supplied collateral may not grow either — supplying more into a market
+    ///      the vault might not get back out of is itself risky behaviour. Independently, any
+    ///      transaction that grows debt must leave the borrowed reserve liquid enough to
+    ///      unwind, and any transaction that deepens the supplied position must leave the
+    ///      collateral reserve liquid enough to withdraw it. A failure means new risk was
+    ///      added into an unhealthy position, a shaky oracle regime, or an illiquid market.
+    function assertRiskRegime() external view {
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
+
+        (, uint256 preDebt, uint256 preHf) = _aaveAccountDataAt(aavePool, vault, preFork);
+        (, uint256 postDebt, uint256 postHf) = _aaveAccountDataAt(aavePool, vault, postFork);
+
+        bool unhealthy = preDebt != 0 && preHf < reduceOnlyHealthFactor;
+        bool shaky =
+            _isStEthDepeggedAt(stEthEthFeed, pegUnit, maxDepegBps, preFork) || !_canReadRateAt(rateSource, preFork);
+        bool illiquid = _collateralIlliquidAt(preFork);
+
+        if (unhealthy || shaky || illiquid) {
+            require(postDebt <= preDebt, "LidoVault: reduce-only regime, debt increased");
+            if (postDebt != 0) {
+                require(postHf >= preHf, "LidoVault: reduce-only regime, health factor declined");
+            }
+        }
+
+        uint256 preSupplied;
+        uint256 postSupplied;
+        if (collateralAssetSupplyToken != address(0)) {
+            preSupplied = _readBalanceAt(collateralAssetSupplyToken, vault, preFork);
+            postSupplied = _readBalanceAt(collateralAssetSupplyToken, vault, postFork);
+        }
+
+        if (shaky || illiquid) {
+            require(postSupplied <= preSupplied, "LidoVault: reduce-only regime, collateral exposure increased");
+        }
+
+        if (minExitLiquidityBps != 0 && postDebt > preDebt) {
+            uint256 vaultDebt = _readBalanceAt(borrowedAssetDebtToken, vault, postFork);
+            uint256 reserveLiquidity = _readBalanceAt(borrowedAsset, borrowedAssetReserve, postFork);
+            require(
+                reserveLiquidity >= ph.mulDivUp(vaultDebt, minExitLiquidityBps, 10_000),
+                "LidoVault: insufficient exit liquidity for new debt"
+            );
+        }
+
+        if (minCollateralLiquidityBps != 0 && postSupplied > preSupplied) {
+            uint256 withdrawable = _readBalanceAt(collateralAsset, collateralAssetReserve, postFork);
+            require(
+                withdrawable >= ph.mulDivUp(postSupplied, minCollateralLiquidityBps, 10_000),
+                "LidoVault: collateral not withdrawable on demand"
+            );
+        }
+    }
+
+    /// @notice Returns whether the collateral reserve can no longer cover the vault's exit.
+    /// @dev Compares the reserve's un-borrowed collateral against the configured fraction of
+    ///      what the vault has supplied. Disabled (always liquid) when unconfigured or when
+    ///      the vault has no supplied position.
+    function _collateralIlliquidAt(PhEvm.ForkId memory fork) internal view returns (bool) {
+        if (minCollateralLiquidityBps == 0) {
+            return false;
+        }
+
+        uint256 supplied = _readBalanceAt(collateralAssetSupplyToken, vault, fork);
+        if (supplied == 0) {
+            return false;
+        }
+
+        uint256 withdrawable = _readBalanceAt(collateralAsset, collateralAssetReserve, fork);
+        return withdrawable < ph.mulDivUp(supplied, minCollateralLiquidityBps, 10_000);
+    }
+
+    /// @notice Checks the vault's position envelope after every transaction.
+    /// @dev Triggered at transaction end. The health factor must end above the hard floor, may
+    ///      only decline while remaining inside the comfort band, and the raw collateral/debt
+    ///      ratio must hold its minimum. A failure means the transaction left the looped
+    ///      position closer to liquidation than the configured policy allows.
+    function assertPositionEnvelope() external view {
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
+
+        (,, uint256 preHf) = _aaveAccountDataAt(aavePool, vault, preFork);
+        (uint256 postCollateral, uint256 postDebt, uint256 postHf) = _aaveAccountDataAt(aavePool, vault, postFork);
+
+        if (postDebt == 0) {
+            return;
+        }
+
+        require(postHf >= minHealthFactor, "LidoVault: health factor below floor");
+
+        if (postHf < preHf) {
+            require(postHf >= reduceOnlyHealthFactor, "LidoVault: health factor declined below comfort band");
+        }
+
+        if (minCollateralRatioBps != 0) {
+            require(
+                ph.ratioGe(postCollateral, postDebt, minCollateralRatioBps, 10_000, 0),
+                "LidoVault: collateral ratio below minimum"
+            );
+        }
+    }
+}

--- a/examples/lido/src/LidoVaultHelpers.sol
+++ b/examples/lido/src/LidoVaultHelpers.sol
@@ -28,25 +28,37 @@ abstract contract LidoVaultHelpers is Assertion {
     }
 
     /// @notice Returns whether the stETH/ETH market price has left the configured peg band.
-    /// @dev A zero feed address disables the check. An unreadable feed or non-positive answer
-    ///      counts as depegged so the protected paths fail closed.
-    function _isStEthDepeggedAt(address feed, uint256 pegUnit, uint256 maxDepegBps, PhEvm.ForkId memory fork)
-        internal
-        view
-        returns (bool)
-    {
+    /// @dev A zero feed address disables the check. The check fails closed — treats the price as
+    ///      depegged — whenever the feed cannot be trusted to report a live, on-peg answer:
+    ///      an unreadable or malformed feed, a non-positive answer, an incomplete round
+    ///      (`updatedAt == 0`), a carried-over stale answer (`answeredInRound < roundId`), or an
+    ///      answer older than `maxStaleness` seconds. Without this an oracle outage would leave a
+    ///      stale on-peg price in place and keep the depeg-gated paths (risk allocation, share
+    ///      mint/burn) open during exactly the conditions they exist to block. A zero
+    ///      `maxStaleness` disables only the age bound; the round-integrity checks always apply.
+    function _isStEthDepeggedAt(
+        address feed,
+        uint256 pegUnit,
+        uint256 maxDepegBps,
+        uint256 maxStaleness,
+        PhEvm.ForkId memory fork
+    ) internal view returns (bool) {
         if (feed == address(0)) {
             return false;
         }
 
         PhEvm.StaticCallResult memory result =
             ph.staticcallAt(feed, abi.encodeCall(IChainlinkFeedLike.latestRoundData, ()), FORK_VIEW_GAS, fork);
-        if (!result.ok) {
+        if (!result.ok || result.data.length < 160) {
             return true;
         }
 
-        (, int256 answer,,,) = abi.decode(result.data, (uint80, int256, uint256, uint256, uint80));
-        if (answer <= 0) {
+        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
+            abi.decode(result.data, (uint80, int256, uint256, uint256, uint80));
+        if (answer <= 0 || updatedAt == 0 || answeredInRound < roundId) {
+            return true;
+        }
+        if (maxStaleness != 0 && block.timestamp > updatedAt && block.timestamp - updatedAt > maxStaleness) {
             return true;
         }
 

--- a/examples/lido/src/LidoVaultHelpers.sol
+++ b/examples/lido/src/LidoVaultHelpers.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+import {IAaveV3PoolLike, IChainlinkFeedLike, IRateProviderLike} from "./LidoVaultInterfaces.sol";
+
+/// @title LidoVaultHelpers
+/// @author Phylax Systems
+/// @notice Shared fork-aware state accessors for Lido stETH vault example assertions.
+/// @dev Written against the generic shape of a Lido stETH vault: a contract custodying
+///      stETH/wstETH that allocates into an Aave v3-like lending market and prices its
+///      shares through some rate source. Nothing here depends on a specific vault stack.
+abstract contract LidoVaultHelpers is Assertion {
+    /// @notice Reads a vault's aggregate Aave v3-like position at a snapshot fork.
+    /// @dev Collateral and debt are denominated in the market base currency (USD, 8 decimals on
+    ///      mainnet Aave). The health factor is 1e18-scaled and `type(uint256).max` without debt.
+    function _aaveAccountDataAt(address pool, address account, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256 collateralBase, uint256 debtBase, uint256 healthFactor)
+    {
+        (collateralBase, debtBase,,,, healthFactor) = abi.decode(
+            _viewAt(pool, abi.encodeCall(IAaveV3PoolLike.getUserAccountData, (account)), fork),
+            (uint256, uint256, uint256, uint256, uint256, uint256)
+        );
+    }
+
+    /// @notice Returns whether the stETH/ETH market price has left the configured peg band.
+    /// @dev A zero feed address disables the check. An unreadable feed or non-positive answer
+    ///      counts as depegged so the protected paths fail closed.
+    function _isStEthDepeggedAt(address feed, uint256 pegUnit, uint256 maxDepegBps, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (bool)
+    {
+        if (feed == address(0)) {
+            return false;
+        }
+
+        PhEvm.StaticCallResult memory result =
+            ph.staticcallAt(feed, abi.encodeCall(IChainlinkFeedLike.latestRoundData, ()), FORK_VIEW_GAS, fork);
+        if (!result.ok) {
+            return true;
+        }
+
+        (, int256 answer,,,) = abi.decode(result.data, (uint80, int256, uint256, uint256, uint80));
+        if (answer <= 0) {
+            return true;
+        }
+
+        uint256 price = uint256(answer);
+        uint256 deviation = price > pegUnit ? price - pegUnit : pegUnit - price;
+        return deviation * 10_000 > pegUnit * maxDepegBps;
+    }
+
+    /// @notice Returns whether a share/asset rate source can currently report a rate.
+    /// @dev A zero source address counts as readable (signal disabled). A reverting or
+    ///      zero-rate source means share pricing is not trustworthy — paused accountants and
+    ///      stale oracles surface exactly this way — so risk-adding paths should fail closed.
+    function _canReadRateAt(address rateSource, PhEvm.ForkId memory fork) internal view returns (bool) {
+        if (rateSource == address(0)) {
+            return true;
+        }
+
+        PhEvm.StaticCallResult memory result =
+            ph.staticcallAt(rateSource, abi.encodeCall(IRateProviderLike.getRate, ()), FORK_VIEW_GAS, fork);
+        if (!result.ok || result.data.length < 32) {
+            return false;
+        }
+
+        return abi.decode(result.data, (uint256)) != 0;
+    }
+}

--- a/examples/lido/src/LidoVaultInterfaces.sol
+++ b/examples/lido/src/LidoVaultInterfaces.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @notice Minimal Aave v3-like pool surface used for vault position health reads.
+interface IAaveV3PoolLike {
+    function getUserAccountData(address user)
+        external
+        view
+        returns (
+            uint256 totalCollateralBase,
+            uint256 totalDebtBase,
+            uint256 availableBorrowsBase,
+            uint256 currentLiquidationThreshold,
+            uint256 ltv,
+            uint256 healthFactor
+        );
+}
+
+/// @notice Minimal Aave v3-like oracle surface used to convert base-currency values.
+interface IAaveOracleLike {
+    function getAssetPrice(address asset) external view returns (uint256 price);
+}
+
+/// @notice Minimal Chainlink aggregator surface used for stETH/ETH market-price reads.
+interface IChainlinkFeedLike {
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/// @notice Minimal wstETH surface used to read the Lido protocol exchange rate.
+interface IWstETHLike {
+    function stEthPerToken() external view returns (uint256 rate);
+}
+
+/// @notice Generic share/asset rate source surface (`getRate()` returning base per share/unit).
+/// @dev Matches Balancer-style rate providers, Veda accountants, and Mellow-style oracles alike.
+interface IRateProviderLike {
+    function getRate() external view returns (uint256 rate);
+}
+
+/// @notice Minimal ERC-20 surface used by supply and NAV reads.
+interface IERC20Like {
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/examples/lido/test/LidoMocks.sol
+++ b/examples/lido/test/LidoMocks.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice Minimal ERC20 with cheat helpers (`setBalance`, `mint`, `burn`) so a single armed
+///         transaction can drive any pre/post balance the Lido assertions read.
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
+    }
+
+    function mint(address to, uint256 amount) public {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function burn(address from, uint256 amount) public {
+        balanceOf[from] -= amount;
+        totalSupply -= amount;
+    }
+
+    /// @dev Overwrites a balance and keeps `totalSupply` consistent.
+    function setBalance(address account, uint256 amount) public {
+        totalSupply = totalSupply - balanceOf[account] + amount;
+        balanceOf[account] = amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+    }
+}
+
+/// @notice wstETH stand-in: an ERC20 that also reports Lido's `stEthPerToken()` rate.
+contract MockWstETH is MockERC20 {
+    uint256 public rate = 1e18;
+
+    constructor() MockERC20("Wrapped stETH", "wstETH", 18) {}
+
+    function setRate(uint256 rate_) external {
+        rate = rate_;
+    }
+
+    function stEthPerToken() external view returns (uint256) {
+        return rate;
+    }
+}
+
+/// @notice Chainlink aggregator stand-in with fully settable round data so the staleness and
+///         round-integrity paths can be exercised directly.
+contract MockChainlinkFeed {
+    uint80 public roundId = 1;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound = 1;
+
+    constructor(int256 answer_, uint256 updatedAt_) {
+        answer = answer_;
+        startedAt = updatedAt_;
+        updatedAt = updatedAt_;
+    }
+
+    function setAnswer(int256 answer_) external {
+        answer = answer_;
+    }
+
+    function setUpdatedAt(uint256 updatedAt_) external {
+        updatedAt = updatedAt_;
+    }
+
+    function setRound(uint80 roundId_, int256 answer_, uint256 updatedAt_, uint80 answeredInRound_) external {
+        roundId = roundId_;
+        answer = answer_;
+        startedAt = updatedAt_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}
+
+/// @notice Generic `getRate()` source (Veda accountant / Balancer-style provider / Mellow oracle).
+contract MockRateSource {
+    uint256 public rate;
+    bool public reverts;
+
+    constructor(uint256 rate_) {
+        rate = rate_;
+    }
+
+    function setRate(uint256 rate_) external {
+        rate = rate_;
+    }
+
+    function setReverts(bool reverts_) external {
+        reverts = reverts_;
+    }
+
+    function getRate() external view returns (uint256) {
+        require(!reverts, "MockRate: unavailable");
+        return rate;
+    }
+}
+
+/// @notice Aave v3-like pool stand-in tracking one account's position.
+contract MockAavePool {
+    struct Account {
+        uint256 collateralBase;
+        uint256 debtBase;
+        uint256 healthFactor;
+    }
+
+    mapping(address => Account) internal account;
+
+    function setAccount(address user, uint256 collateralBase, uint256 debtBase, uint256 healthFactor) external {
+        account[user] = Account(collateralBase, debtBase, healthFactor);
+    }
+
+    function getUserAccountData(address user)
+        external
+        view
+        returns (uint256, uint256, uint256, uint256, uint256, uint256)
+    {
+        Account memory a = account[user];
+        uint256 hf = a.debtBase == 0 ? type(uint256).max : a.healthFactor;
+        return (a.collateralBase, a.debtBase, 0, 0, 0, hf);
+    }
+}
+
+/// @notice Aave v3-like oracle stand-in returning a configurable per-asset price.
+contract MockAaveOracle {
+    mapping(address => uint256) public priceOf;
+
+    function setPrice(address asset, uint256 price) external {
+        priceOf[asset] = price;
+    }
+
+    function getAssetPrice(address asset) external view returns (uint256) {
+        return priceOf[asset];
+    }
+}
+
+/// @notice Universal vault/strategy-executor adopter. As the assertion's `vault` account it holds
+///         the position and balances; its mutators let a single armed transaction move the state
+///         the risk and exit-buffer assertions read at the transaction boundary.
+contract MockLidoVault {
+    function setPosition(MockAavePool pool, uint256 collateralBase, uint256 debtBase, uint256 healthFactor) public {
+        pool.setAccount(address(this), collateralBase, debtBase, healthFactor);
+    }
+
+    function setSupplied(MockERC20 supplyToken, uint256 amount) public {
+        supplyToken.setBalance(address(this), amount);
+    }
+
+    function setSelfDebt(MockERC20 debtToken, uint256 amount) public {
+        debtToken.setBalance(address(this), amount);
+    }
+
+    /// @dev Grow the position and the vault's tracked debt token balance in one transaction.
+    function borrowMore(
+        MockAavePool pool,
+        uint256 collateralBase,
+        uint256 debtBase,
+        uint256 healthFactor,
+        MockERC20 debtToken,
+        uint256 vaultDebt
+    ) external {
+        setPosition(pool, collateralBase, debtBase, healthFactor);
+        setSelfDebt(debtToken, vaultDebt);
+    }
+
+    function transferOut(MockERC20 token, address to, uint256 amount) external {
+        token.transfer(to, amount);
+    }
+}
+
+/// @notice Share-token adopter for the peg assertion. Supply changes (mint/burn) mark entries and
+///         exits; the poke helpers let a transaction touching the share token also move the wstETH
+///         rate / provider so the rate-integrity check can be exercised.
+contract MockShareToken is MockERC20 {
+    constructor() MockERC20("Lido Vault Share", "lvSHARE", 18) {}
+
+    function setWstEthRate(MockWstETH wstEth, uint256 rate) external {
+        wstEth.setRate(rate);
+    }
+
+    function setProviderRate(MockRateSource provider, uint256 rate) external {
+        provider.setRate(rate);
+    }
+}

--- a/examples/lido/test/LidoStEthExitBufferAssertion.t.sol
+++ b/examples/lido/test/LidoStEthExitBufferAssertion.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LidoStEthExitBufferAssertion} from "../src/LidoStEthExitBufferAssertion.sol";
+import {MockERC20, MockWstETH, MockLidoVault} from "./LidoMocks.sol";
+
+contract LidoStEthExitBufferAssertionTest is Test, CredibleTest {
+    MockLidoVault internal vault;
+    MockERC20 internal stEth;
+    MockWstETH internal wstEth;
+    MockERC20 internal receipt; // deployed stETH-equivalent receipt (e.g. Aave awstETH)
+
+    address internal sink = makeAddr("sink");
+
+    function setUp() public {
+        vault = new MockLidoVault();
+        stEth = new MockERC20("Lido stETH", "stETH", 18);
+        wstEth = new MockWstETH();
+        receipt = new MockERC20("Aave wstETH", "awstETH", 18);
+    }
+
+    function _arm(
+        bytes4 sel,
+        uint256 minIdleStEthEq,
+        uint256 minBufferBps,
+        uint256 outflowThresholdBps,
+        uint256 outflowWindowDuration
+    ) internal {
+        bytes memory createData = abi.encodePacked(
+            type(LidoStEthExitBufferAssertion).creationCode,
+            abi.encode(
+                address(vault),
+                address(stEth),
+                address(wstEth),
+                address(receipt),
+                minIdleStEthEq,
+                minBufferBps,
+                outflowThresholdBps,
+                outflowWindowDuration
+            )
+        );
+        cl.assertion(address(vault), createData, sel);
+    }
+
+    // --- Buffer floor ------------------------------------------------------
+
+    function testBufferFloorPassesAboveFloor() public {
+        // idle 10 + deployed 90 = 100 total; 5% floor = 5. After moving 1 out, idle 9 >= ~5.
+        stEth.setBalance(address(vault), 10 ether);
+        receipt.setBalance(address(vault), 90 ether);
+        _arm(LidoStEthExitBufferAssertion.assertWithdrawableBufferFloor.selector, 0, 500, 0, 0);
+
+        vault.transferOut(stEth, sink, 1 ether);
+    }
+
+    function testBufferFloorTripsBelowRelativeFloor() public {
+        // idle 5 + deployed 95 = 100 total; 5% floor = 5. Moving 1 out drops idle to 4 < 5.
+        stEth.setBalance(address(vault), 5 ether);
+        receipt.setBalance(address(vault), 95 ether);
+        _arm(LidoStEthExitBufferAssertion.assertWithdrawableBufferFloor.selector, 0, 500, 0, 0);
+
+        vm.expectRevert(bytes("LidoVault: withdrawable stETH buffer below floor"));
+        vault.transferOut(stEth, sink, 1 ether);
+    }
+
+    function testBufferFloorTripsBelowAbsoluteFloor() public {
+        // Absolute floor of 8 stETH (bps disabled). Total stays > 8, so the floor is not capped.
+        stEth.setBalance(address(vault), 10 ether);
+        receipt.setBalance(address(vault), 90 ether);
+        _arm(LidoStEthExitBufferAssertion.assertWithdrawableBufferFloor.selector, 8 ether, 0, 0, 0);
+
+        vm.expectRevert(bytes("LidoVault: withdrawable stETH buffer below floor"));
+        vault.transferOut(stEth, sink, 3 ether); // idle 7 < 8
+    }
+
+    function testBufferFloorCountsWstEthAtLidoRate() public {
+        // wstETH valued at 1.2 stEthPerToken: idle = 6 wstETH * 1.2 = 7.2 stETH-eq, below the 8 floor.
+        wstEth.setRate(1.2e18);
+        wstEth.setBalance(address(vault), 6 ether);
+        receipt.setBalance(address(vault), 90 ether);
+        _arm(LidoStEthExitBufferAssertion.assertWithdrawableBufferFloor.selector, 8 ether, 0, 0, 0);
+
+        // Touch the vault without changing balances; the 7.2 stETH-eq idle is already below floor.
+        vm.expectRevert(bytes("LidoVault: withdrawable stETH buffer below floor"));
+        vault.transferOut(stEth, sink, 0);
+    }
+
+    function testBufferFloorPassesWhenVaultHoldsNothing() public {
+        // No stETH at all: nothing to reserve, draining the last of it is the breaker's job.
+        _arm(LidoStEthExitBufferAssertion.assertWithdrawableBufferFloor.selector, 1 ether, 500, 0, 0);
+
+        vault.transferOut(stEth, sink, 0);
+    }
+
+    // --- Outflow circuit breaker ------------------------------------------
+
+    /// @dev The `watchCumulativeOutflow` trigger that fires `assertOutflowWithinLimit` live is driven
+    ///      by the executor's rolling-window accounting and is not simulated by local `pcl test`, so
+    ///      the breaker's hard-revert decision is validated by calling it directly rather than via an
+    ///      armed `cl.assertion` transaction.
+    function testOutflowBreakerRevertsWhenInvoked() public {
+        LidoStEthExitBufferAssertion assertion = new LidoStEthExitBufferAssertion(
+            address(vault), address(stEth), address(wstEth), address(receipt), 0, 0, 5_000, 1 days
+        );
+        vm.expectRevert(bytes("LidoVault: stETH outflow circuit breaker tripped"));
+        assertion.assertOutflowWithinLimit();
+    }
+
+    // --- Constructor wiring ------------------------------------------------
+
+    function testRejectsZeroVault() public {
+        vm.expectRevert(bytes("LidoVault: zero vault"));
+        new LidoStEthExitBufferAssertion(address(0), address(stEth), address(wstEth), address(0), 0, 500, 0, 0);
+    }
+
+    function testRejectsZeroStEth() public {
+        vm.expectRevert(bytes("LidoVault: zero stETH"));
+        new LidoStEthExitBufferAssertion(address(vault), address(0), address(wstEth), address(0), 0, 500, 0, 0);
+    }
+
+    function testRejectsZeroWstEth() public {
+        vm.expectRevert(bytes("LidoVault: zero wstETH"));
+        new LidoStEthExitBufferAssertion(address(vault), address(stEth), address(0), address(0), 0, 500, 0, 0);
+    }
+
+    function testRejectsBufferBpsTooLarge() public {
+        vm.expectRevert(bytes("LidoVault: buffer bps too large"));
+        new LidoStEthExitBufferAssertion(address(vault), address(stEth), address(wstEth), address(0), 0, 10_001, 0, 0);
+    }
+
+    function testRejectsOutflowBpsTooLarge() public {
+        vm.expectRevert(bytes("LidoVault: outflow bps too large"));
+        new LidoStEthExitBufferAssertion(
+            address(vault), address(stEth), address(wstEth), address(0), 0, 0, 10_001, 1 days
+        );
+    }
+
+    function testRejectsZeroOutflowWindow() public {
+        vm.expectRevert(bytes("LidoVault: zero outflow window"));
+        new LidoStEthExitBufferAssertion(address(vault), address(stEth), address(wstEth), address(0), 0, 0, 5_000, 0);
+    }
+
+    function testDeploys() public {
+        LidoStEthExitBufferAssertion assertion = new LidoStEthExitBufferAssertion(
+            address(vault), address(stEth), address(wstEth), address(receipt), 1 ether, 500, 5_000, 1 days
+        );
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/examples/lido/test/LidoStEthVaultNavAssertion.t.sol
+++ b/examples/lido/test/LidoStEthVaultNavAssertion.t.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LidoStEthVaultNavAssertion} from "../src/LidoStEthVaultNavAssertion.sol";
+import {MockERC20, MockWstETH, MockRateSource, MockAavePool, MockAaveOracle} from "./LidoMocks.sol";
+
+contract LidoStEthVaultNavAssertionTest is Test, CredibleTest {
+    MockRateSource internal rateSource; // the rate reporter (also the adopter)
+    MockERC20 internal shareToken;
+    MockERC20 internal weth; // base asset
+    MockERC20 internal stEth;
+    MockWstETH internal wstEth;
+    MockAavePool internal pool;
+    MockAaveOracle internal oracle;
+
+    address internal vault = makeAddr("vault");
+    address internal alice = makeAddr("alice");
+
+    uint256 internal constant TOLERANCE_BPS = 50; // 0.5%
+
+    function setUp() public {
+        rateSource = new MockRateSource(1e18);
+        shareToken = new MockERC20("Share", "SHARE", 18);
+        weth = new MockERC20("Wrapped Ether", "WETH", 18);
+        stEth = new MockERC20("Lido stETH", "stETH", 18);
+        wstEth = new MockWstETH();
+        pool = new MockAavePool();
+        oracle = new MockAaveOracle();
+
+        // Idle 100 WETH backs 100 shares => NAV/share == 1.0.
+        weth.setBalance(vault, 100 ether);
+        shareToken.mint(alice, 100 ether);
+    }
+
+    function _arm(bytes4 sel, address aavePool, address aaveOracle) internal {
+        bytes memory createData = abi.encodePacked(
+            type(LidoStEthVaultNavAssertion).creationCode,
+            abi.encode(
+                vault,
+                address(shareToken),
+                address(rateSource),
+                aavePool,
+                aaveOracle,
+                address(weth),
+                address(stEth),
+                address(wstEth),
+                uint8(18),
+                TOLERANCE_BPS
+            )
+        );
+        cl.assertion(address(rateSource), createData, sel);
+    }
+
+    function _armIdleOnly(bytes4 sel) internal {
+        _arm(sel, address(0), address(0));
+    }
+
+    // --- Rate-vs-NAV --------------------------------------------------------
+
+    function testRateWithinTolerancePasses() public {
+        _armIdleOnly(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector);
+        // NAV/share is 1.0; 1.004 sits inside the 0.5% band.
+        rateSource.setRate(1.004e18);
+    }
+
+    function testRateAboveNavTrips() public {
+        _armIdleOnly(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector);
+        vm.expectRevert(bytes("LidoVault: reported rate above on-chain NAV"));
+        rateSource.setRate(1.1e18);
+    }
+
+    function testRateBelowNavTrips() public {
+        _armIdleOnly(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector);
+        vm.expectRevert(bytes("LidoVault: reported rate below on-chain NAV"));
+        rateSource.setRate(0.9e18);
+    }
+
+    function testCountsWstEthAtLidoRate() public {
+        // Add 50 wstETH at 1.2 stEthPerToken = 60 stETH-eq; NAV 160 / 100 shares = 1.6.
+        wstEth.setRate(1.2e18);
+        wstEth.setBalance(vault, 50 ether);
+        _armIdleOnly(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector);
+
+        rateSource.setRate(1.6e18);
+    }
+
+    function testZeroSupplyPasses() public {
+        shareToken.burn(alice, 100 ether); // supply now 0
+        _armIdleOnly(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector);
+
+        // No shares: nothing to price against, any reported rate is vacuously fine.
+        rateSource.setRate(5e18);
+    }
+
+    function testInsolventBookTrips() public {
+        oracle.setPrice(address(weth), 1e18); // base price: 1 base-currency unit == 1 WETH
+        pool.setAccount(vault, 1e18, 1000e18, 1e18); // $1 collateral, $1000 debt
+        _arm(LidoStEthVaultNavAssertion.assertShareRateMatchesNav.selector, address(pool), address(oracle));
+
+        vm.expectRevert(bytes("LidoVault: vault book is insolvent"));
+        rateSource.setRate(1e18);
+    }
+
+    // --- Constructor wiring ------------------------------------------------
+
+    function testRejectsZeroVault() public {
+        vm.expectRevert(bytes("LidoVault: zero vault"));
+        new LidoStEthVaultNavAssertion(
+            address(0),
+            address(shareToken),
+            address(rateSource),
+            address(0),
+            address(0),
+            address(weth),
+            address(stEth),
+            address(wstEth),
+            18,
+            TOLERANCE_BPS
+        );
+    }
+
+    function testRejectsZeroRateSource() public {
+        vm.expectRevert(bytes("LidoVault: zero rate source"));
+        new LidoStEthVaultNavAssertion(
+            vault,
+            address(shareToken),
+            address(0),
+            address(0),
+            address(0),
+            address(weth),
+            address(stEth),
+            address(wstEth),
+            18,
+            TOLERANCE_BPS
+        );
+    }
+
+    function testRejectsZeroOracleWhenPoolSet() public {
+        vm.expectRevert(bytes("LidoVault: zero aave oracle"));
+        new LidoStEthVaultNavAssertion(
+            vault,
+            address(shareToken),
+            address(rateSource),
+            address(pool),
+            address(0),
+            address(weth),
+            address(stEth),
+            address(wstEth),
+            18,
+            TOLERANCE_BPS
+        );
+    }
+
+    function testRejectsToleranceTooLarge() public {
+        vm.expectRevert(bytes("LidoVault: tolerance too large"));
+        new LidoStEthVaultNavAssertion(
+            vault,
+            address(shareToken),
+            address(rateSource),
+            address(0),
+            address(0),
+            address(weth),
+            address(stEth),
+            address(wstEth),
+            18,
+            10_001
+        );
+    }
+
+    function testDeploys() public {
+        LidoStEthVaultNavAssertion assertion = new LidoStEthVaultNavAssertion(
+            vault,
+            address(shareToken),
+            address(rateSource),
+            address(pool),
+            address(oracle),
+            address(weth),
+            address(stEth),
+            address(wstEth),
+            18,
+            TOLERANCE_BPS
+        );
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/examples/lido/test/LidoStEthVaultPegAssertion.t.sol
+++ b/examples/lido/test/LidoStEthVaultPegAssertion.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LidoStEthVaultPegAssertion} from "../src/LidoStEthVaultPegAssertion.sol";
+import {MockChainlinkFeed, MockWstETH, MockRateSource, MockShareToken} from "./LidoMocks.sol";
+
+contract LidoStEthVaultPegAssertionTest is Test, CredibleTest {
+    MockShareToken internal shareToken;
+    MockChainlinkFeed internal feed;
+    MockWstETH internal wstEth;
+    MockRateSource internal provider;
+
+    address internal alice = makeAddr("alice");
+
+    uint256 internal constant MAX_DEPEG_BPS = 100; // 1%
+    uint256 internal constant MAX_MISMATCH_BPS = 50; // 0.5%
+
+    function setUp() public {
+        shareToken = new MockShareToken();
+        feed = new MockChainlinkFeed(1e18, block.timestamp); // on peg, fresh
+        wstEth = new MockWstETH();
+        provider = new MockRateSource(1e18);
+
+        shareToken.mint(alice, 100 ether); // starting supply to mint/burn against
+    }
+
+    function _arm(bytes4 sel, uint256 maxFeedStalenessSecs) internal {
+        bytes memory createData = abi.encodePacked(
+            type(LidoStEthVaultPegAssertion).creationCode,
+            abi.encode(
+                address(shareToken),
+                address(feed),
+                uint8(18),
+                MAX_DEPEG_BPS,
+                maxFeedStalenessSecs,
+                address(wstEth),
+                address(provider),
+                MAX_MISMATCH_BPS
+            )
+        );
+        cl.assertion(address(shareToken), createData, sel);
+    }
+
+    // --- Supply-change depeg gate ------------------------------------------
+
+    function testMintOnPegPasses() public {
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+        shareToken.mint(alice, 10 ether);
+    }
+
+    function testBurnOnPegPasses() public {
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+        shareToken.burn(alice, 10 ether);
+    }
+
+    function testMintWhileDepeggedTrips() public {
+        feed.setAnswer(0.95e18); // 5% off peg
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+
+        vm.expectRevert(bytes("LidoVault: stETH off peg, share pricing unsafe"));
+        shareToken.mint(alice, 10 ether);
+    }
+
+    function testBurnWhileDepeggedTrips() public {
+        feed.setAnswer(1.05e18); // 5% off peg the other way
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+
+        vm.expectRevert(bytes("LidoVault: stETH off peg, share pricing unsafe"));
+        shareToken.burn(alice, 10 ether);
+    }
+
+    function testNoSupplyChangePassesEvenWhenDepegged() public {
+        feed.setAnswer(0.95e18); // depegged, but this tx does not move supply
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+
+        // Touches the share token (poking an unrelated rate) without minting/burning.
+        shareToken.setProviderRate(provider, 1e18);
+    }
+
+    // --- Feed staleness / round integrity (fail closed) --------------------
+
+    function testMintWhileFeedStaleTrips() public {
+        // Answer is on peg, but the round is older than the 1h max age.
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 1 hours);
+        vm.warp(block.timestamp + 2 hours);
+
+        vm.expectRevert(bytes("LidoVault: stETH off peg, share pricing unsafe"));
+        shareToken.mint(alice, 10 ether);
+    }
+
+    function testMintWhileRoundIncompleteTrips() public {
+        feed.setRound(2, 1e18, 0, 2); // updatedAt == 0: incomplete round
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+
+        vm.expectRevert(bytes("LidoVault: stETH off peg, share pricing unsafe"));
+        shareToken.mint(alice, 10 ether);
+    }
+
+    function testMintWhileRoundStaleTrips() public {
+        feed.setRound(5, 1e18, block.timestamp, 4); // answeredInRound < roundId: carried-over answer
+        _arm(LidoStEthVaultPegAssertion.assertMintBurnPegSafety.selector, 0);
+
+        vm.expectRevert(bytes("LidoVault: stETH off peg, share pricing unsafe"));
+        shareToken.mint(alice, 10 ether);
+    }
+
+    // --- wstETH rate integrity ---------------------------------------------
+
+    function testRateIntegrityPasses() public {
+        _arm(LidoStEthVaultPegAssertion.assertWstEthRateIntegrity.selector, 0);
+        // Provider matches the protocol rate exactly.
+        shareToken.setProviderRate(provider, 1e18);
+    }
+
+    function testWstEthRateDecreaseTrips() public {
+        wstEth.setRate(1.1e18); // pre-tx protocol rate
+        _arm(LidoStEthVaultPegAssertion.assertWstEthRateIntegrity.selector, 0);
+
+        vm.expectRevert(bytes("LidoVault: wstETH rate decreased in transaction"));
+        shareToken.setWstEthRate(wstEth, 1.0e18); // a decrease cannot happen mid-tx
+    }
+
+    function testProviderDesyncTrips() public {
+        _arm(LidoStEthVaultPegAssertion.assertWstEthRateIntegrity.selector, 0);
+
+        // Provider reports 1.1 against a protocol rate of 1.0: 10% off, past the 0.5% tolerance.
+        vm.expectRevert(bytes("LidoVault: rate provider desynced from Lido rate"));
+        shareToken.setProviderRate(provider, 1.1e18);
+    }
+
+    // --- Constructor wiring ------------------------------------------------
+
+    function testRejectsZeroShareToken() public {
+        vm.expectRevert(bytes("LidoVault: zero share token"));
+        new LidoStEthVaultPegAssertion(
+            address(0), address(feed), 18, MAX_DEPEG_BPS, 0, address(wstEth), address(provider), MAX_MISMATCH_BPS
+        );
+    }
+
+    function testRejectsZeroWstEth() public {
+        vm.expectRevert(bytes("LidoVault: zero wstETH"));
+        new LidoStEthVaultPegAssertion(
+            address(shareToken), address(feed), 18, MAX_DEPEG_BPS, 0, address(0), address(provider), MAX_MISMATCH_BPS
+        );
+    }
+
+    function testDeploys() public {
+        LidoStEthVaultPegAssertion assertion = new LidoStEthVaultPegAssertion(
+            address(shareToken),
+            address(feed),
+            18,
+            MAX_DEPEG_BPS,
+            1 hours,
+            address(wstEth),
+            address(provider),
+            MAX_MISMATCH_BPS
+        );
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/examples/lido/test/LidoStEthVaultRiskAssertion.t.sol
+++ b/examples/lido/test/LidoStEthVaultRiskAssertion.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LidoStEthVaultRiskAssertion} from "../src/LidoStEthVaultRiskAssertion.sol";
+import {MockERC20, MockAavePool, MockChainlinkFeed, MockRateSource, MockLidoVault} from "./LidoMocks.sol";
+
+contract LidoStEthVaultRiskAssertionTest is Test, CredibleTest {
+    MockLidoVault internal vault;
+    MockAavePool internal pool;
+    MockChainlinkFeed internal feed;
+    MockRateSource internal rateSource;
+    MockERC20 internal weth; // borrowed asset
+    MockERC20 internal debtWeth; // borrowed-asset debt token
+    MockERC20 internal collateral; // collateral asset (wstETH)
+    MockERC20 internal aWstEth; // collateral supply token
+
+    address internal borrowReserve = makeAddr("borrowReserve");
+    address internal collReserve = makeAddr("collReserve");
+
+    // Healthy baseline: HF 2.0, $210 collateral / $200 debt (1.05x), reserves fully cover exit.
+    uint256 internal constant COLLATERAL = 210e8;
+    uint256 internal constant DEBT = 200e8;
+    uint256 internal constant SUPPLIED = 100 ether;
+    uint256 internal constant VAULT_DEBT = 50 ether;
+
+    function setUp() public {
+        vault = new MockLidoVault();
+        pool = new MockAavePool();
+        feed = new MockChainlinkFeed(1e18, block.timestamp); // on peg, fresh
+        rateSource = new MockRateSource(1e18);
+        weth = new MockERC20("Wrapped Ether", "WETH", 18);
+        debtWeth = new MockERC20("Variable Debt WETH", "vWETH", 18);
+        collateral = new MockERC20("Wrapped stETH", "wstETH", 18);
+        aWstEth = new MockERC20("Aave wstETH", "awstETH", 18);
+
+        pool.setAccount(address(vault), COLLATERAL, DEBT, 2e18);
+        aWstEth.setBalance(address(vault), SUPPLIED);
+        collateral.setBalance(collReserve, SUPPLIED); // fully withdrawable
+        debtWeth.setBalance(address(vault), VAULT_DEBT);
+        weth.setBalance(borrowReserve, VAULT_DEBT); // fully covers exit
+    }
+
+    function _baseConfig() internal view returns (LidoStEthVaultRiskAssertion.RiskConfig memory c) {
+        c.vault = address(vault);
+        c.aavePool = address(pool);
+        c.stEthEthFeed = address(feed);
+        c.stEthEthFeedDecimals = 18;
+        c.maxDepegBps = 100; // 1%
+        c.maxFeedStalenessSecs = 0;
+        c.rateSource = address(rateSource);
+        c.borrowedAsset = address(weth);
+        c.borrowedAssetReserve = borrowReserve;
+        c.borrowedAssetDebtToken = address(debtWeth);
+        c.collateralAsset = address(collateral);
+        c.collateralAssetReserve = collReserve;
+        c.collateralAssetSupplyToken = address(aWstEth);
+        c.minHealthFactor = 1.01e18;
+        c.reduceOnlyHealthFactor = 1.05e18;
+        c.minCollateralRatioBps = 10_500; // 1.05x
+        c.minExitLiquidityBps = 10_000;
+        c.minCollateralLiquidityBps = 10_000;
+    }
+
+    function _arm(bytes4 sel, LidoStEthVaultRiskAssertion.RiskConfig memory c) internal {
+        bytes memory createData = abi.encodePacked(type(LidoStEthVaultRiskAssertion).creationCode, abi.encode(c));
+        cl.assertion(address(vault), createData, sel);
+    }
+
+    function _arm(bytes4 sel) internal {
+        _arm(sel, _baseConfig());
+    }
+
+    // --- assertRiskRegime: healthy paths -----------------------------------
+
+    function testHealthyDebtGrowthPasses() public {
+        weth.setBalance(borrowReserve, 100 ether); // reserve covers the larger debt
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        // Grow debt to $210 / 60 WETH while staying healthy and fully covered.
+        vault.borrowMore(pool, 230e8, 210e8, 1.9e18, debtWeth, 60 ether);
+    }
+
+    function testReduceOnlyAllowsDeleverage() public {
+        pool.setAccount(address(vault), COLLATERAL, DEBT, 1.04e18); // unhealthy: below comfort band
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        // Repaying debt and improving HF is always allowed, even in reduce-only.
+        vault.setPosition(pool, COLLATERAL, 150e8, 1.06e18);
+    }
+
+    // --- assertRiskRegime: reduce-only triggers ----------------------------
+
+    function testUnhealthyDebtGrowthTrips() public {
+        pool.setAccount(address(vault), COLLATERAL, DEBT, 1.04e18); // below comfort band
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: reduce-only regime, debt increased"));
+        vault.borrowMore(pool, COLLATERAL, 210e8, 1.04e18, debtWeth, 60 ether);
+    }
+
+    function testUnhealthyHealthFactorDeclineTrips() public {
+        pool.setAccount(address(vault), COLLATERAL, DEBT, 1.04e18); // below comfort band
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        // Debt unchanged but HF slips further: not allowed while reduce-only.
+        vm.expectRevert(bytes("LidoVault: reduce-only regime, health factor declined"));
+        vault.setPosition(pool, COLLATERAL, DEBT, 1.02e18);
+    }
+
+    function testDepegBlocksCollateralGrowth() public {
+        feed.setAnswer(0.95e18); // 5% off peg, well past the 1% band
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: reduce-only regime, collateral exposure increased"));
+        vault.setSupplied(aWstEth, 150 ether);
+    }
+
+    function testUnreadableRateBlocksDebtGrowth() public {
+        rateSource.setReverts(true); // share pricing not trustworthy
+        weth.setBalance(borrowReserve, 100 ether);
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: reduce-only regime, debt increased"));
+        vault.borrowMore(pool, 230e8, 210e8, 1.9e18, debtWeth, 60 ether);
+    }
+
+    function testIlliquidCollateralBlocksCollateralGrowth() public {
+        collateral.setBalance(collReserve, 50 ether); // reserve holds < 100% of supplied
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: reduce-only regime, collateral exposure increased"));
+        vault.setSupplied(aWstEth, 150 ether);
+    }
+
+    // --- assertRiskRegime: liquidity guards --------------------------------
+
+    function testInsufficientExitLiquidityTrips() public {
+        // Healthy, but the borrowed reserve cannot cover the grown debt (50 < 100 WETH).
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: insufficient exit liquidity for new debt"));
+        vault.borrowMore(pool, 230e8, 210e8, 1.9e18, debtWeth, 100 ether);
+    }
+
+    function testCollateralNotWithdrawableTrips() public {
+        // Healthy and liquid pre-state, but deepening the supply leaves it under-covered.
+        _arm(LidoStEthVaultRiskAssertion.assertRiskRegime.selector);
+
+        vm.expectRevert(bytes("LidoVault: collateral not withdrawable on demand"));
+        vault.setSupplied(aWstEth, 150 ether); // reserve still only 100
+    }
+
+    // --- assertPositionEnvelope --------------------------------------------
+
+    function testEnvelopePasses() public {
+        _arm(LidoStEthVaultRiskAssertion.assertPositionEnvelope.selector);
+
+        vault.borrowMore(pool, 230e8, 210e8, 1.9e18, debtWeth, 60 ether);
+    }
+
+    function testEnvelopeIgnoresDebtFreePosition() public {
+        _arm(LidoStEthVaultRiskAssertion.assertPositionEnvelope.selector);
+
+        // No debt: the envelope has nothing to enforce.
+        vault.setPosition(pool, 50e8, 0, 0);
+    }
+
+    function testHealthFactorBelowFloorTrips() public {
+        _arm(LidoStEthVaultRiskAssertion.assertPositionEnvelope.selector);
+
+        vm.expectRevert(bytes("LidoVault: health factor below floor"));
+        vault.setPosition(pool, COLLATERAL, DEBT, 1.005e18); // below the 1.01 floor
+    }
+
+    function testHealthFactorDeclineBelowBandTrips() public {
+        _arm(LidoStEthVaultRiskAssertion.assertPositionEnvelope.selector);
+
+        // Above the floor but slipping below the comfort band while declining.
+        vm.expectRevert(bytes("LidoVault: health factor declined below comfort band"));
+        vault.setPosition(pool, COLLATERAL, DEBT, 1.03e18);
+    }
+
+    function testCollateralRatioBelowMinTrips() public {
+        _arm(LidoStEthVaultRiskAssertion.assertPositionEnvelope.selector);
+
+        // HF holds, but $205 collateral / $200 debt is 1.025x, below the 1.05x minimum.
+        vm.expectRevert(bytes("LidoVault: collateral ratio below minimum"));
+        vault.setPosition(pool, 205e8, DEBT, 1.5e18);
+    }
+
+    // --- Constructor wiring ------------------------------------------------
+
+    function testRejectsZeroVault() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.vault = address(0);
+        vm.expectRevert(bytes("LidoVault: zero vault"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testRejectsZeroPool() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.aavePool = address(0);
+        vm.expectRevert(bytes("LidoVault: zero pool"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testRejectsFloorBelowLiquidation() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.minHealthFactor = 0.99e18;
+        vm.expectRevert(bytes("LidoVault: floor below liquidation"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testRejectsBandBelowFloor() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.reduceOnlyHealthFactor = 1.0e18; // below minHealthFactor
+        vm.expectRevert(bytes("LidoVault: band below floor"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testRejectsZeroBorrowedAssetWhenExitLiquiditySet() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.borrowedAsset = address(0);
+        vm.expectRevert(bytes("LidoVault: zero borrowed asset"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testRejectsZeroCollateralAssetWhenCollLiquiditySet() public {
+        LidoStEthVaultRiskAssertion.RiskConfig memory c = _baseConfig();
+        c.collateralAsset = address(0);
+        vm.expectRevert(bytes("LidoVault: zero collateral asset"));
+        new LidoStEthVaultRiskAssertion(c);
+    }
+
+    function testDeploys() public {
+        LidoStEthVaultRiskAssertion assertion = new LidoStEthVaultRiskAssertion(_baseConfig());
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -115,6 +115,14 @@ cache_path = "examples/euler/cache"
 libs = ["lib"]
 remappings = ["credible-std/=src/"]
 
+[profile.lido]
+src = "examples/lido/src"
+test = "examples/lido/test"
+out = "examples/lido/out"
+cache_path = "examples/lido/cache"
+libs = ["lib"]
+remappings = ["credible-std/=src/"]
+
 [profile.lighter]
 src = "examples/lighter/src"
 test = "examples/lighter/test"


### PR DESCRIPTION
## Lido stETH vault flow assertion suite

Generic Credible Layer assertions for **any vault that custodies stETH/wstETH and deploys it into an Aave-style market** (Veda BoringVault / GGV, Mellow flexible-vaults / EarnETH, Lido V3 stVaults, or comparable loopers). Everything is expressed at transaction boundaries, configured with addresses and thresholds — no vault-stack-specific coupling.

### Assertions

| Contract | What it enforces |
|---|---|
| `LidoStEthExitBufferAssertion` | **Withdrawable-stETH buffer floor** on every transaction (idle stETH-equivalent stays above the larger of an absolute minimum and a fraction of total exposure → the vault is never fully deployed) plus a **rolling-window outflow circuit breaker** on stETH/wstETH. The breaker runs in the block builder, so a burst drain is never included even against a fully compromised signer pipeline. |
| `LidoStEthVaultRiskAssertion` | Reduce-only regime under unhealthy / off-peg / illiquid conditions, exit-liquidity and collateral-withdrawability guards, and a health-factor + collateral-ratio position envelope. |
| `LidoStEthVaultPegAssertion` | Supply-change depeg gate (any mint/burn reverts while stETH/ETH is outside the peg band) and wstETH rate integrity. |
| `LidoStEthVaultNavAssertion` | Reported share rate checked against NAV recomputed from on-chain state, in both directions. |

Shared `LidoVaultHelpers` / `LidoVaultInterfaces` back all four.

### Honest boundaries

- **Requestable, not claimable.** On-chain we can guarantee stETH stays *requestable* to Lido's withdrawal queue at any time; instant claimability is bounded by the validator exit queue and the 1,000 ETH/request cap, which no per-vault check controls.
- **Outflow breaker is destination-blind in v1** — it rate-limits all stETH/wstETH leaving the vault; a destination-aware variant (exempt transfers to Lido's `WithdrawalQueueERC721`) is the named next step.
- No protection against market-price loss; third-party Aave liquidations are out of reach; Lido core is untouched.

### Build

```sh
FOUNDRY_PROFILE=lido forge build
```

Builds clean; `forge fmt --check` passes.

Closes ENG-3428.
