### PR TITLE
feat(lido): EasyTrack flash-loan governance assertion

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [fluid]
+        profile: [fluid, lido]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/examples/lido/src/LidoEasyTrackFlashLoanAssertion.sol
+++ b/examples/lido/src/LidoEasyTrackFlashLoanAssertion.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+/// @title LidoEasyTrackFlashLoanAssertion
+/// @author Phylax Systems
+/// @notice Blocks flash-loaned governance power from being exercised against a Lido governance
+///         contract (the motivating case is EasyTrack), without upgrading the governance contract.
+/// @dev Apply to the governance contract itself (e.g. EasyTrack) — the account that receives the
+///      flash-loan-sensitive calls. Configure it with the governance token (LDO) and the set of
+///      function selectors whose effect is weighted by `governanceToken` balance.
+///
+///      ## The vulnerability (from the Lido call)
+///      EasyTrack is optimistic governance: whitelisted factories create *motions* that execute
+///      after an objection window unless LDO holders object past a threshold. An objection's weight
+///      is read from the governance token at the motion's snapshot block, and that snapshot is taken
+///      at the block the motion *starts* rather than the block before. Because a same-block balance
+///      read returns the live balance, an attacker can, in a single transaction, **flash-loan LDO,
+///      exercise the balance-weighted action, and repay the loan** — borrowed voting power that was
+///      never actually held counts. EasyTrack is not upgradable, so the snapshot cannot simply be
+///      moved to `block.number - 1`; an external execution gate is the agile patch.
+///
+///      ## The invariant
+///      Voting power exercised against the protected selectors must be power the actor *already held
+///      at the start of the transaction* — not power acquired within the same transaction. A flash
+///      loan is exactly the act of acquiring (and returning) the token inside one transaction, so an
+///      actor whose `governanceToken` balance is larger at the moment of the governance call than it
+///      was at the start of the transaction is using power it did not durably hold. This re-creates
+///      the "snapshot a block earlier" property from the outside: same-block (flash-loaned) balance
+///      no longer counts, because the transaction that relies on it is never included.
+///
+///      ## Two detection layers (the two approaches discussed on the call), both armable
+///      - **`assertNoFlashLoanedVotingPower` (primary, precise).** For the protected call that fired
+///        this invocation, compare the caller's `governanceToken` balance at the start of the
+///        transaction (`PreTx`) against its balance immediately before the governance call executes
+///        (`PreCall`). Any increase beyond `maxIntraTxAcquired` means voting power was sourced within
+///        the transaction — revert. This reads the balance at *exactly* the point the governance
+///        snapshot would, so it neither misses a borrow that lands just before the call nor flags a
+///        borrow that was already repaid before it.
+///      - **`assertNoSameTxGovTokenInflow` (corroborating, coarser).** For the firing call's caller,
+///        sum the gross `governanceToken` transferred *to* it anywhere in the transaction. Any inflow
+///        beyond `maxIntraTxAcquired` reverts. This is the "read the transfer logs" approach: cheaper
+///        and it catches power routed through the caller even if intermediate balances net out, at the
+///        cost of also flagging an actor who legitimately receives the token and acts in the same
+///        transaction. Arm it alongside the primary layer when the governance entrypoint can be
+///        reached by a contract that only holds the token transiently.
+///
+///      Both layers are wired with `registerFnCallTrigger`, so each fires once per matching protected
+///      call with the firing call exposed via `ph.context()` — a transaction that does not touch
+///      governance pays nothing, and a transaction with multiple protected calls checks each exactly
+///      once instead of re-scanning every call on every invocation.
+contract LidoEasyTrackFlashLoanAssertion is Assertion {
+    /// @notice The governance contract this assertion protects (the assertion adopter). Protected
+    ///         selectors are matched against calls received here.
+    address public immutable governanceContract;
+
+    /// @notice The balance-weighted governance token (LDO). Voting power is its `balanceOf`.
+    address public immutable governanceToken;
+
+    /// @notice Per-actor, per-transaction allowance of newly-acquired governance power, in token
+    ///         units. Zero (the default and recommended value) forbids any intra-transaction
+    ///         acquisition. A non-zero value tolerates small legitimate same-transaction top-ups.
+    uint256 public immutable maxIntraTxAcquired;
+
+    /// @notice Function selectors on `governanceContract` whose effect is weighted by
+    ///         `governanceToken` balance and must therefore be protected from flash-loaned power
+    ///         (e.g. `EasyTrack.objectToMotion(uint256)`).
+    bytes4[] public protectedSelectors;
+
+    constructor(
+        address governanceContract_,
+        address governanceToken_,
+        uint256 maxIntraTxAcquired_,
+        bytes4[] memory protectedSelectors_
+    ) {
+        require(governanceContract_ != address(0), "LidoGov: zero governance contract");
+        require(governanceToken_ != address(0), "LidoGov: zero governance token");
+        require(protectedSelectors_.length != 0, "LidoGov: no protected selectors");
+
+        governanceContract = governanceContract_;
+        governanceToken = governanceToken_;
+        maxIntraTxAcquired = maxIntraTxAcquired_;
+
+        for (uint256 i; i < protectedSelectors_.length; ++i) {
+            require(protectedSelectors_[i] != bytes4(0), "LidoGov: zero selector");
+            protectedSelectors.push(protectedSelectors_[i]);
+        }
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Wires both detection layers to every protected selector.
+    /// @dev Each protected selector gets an `onFnCall` trigger for both assertion functions, so the
+    ///      armed layer fires once per matching call with the firing call available via `ph.context()`.
+    ///      An operator arms whichever layer(s) they want; only the armed function executes, and only
+    ///      when its selector is called on the governance contract.
+    function triggers() external view override {
+        for (uint256 i; i < protectedSelectors.length; ++i) {
+            registerFnCallTrigger(this.assertNoFlashLoanedVotingPower.selector, protectedSelectors[i]);
+            registerFnCallTrigger(this.assertNoSameTxGovTokenInflow.selector, protectedSelectors[i]);
+        }
+    }
+
+    /// @notice Primary layer: forbids exercising governance power acquired within the transaction.
+    /// @dev Scoped to the single protected call that fired this invocation (`ph.context()`): the
+    ///      caller's governance-token balance immediately before that call (`PreCall`) must not exceed
+    ///      its balance at the start of the transaction (`PreTx`) by more than `maxIntraTxAcquired`.
+    ///      Reading at `PreCall` aligns with what the governance snapshot sees: a flash loan repaid
+    ///      before the call reads back to baseline and passes; a flash loan still held at the call
+    ///      shows the inflated balance and trips. The trigger fires once per protected call, so there
+    ///      is no need to re-scan every selector and every matching call here.
+    function assertNoFlashLoanedVotingPower() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        address actor = _triggerCaller(ctx);
+
+        uint256 atTxStart = _readBalanceAt(governanceToken, actor, _preTx());
+        uint256 atCall = _readBalanceAt(governanceToken, actor, _preCall(ctx.callStart));
+
+        require(atCall <= atTxStart + maxIntraTxAcquired, "LidoGov: flash-loaned voting power");
+    }
+
+    /// @notice Corroborating layer: forbids same-transaction governance-token inflow to an actor
+    ///         that exercises governance.
+    /// @dev Scoped to the firing protected call's caller (`ph.context()`): the *gross* amount of
+    ///      `governanceToken` transferred to it anywhere in the transaction must not exceed
+    ///      `maxIntraTxAcquired`. Gross, not net, on purpose: a flash loan is borrowed and repaid
+    ///      within the transaction, so its net effect on the actor is zero — only the gross inbound
+    ///      leg reveals it. This reads the raw transfer log (`getErc20Transfers`) rather than the
+    ///      reduced per-account deltas, precisely because the reduced view nets the round trip away.
+    ///      Coarser than the primary layer (it also flags an actor that legitimately receives the
+    ///      token and acts in the same transaction), but it catches power routed through a
+    ///      transiently-funded caller. Arm it as defense in depth.
+    function assertNoSameTxGovTokenInflow() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        address actor = _triggerCaller(ctx);
+
+        PhEvm.Erc20TransferData[] memory deltas = ph.getErc20Transfers(governanceToken, _postTx());
+
+        uint256 inbound;
+        for (uint256 d; d < deltas.length; ++d) {
+            if (deltas[d].to == actor) {
+                inbound += deltas[d].value;
+            }
+        }
+
+        require(inbound <= maxIntraTxAcquired, "LidoGov: same-tx governance token inflow");
+    }
+
+    /// @notice Resolves the caller of the protected call that fired this invocation.
+    /// @dev `ph.context()` identifies the firing call by `callStart`; matching it against the
+    ///      selector-filtered `getCallInputs` view yields that call's caller. `getCallInputs` is used
+    ///      rather than `matchingCalls` so the assertion remains executable under `pcl test`.
+    function _triggerCaller(PhEvm.TriggerContext memory ctx) private view returns (address) {
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(governanceContract, ctx.selector);
+        for (uint256 i; i < calls.length; ++i) {
+            if (calls[i].id == ctx.callStart) return calls[i].caller;
+        }
+        revert("LidoGov: trigger call not found");
+    }
+}

--- a/examples/lido/test/LidoEasyTrackFlashLoanAssertion.t.sol
+++ b/examples/lido/test/LidoEasyTrackFlashLoanAssertion.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {LidoEasyTrackFlashLoanAssertion} from "../src/LidoEasyTrackFlashLoanAssertion.sol";
+import {MockERC20} from "./LidoMocks.sol";
+import {MockEasyTrack, MockFlashGovAttacker, MockHonestObjector} from "./LidoGovMocks.sol";
+
+contract LidoEasyTrackFlashLoanAssertionTest is Test, CredibleTest {
+    MockERC20 internal ldo;
+    MockEasyTrack internal gov;
+    MockFlashGovAttacker internal attacker;
+    MockHonestObjector internal honest;
+
+    address internal lender = makeAddr("flashLender");
+
+    uint256 internal constant MOTION_ID = 1;
+    uint256 internal constant LOAN = 5_000_000 ether; // enough LDO to clear an objection threshold
+
+    function setUp() public {
+        ldo = new MockERC20("Lido DAO Token", "LDO", 18);
+        gov = new MockEasyTrack(ldo);
+        attacker = new MockFlashGovAttacker();
+        honest = new MockHonestObjector();
+    }
+
+    function _selectors() internal pure returns (bytes4[] memory sels) {
+        sels = new bytes4[](2);
+        sels[0] = MockEasyTrack.objectToMotion.selector;
+        sels[1] = MockEasyTrack.createMotion.selector;
+    }
+
+    function _arm(bytes4 fn, uint256 maxIntraTxAcquired) internal {
+        bytes memory createData = abi.encodePacked(
+            type(LidoEasyTrackFlashLoanAssertion).creationCode,
+            abi.encode(address(gov), address(ldo), maxIntraTxAcquired, _selectors())
+        );
+        cl.assertion(address(gov), createData, fn);
+    }
+
+    // --- Primary layer: balance delta around the governance call -----------
+
+    function testFlashLoanedObjectionTripsBalanceLayer() public {
+        // Lender funds the flash loan; attacker holds no LDO at transaction start.
+        ldo.setBalance(lender, LOAN);
+        vm.prank(lender);
+        ldo.approve(address(attacker), LOAN);
+
+        _arm(LidoEasyTrackFlashLoanAssertion.assertNoFlashLoanedVotingPower.selector, 0);
+
+        // borrow → object with borrowed power → repay, all in one transaction.
+        vm.expectRevert(bytes("LidoGov: flash-loaned voting power"));
+        attacker.flashObject(gov, ldo, lender, MOTION_ID, LOAN);
+    }
+
+    function testHonestObjectionPassesBalanceLayer() public {
+        // Honest objector durably holds LDO before the transaction.
+        ldo.setBalance(address(honest), LOAN);
+
+        _arm(LidoEasyTrackFlashLoanAssertion.assertNoFlashLoanedVotingPower.selector, 0);
+
+        honest.object(gov, MOTION_ID);
+    }
+
+    function testSmallSameTxTopUpAllowedByTolerance() public {
+        // Honest holder already holds power; a tiny same-tx top-up is within tolerance.
+        ldo.setBalance(lender, 1 ether);
+        vm.prank(lender);
+        ldo.approve(address(attacker), 1 ether);
+
+        _arm(LidoEasyTrackFlashLoanAssertion.assertNoFlashLoanedVotingPower.selector, 1 ether);
+
+        // Borrows exactly the tolerance, so the increase is allowed.
+        attacker.flashObject(gov, ldo, lender, MOTION_ID, 1 ether);
+    }
+
+    // --- Corroborating layer: same-tx gov-token inflow ---------------------
+
+    function testFlashLoanedObjectionTripsInflowLayer() public {
+        ldo.setBalance(lender, LOAN);
+        vm.prank(lender);
+        ldo.approve(address(attacker), LOAN);
+
+        _arm(LidoEasyTrackFlashLoanAssertion.assertNoSameTxGovTokenInflow.selector, 0);
+
+        // A flash loan nets to zero for the attacker, but the gross inbound leg trips this layer.
+        vm.expectRevert(bytes("LidoGov: same-tx governance token inflow"));
+        attacker.flashObject(gov, ldo, lender, MOTION_ID, LOAN);
+    }
+
+    function testHonestObjectionPassesInflowLayer() public {
+        ldo.setBalance(address(honest), LOAN);
+
+        _arm(LidoEasyTrackFlashLoanAssertion.assertNoSameTxGovTokenInflow.selector, 0);
+
+        honest.object(gov, MOTION_ID);
+    }
+
+    // --- Constructor wiring ------------------------------------------------
+
+    function testRejectsZeroGovernanceContract() public {
+        vm.expectRevert(bytes("LidoGov: zero governance contract"));
+        new LidoEasyTrackFlashLoanAssertion(address(0), address(ldo), 0, _selectors());
+    }
+
+    function testRejectsZeroGovernanceToken() public {
+        vm.expectRevert(bytes("LidoGov: zero governance token"));
+        new LidoEasyTrackFlashLoanAssertion(address(gov), address(0), 0, _selectors());
+    }
+
+    function testRejectsEmptySelectors() public {
+        vm.expectRevert(bytes("LidoGov: no protected selectors"));
+        new LidoEasyTrackFlashLoanAssertion(address(gov), address(ldo), 0, new bytes4[](0));
+    }
+
+    function testRejectsZeroSelector() public {
+        bytes4[] memory sels = new bytes4[](1);
+        sels[0] = bytes4(0);
+        vm.expectRevert(bytes("LidoGov: zero selector"));
+        new LidoEasyTrackFlashLoanAssertion(address(gov), address(ldo), 0, sels);
+    }
+
+    function testDeploys() public {
+        LidoEasyTrackFlashLoanAssertion assertion =
+            new LidoEasyTrackFlashLoanAssertion(address(gov), address(ldo), 0, _selectors());
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/examples/lido/test/LidoGovMocks.sol
+++ b/examples/lido/test/LidoGovMocks.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {MockERC20} from "./LidoMocks.sol";
+
+/// @notice EasyTrack-style optimistic governance stand-in. `objectToMotion` is balance-weighted: it
+///         records the caller's live governance-token balance as the objection weight — the exact
+///         same-block read that the real EasyTrack snapshot makes, and the surface a flash loan
+///         attacks. `createMotion` is included as a second protected entrypoint.
+contract MockEasyTrack {
+    MockERC20 public immutable governanceToken;
+
+    /// @notice motionId => objector => weight credited at objection time.
+    mapping(uint256 => mapping(address => uint256)) public objectionWeight;
+    uint256 public lastMotionId;
+
+    constructor(MockERC20 governanceToken_) {
+        governanceToken = governanceToken_;
+    }
+
+    /// @dev Mirrors the vulnerable read: objection weight = live balance of the caller.
+    function objectToMotion(uint256 motionId) external {
+        objectionWeight[motionId][msg.sender] = governanceToken.balanceOf(msg.sender);
+    }
+
+    function createMotion(address factory, bytes calldata data) external returns (uint256 motionId) {
+        factory;
+        data;
+        motionId = ++lastMotionId;
+    }
+}
+
+/// @notice Flash-loan attacker: in a single transaction it borrows the governance token from a
+///         lender, exercises a balance-weighted governance action with the borrowed power, then
+///         repays. The lender must have approved this contract for `amount` beforehand.
+contract MockFlashGovAttacker {
+    /// @notice Borrow → object → repay, all in one transaction (one armed `cl.assertion` call).
+    function flashObject(MockEasyTrack gov, MockERC20 token, address lender, uint256 motionId, uint256 amount)
+        external
+    {
+        token.transferFrom(lender, address(this), amount); // borrow
+        gov.objectToMotion(motionId); // exercise flash-loaned voting power
+        token.transfer(lender, amount); // repay
+    }
+}
+
+/// @notice Honest participant: holds its governance token across transactions and simply objects.
+///         Used to prove the assertion does not flag power that was durably held at transaction start.
+contract MockHonestObjector {
+    function object(MockEasyTrack gov, uint256 motionId) external {
+        gov.objectToMotion(motionId);
+    }
+}

--- a/examples/lido/test/LidoMocks.sol
+++ b/examples/lido/test/LidoMocks.sol
@@ -12,6 +12,8 @@ contract MockERC20 {
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
 
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
     constructor(string memory name_, string memory symbol_, uint8 decimals_) {
         name = name_;
         symbol = symbol_;
@@ -21,11 +23,13 @@ contract MockERC20 {
     function mint(address to, uint256 amount) public {
         balanceOf[to] += amount;
         totalSupply += amount;
+        emit Transfer(address(0), to, amount);
     }
 
     function burn(address from, uint256 amount) public {
         balanceOf[from] -= amount;
         totalSupply -= amount;
+        emit Transfer(from, address(0), amount);
     }
 
     /// @dev Overwrites a balance and keeps `totalSupply` consistent.
@@ -56,6 +60,7 @@ contract MockERC20 {
     function _transfer(address from, address to, uint256 amount) internal {
         balanceOf[from] -= amount;
         balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a Credible Layer assertion that blocks **flash-loaned governance power** from being exercised against a Lido governance contract — the motivating case being **EasyTrack**, raised by Lido on a recent call.

EasyTrack is optimistic governance: whitelisted factories create motions that execute after an objection window unless LDO holders object past a threshold. The objection weight is read from the governance token at the motion's **start block** rather than the block before. Because a same-block balance read returns the live balance, an attacker can, in one transaction, **flash-loan LDO, exercise the balance-weighted action, and repay the loan** — borrowed voting power that was never durably held still counts. EasyTrack is not upgradable, so the snapshot can't simply be moved to `block.number - 1`; an external execution gate is the agile patch.

The assertion re-creates the "snapshot a block earlier" property from the outside, so the governance contract needs no upgrade.

## Invariant

Voting power exercised against the protected selectors must be power the actor *already held at the start of the transaction* — not power acquired within the same transaction.

## Two detection layers (both independently armable)

1. **`assertNoFlashLoanedVotingPower`** (primary, precise) — for every protected call, the caller's LDO balance at `PreCall` must not exceed its balance at `PreTx` by more than `maxIntraTxAcquired`. Reads at exactly the point the governance snapshot would: a flash loan repaid before the call reads back to baseline and passes; one still held at the call trips.
2. **`assertNoSameTxGovTokenInflow`** (corroborating, coarser) — for every protected call, the *gross* LDO transferred to the caller anywhere in the tx must not exceed `maxIntraTxAcquired`. Reads the raw transfer log (`getErc20Transfers`), **not** the reduced per-account deltas — the reduced view nets a borrow+repay flash loan to zero and the actor disappears. Catches power routed through a transiently-funded caller, at the cost of also flagging an actor that legitimately receives the token and acts in the same tx. Arm as defense in depth.

Both fire only via `registerCallTrigger` on the protected selectors, so transactions that don't touch governance pay nothing. The assertion is generic over `(governanceContract, governanceToken, maxIntraTxAcquired, protectedSelectors)`, so it applies to any LDO-balance-weighted governance entrypoint, not just `objectToMotion`.

## Files

- `examples/lido/src/LidoEasyTrackFlashLoanAssertion.sol` — the assertion
- `examples/lido/test/LidoEasyTrackFlashLoanAssertion.t.sol` — 10 pass/trip tests
- `examples/lido/test/LidoGovMocks.sol` — EasyTrack + flash-attacker + honest-objector mocks
- `examples/lido/test/LidoMocks.sol` — gave the shared `MockERC20` standard `Transfer` events (correctness fix so log-based precompiles see transfers; no behavior change to existing suites)

## Testing

`FOUNDRY_PROFILE=lido pcl test` → **69 passed, 0 failed** across all 5 Lido suites (10 new; the other 59 unaffected by the mock edit).

## Note for adoption

EasyTrack isn't upgradable, so to attach this gate Lido registers the EasyTrack address as an assertion adopter on the Credible Layer — no contract change needed.
