### PR TITLE
feat(safe): add CredibleSafeGuard transaction guard

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -34,12 +34,14 @@ jobs:
   # Example assertion suites live under their own foundry profiles (examples/<name>) and also use the
   # Phorge-only `cl.assertion` cheatcode, so they run under `pcl test` here. Add a profile to the
   # matrix when its example is ready to be gated on every PR.
+  # `safe-guard` is a plain-forge integration suite (real Gnosis Safe + CredibleSafeGuard) on its own
+  # profile because the Safe contracts need the legacy pipeline; pcl runs plain forge tests too.
   examples-pcl:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        profile: [fluid, lido, mellow]
+        profile: [fluid, lido, mellow, safe-guard]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/safe-smart-account"]
+	path = lib/safe-smart-account
+	url = https://github.com/safe-global/safe-smart-account

--- a/examples/safe-guard/README.md
+++ b/examples/safe-guard/README.md
@@ -1,0 +1,27 @@
+# Credible Safe Guard integration
+
+Real end-to-end tests for `src/protection/safe/CredibleSafeGuard.sol`, run against an actual Gnosis Safe (v1.4.1).
+
+The guard contract and its unit tests live in the root project:
+
+- `src/protection/safe/CredibleSafeGuard.sol`
+- `src/protection/safe/ICredibleRegistry.sol`
+- `test/protection/safe/CredibleSafeGuard.t.sol` (unit tests)
+
+These integration tests live under their own profile because the Safe contracts compile with the legacy pipeline (`optimizer = true`, no `via_ir`), while the root profiles use `via_ir`.
+
+## What it covers
+
+- Installing the guard on a real Safe via a signed `execTransaction` → `setGuard`, which exercises Safe's real `GS300` ERC-165 check against the guard.
+- A signed Safe transaction executing in a credible block.
+- A signed Safe transaction reverting with `NonCredibleBlock` in a non-credible block while the builder set is live.
+- The fail-open path: a signed Safe transaction executing once the builder set has been silent past the configured window.
+- An end-to-end builder stall-then-recover sequence.
+
+## Run
+
+```sh
+FOUNDRY_PROFILE=safe-guard forge test
+```
+
+The Safe contracts come from the `safe-smart-account` submodule under `lib/`, so initialize submodules first (`git submodule update --init --recursive`).

--- a/examples/safe-guard/src/CredibleRegistryMock.sol
+++ b/examples/safe-guard/src/CredibleRegistryMock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ICredibleRegistry} from "credible-std/protection/safe/ICredibleRegistry.sol";
+
+/// @notice Test double for the Credible Registry. Exposes fine-grained setters plus a faithful
+///         `markCurrentBlockCredible()` replicating `phylaxsystems/credible-registry` semantics.
+contract CredibleRegistryMock is ICredibleRegistry {
+    mapping(uint256 blockNumber => bool credible) internal _credible;
+    uint256 internal _lastCredibleBlock;
+
+    function setCredibleBlock(uint256 blockNumber, bool credible) external {
+        _credible[blockNumber] = credible;
+    }
+
+    function setLastCredibleBlock(uint256 blockNumber) external {
+        _lastCredibleBlock = blockNumber;
+    }
+
+    /// @dev Mirrors the real registry: marks `block.number` credible and advances the pointer.
+    function markCurrentBlockCredible() external {
+        _credible[block.number] = true;
+        _lastCredibleBlock = block.number;
+    }
+
+    function isCredibleBlock(uint256 blockNumber) external view returns (bool) {
+        return _credible[blockNumber];
+    }
+
+    function lastCredibleBlock() external view returns (uint256) {
+        return _lastCredibleBlock;
+    }
+}

--- a/examples/safe-guard/test/CredibleSafeGuardSafeIntegration.t.sol
+++ b/examples/safe-guard/test/CredibleSafeGuardSafeIntegration.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Safe} from "../../../lib/safe-smart-account/contracts/Safe.sol";
+import {SafeProxyFactory} from "../../../lib/safe-smart-account/contracts/proxies/SafeProxyFactory.sol";
+import {Enum} from "../../../lib/safe-smart-account/contracts/common/Enum.sol";
+
+import {CredibleSafeGuard} from "credible-std/protection/safe/CredibleSafeGuard.sol";
+import {CredibleRegistryMock} from "../src/CredibleRegistryMock.sol";
+
+/// @notice End-to-end tests that install {CredibleSafeGuard} on a real Gnosis Safe (v1.4.1) and
+///         drive real, owner-signed `execTransaction` calls through the credible, non-credible,
+///         and fail-open paths. Installing the guard via `setGuard` also exercises Safe's real
+///         `GS300` ERC-165 check against {CredibleSafeGuard.supportsInterface}.
+contract CredibleSafeGuardSafeIntegrationTest is Test {
+    /// @dev Safe stores the transaction guard at keccak256("guard_manager.guard.address").
+    bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    uint256 internal constant THRESHOLD = 75;
+    uint256 internal constant BASE_BLOCK = 1_000_000;
+
+    uint256 internal ownerPk = uint256(keccak256("safe.owner"));
+    address internal owner;
+
+    CredibleRegistryMock internal registry;
+    CredibleSafeGuard internal guard;
+    Safe internal safe;
+
+    function setUp() public {
+        owner = vm.addr(ownerPk);
+
+        registry = new CredibleRegistryMock();
+        guard = new CredibleSafeGuard(registry, THRESHOLD);
+
+        Safe singleton = new Safe();
+        SafeProxyFactory factory = new SafeProxyFactory();
+
+        address[] memory owners = new address[](1);
+        owners[0] = owner;
+
+        bytes memory initializer =
+            abi.encodeCall(Safe.setup, (owners, 1, address(0), "", address(0), address(0), 0, payable(address(0))));
+        safe = Safe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, 0))));
+
+        vm.roll(BASE_BLOCK);
+
+        // `setGuard` is `authorized` (callable only by the Safe itself), so route it through a
+        // signed `execTransaction`. The guard is not yet active for this call, and Safe runs its
+        // real ERC-165 check on our guard while installing it (reverting GS300 if it were wrong).
+        bytes memory setGuardData = abi.encodeWithSignature("setGuard(address)", address(guard));
+        bytes memory sig = _signTx(address(safe), 0, setGuardData);
+        safe.execTransaction(
+            address(safe), 0, setGuardData, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), sig
+        );
+
+        assertEq(_installedGuard(), address(guard), "guard not installed");
+    }
+
+    function test_realSafe_guardInstalledViaErc165Check() public view {
+        // setUp would have reverted with GS300 if supportsInterface were wrong.
+        assertEq(_installedGuard(), address(guard));
+    }
+
+    function test_realSafe_executesInCredibleBlock() public {
+        registry.markCurrentBlockCredible();
+
+        uint256 nonceBefore = safe.nonce();
+        bool ok = _execSafeTx(owner, 0, "");
+
+        assertTrue(ok);
+        assertEq(safe.nonce(), nonceBefore + 1);
+    }
+
+    function test_realSafe_revertsInNonCredibleBlockWithinWindow() public {
+        // Last credible block is one behind: builder set still considered live.
+        registry.setLastCredibleBlock(block.number - 1);
+
+        uint256 nonceBefore = safe.nonce();
+        bytes memory sig = _signTx(owner, 0, "");
+
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        safe.execTransaction(owner, 0, "", Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), sig);
+
+        // A reverted Safe transaction does not consume the nonce.
+        assertEq(safe.nonce(), nonceBefore);
+    }
+
+    function test_realSafe_failsOpenWhenBuilderOffline() public {
+        // No credible block within the configured window: fail open and let the Safe transact.
+        registry.setLastCredibleBlock(block.number - (THRESHOLD + 1));
+
+        uint256 nonceBefore = safe.nonce();
+        bool ok = _execSafeTx(owner, 0, "");
+
+        assertTrue(ok);
+        assertEq(safe.nonce(), nonceBefore + 1);
+    }
+
+    function test_realSafe_endToEnd_stallThenRecover() public {
+        // Builder healthy: current block is credible -> allowed.
+        registry.markCurrentBlockCredible();
+        assertTrue(_execSafeTx(owner, 0, ""));
+
+        // Builder misses a few blocks but is still within the live window -> blocked.
+        vm.roll(block.number + 10);
+        bytes memory sig = _signTx(owner, 0, "");
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        safe.execTransaction(owner, 0, "", Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), sig);
+
+        // Builder stays silent past the window -> fail open -> allowed.
+        vm.roll(block.number + THRESHOLD);
+        assertTrue(_execSafeTx(owner, 0, ""));
+
+        // Builder recovers and marks the new current block -> allowed again.
+        registry.markCurrentBlockCredible();
+        assertTrue(_execSafeTx(owner, 0, ""));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// @dev Signs a single-owner Safe transaction (CALL, no gas refund) over the current nonce.
+    function _signTx(address to, uint256 value, bytes memory data) internal view returns (bytes memory) {
+        bytes32 txHash = safe.getTransactionHash(
+            to, value, data, Enum.Operation.Call, 0, 0, 0, address(0), address(0), safe.nonce()
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, txHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Signs and submits a Safe transaction; reverts bubble up to the caller.
+    function _execSafeTx(address to, uint256 value, bytes memory data) internal returns (bool) {
+        bytes memory sig = _signTx(to, value, data);
+        return safe.execTransaction(to, value, data, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), sig);
+    }
+
+    function _installedGuard() internal view returns (address) {
+        return address(uint160(uint256(vm.load(address(safe), GUARD_STORAGE_SLOT))));
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -171,6 +171,19 @@ cache_path = "examples/safe/cache"
 libs = ["lib"]
 remappings = ["credible-std/=src/"]
 
+# Real Gnosis Safe end-to-end tests for src/protection/safe/CredibleSafeGuard.sol.
+# Separate profile because the Safe contracts compile with the legacy pipeline
+# (optimizer, no via_ir), unlike the via_ir root profiles.
+[profile.safe-guard]
+src = "examples/safe-guard/src"
+test = "examples/safe-guard/test"
+out = "examples/safe-guard/out"
+cache_path = "examples/safe-guard/cache"
+libs = ["lib"]
+remappings = ["credible-std/=src/"]
+optimizer = true
+via_ir = false
+
 [profile.spark]
 src = "examples/spark/src"
 test = "examples/spark/test"

--- a/src/protection/safe/CredibleSafeGuard.sol
+++ b/src/protection/safe/CredibleSafeGuard.sol
@@ -45,11 +45,19 @@ interface ITransactionGuard is IERC165 {
 
 /// @title CredibleSafeGuard
 /// @author Phylax Systems
-/// @notice Safe transaction guard that only allows Safe executions while the current block is
-///         credible, i.e. built by a Credible Layer builder that enforces assertions. When the
-///         credible builder set is offline the guard fails open so the Safe is never bricked.
+/// @notice Safe transaction guard that only allows owner/multisig Safe transactions while the
+///         current block is credible, i.e. built by a Credible Layer builder that enforces
+///         assertions. When the credible builder set is offline the guard fails open so the Safe
+///         is never bricked.
 /// @dev Installed on a Safe via `setGuard(address(thisGuard))`. The Safe calls
 ///      {checkTransaction} before every owner-path execution; a revert blocks that execution.
+///
+///      Scope. This guard implements only Safe's transaction-guard interface ({ITransactionGuard}),
+///      so it gates the owner/multisig `execTransaction` path only. Module executions
+///      (`execTransactionFromModule`/`...ReturnData`) do not run transaction guards, so an enabled
+///      module can still execute while the current block is not credible. Gating module executions
+///      requires a separate Safe module guard (the v1.5.0 `checkModuleTransaction` hook) or a
+///      Credible Layer assertion such as {SafeTxShapeAssertion}.
 ///
 ///      Decision in {checkTransaction}:
 ///      1. If the credible builder set looks offline (the most recent credible block is more

--- a/src/protection/safe/CredibleSafeGuard.sol
+++ b/src/protection/safe/CredibleSafeGuard.sol
@@ -60,12 +60,13 @@ interface ITransactionGuard is IERC165 {
 ///      Credible Layer assertion such as {SafeTxShapeAssertion}.
 ///
 ///      Decision in {checkTransaction}:
-///      1. If the credible builder set looks offline (the most recent credible block is more
-///         than `failOpenBlockThreshold` blocks behind the current block), FAIL OPEN and allow
-///         the transaction. This prevents a stalled builder set from permanently locking the Safe.
-///      2. Otherwise the builder set is live, so the current block MUST be credible; if it is
-///         not, the transaction is blocked with {NonCredibleBlock}.
-///      3. If the current block is itself credible, the transaction is always allowed.
+///      1. If the current block is credible, the transaction is always allowed.
+///      2. Otherwise, if the credible builder set looks offline (the most recent credible block
+///         is more than `failOpenBlockThreshold` blocks behind the current block), FAIL OPEN and
+///         allow the transaction. This prevents a stalled builder set from permanently locking
+///         the Safe.
+///      3. Otherwise the builder set is live and the current block is not credible, so the
+///         transaction is blocked with {NonCredibleBlock}.
 ///
 ///      Fail-open window. The product requirement is "fail open after ~15 minutes with no
 ///      credible blocks". The {ICredibleRegistry} records credibility by block number and does
@@ -133,7 +134,7 @@ contract CredibleSafeGuard is ITransactionGuard {
     /// @dev View helper mirroring {checkTransaction}'s decision for off-chain inspection.
     /// @return True if the current block is credible or the guard is failing open.
     function isCurrentBlockAllowed() external view returns (bool) {
-        return _failOpenActive() || credibleRegistry.isCredibleBlock(block.number);
+        return credibleRegistry.isCredibleBlock(block.number) || _failOpenActive();
     }
 
     /// @notice Whether the guard is currently failing open because the builder set looks offline.
@@ -142,10 +143,12 @@ contract CredibleSafeGuard is ITransactionGuard {
         return _failOpenActive();
     }
 
-    /// @dev Core gate: fail open when the builder set is offline, otherwise require credibility.
+    /// @dev Core gate: allow credible blocks, otherwise fail open only when the builder set is
+    ///      offline. The credible-block check runs first so the expected hot path (credible block,
+    ///      live builder set) costs a single registry call.
     function _checkCredibleBlock() internal view {
-        if (_failOpenActive()) return;
-        if (!credibleRegistry.isCredibleBlock(block.number)) revert NonCredibleBlock();
+        if (credibleRegistry.isCredibleBlock(block.number)) return;
+        if (!_failOpenActive()) revert NonCredibleBlock();
     }
 
     /// @dev Fail-open is active when the current block is strictly more than

--- a/src/protection/safe/CredibleSafeGuard.sol
+++ b/src/protection/safe/CredibleSafeGuard.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ICredibleRegistry} from "./ICredibleRegistry.sol";
+
+/// @notice Minimal subset of Safe's `Enum` library, vendored so the guard does not
+///         depend on the Safe contracts package.
+library Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+/// @notice ERC-165 interface (EIP-165 / OpenZeppelin `IERC165`).
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+/// @notice Safe transaction guard interface, identical to Safe's `Guard` (v1.3.0/v1.4.1)
+///         and `ITransactionGuard` (v1.5.0).
+/// @dev `type(ITransactionGuard).interfaceId == 0xe6d7a83a`, the same value Safe's
+///      `GuardManager.setGuard` checks via ERC-165 (error `GS300` otherwise), so a
+///      {CredibleSafeGuard} can be installed on any Safe that supports transaction guards.
+interface ITransactionGuard is IERC165 {
+    /// @notice Called by the Safe before executing an owner-authorized transaction.
+    /// @dev Reverting here blocks the Safe transaction from executing.
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external;
+
+    /// @notice Called by the Safe after executing the transaction.
+    function checkAfterExecution(bytes32 hash, bool success) external;
+}
+
+/// @title CredibleSafeGuard
+/// @author Phylax Systems
+/// @notice Safe transaction guard that only allows Safe executions while the current block is
+///         credible, i.e. built by a Credible Layer builder that enforces assertions. When the
+///         credible builder set is offline the guard fails open so the Safe is never bricked.
+/// @dev Installed on a Safe via `setGuard(address(thisGuard))`. The Safe calls
+///      {checkTransaction} before every owner-path execution; a revert blocks that execution.
+///
+///      Decision in {checkTransaction}:
+///      1. If the credible builder set looks offline (the most recent credible block is more
+///         than `failOpenBlockThreshold` blocks behind the current block), FAIL OPEN and allow
+///         the transaction. This prevents a stalled builder set from permanently locking the Safe.
+///      2. Otherwise the builder set is live, so the current block MUST be credible; if it is
+///         not, the transaction is blocked with {NonCredibleBlock}.
+///      3. If the current block is itself credible, the transaction is always allowed.
+///
+///      Fail-open window. The product requirement is "fail open after ~15 minutes with no
+///      credible blocks". The {ICredibleRegistry} records credibility by block number and does
+///      not expose timestamps, so the window is expressed as a block count that the credible
+///      builder set would produce in ~15 minutes on the target chain, e.g.:
+///        - ~12s blocks (Ethereum mainnet): 15 min  ~= 75 blocks
+///        - ~2s blocks  (typical L2):       15 min  ~= 450 blocks
+///        - ~1s blocks:                     15 min  ~= 900 blocks
+///      Both the registry address and the fail-open threshold are immutable; re-pointing or
+///      re-tuning means deploying a new guard and calling `setGuard` again.
+contract CredibleSafeGuard is ITransactionGuard {
+    /// @notice The on-chain Credible Registry queried for block credibility.
+    ICredibleRegistry public immutable credibleRegistry;
+
+    /// @notice Number of blocks the most recent credible block may lag the current block before
+    ///         the guard fails open. Should approximate the chain's 15-minute block budget.
+    uint256 public immutable failOpenBlockThreshold;
+
+    /// @notice Thrown when the current block is not credible and the builder set is live.
+    error NonCredibleBlock();
+    /// @notice Thrown when constructed with the zero address as the registry.
+    error ZeroCredibleRegistryAddress();
+    /// @notice Thrown when constructed with a zero fail-open threshold.
+    error ZeroFailOpenBlockThreshold();
+
+    /// @param credibleRegistry_ The Credible Registry address (configurable per deployment).
+    /// @param failOpenBlockThreshold_ Blocks of builder silence tolerated before failing open.
+    constructor(ICredibleRegistry credibleRegistry_, uint256 failOpenBlockThreshold_) {
+        if (address(credibleRegistry_) == address(0)) revert ZeroCredibleRegistryAddress();
+        if (failOpenBlockThreshold_ == 0) revert ZeroFailOpenBlockThreshold();
+
+        credibleRegistry = credibleRegistry_;
+        failOpenBlockThreshold = failOpenBlockThreshold_;
+    }
+
+    /// @inheritdoc ITransactionGuard
+    /// @dev Reverts with {NonCredibleBlock} to block a Safe transaction. All transaction fields
+    ///      are ignored: the guard only gates on whether the executing block is credible.
+    function checkTransaction(
+        address,
+        uint256,
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
+    ) external view override {
+        _checkCredibleBlock();
+    }
+
+    /// @inheritdoc ITransactionGuard
+    /// @dev No post-execution checks are performed.
+    function checkAfterExecution(bytes32, bool) external pure override {}
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(ITransactionGuard).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @notice Whether a Safe transaction would currently be allowed by this guard.
+    /// @dev View helper mirroring {checkTransaction}'s decision for off-chain inspection.
+    /// @return True if the current block is credible or the guard is failing open.
+    function isCurrentBlockAllowed() external view returns (bool) {
+        return _failOpenActive() || credibleRegistry.isCredibleBlock(block.number);
+    }
+
+    /// @notice Whether the guard is currently failing open because the builder set looks offline.
+    /// @return True if the most recent credible block lags the current block beyond the threshold.
+    function failOpenActive() external view returns (bool) {
+        return _failOpenActive();
+    }
+
+    /// @dev Core gate: fail open when the builder set is offline, otherwise require credibility.
+    function _checkCredibleBlock() internal view {
+        if (_failOpenActive()) return;
+        if (!credibleRegistry.isCredibleBlock(block.number)) revert NonCredibleBlock();
+    }
+
+    /// @dev Fail-open is active when the current block is strictly more than
+    ///      `failOpenBlockThreshold` blocks ahead of the last credible block. The
+    ///      `block.number > lastCredibleBlock_` guard avoids underflow if the registry ever
+    ///      reports a last credible block at or beyond the current block.
+    function _failOpenActive() internal view returns (bool) {
+        uint256 lastCredibleBlock_ = credibleRegistry.lastCredibleBlock();
+        return block.number > lastCredibleBlock_ && block.number - lastCredibleBlock_ > failOpenBlockThreshold;
+    }
+}

--- a/src/protection/safe/ICredibleRegistry.sol
+++ b/src/protection/safe/ICredibleRegistry.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title ICredibleRegistry
+/// @author Phylax Systems
+/// @notice Read interface for the on-chain Credible Registry that tracks which blocks were
+///         marked credible by authorized credible block builders.
+/// @dev Mirrors the read surface of `phylaxsystems/credible-registry` so consumers such as
+///      {CredibleSafeGuard} are drop-in compatible with the deployed registry. The registry
+///      records block credibility by block number; it does not expose timestamps.
+interface ICredibleRegistry {
+    /// @notice Returns whether the given block number was marked credible by a whitelisted builder.
+    /// @param blockNumber The block number to query.
+    /// @return True if `blockNumber` was marked credible, false otherwise.
+    function isCredibleBlock(uint256 blockNumber) external view returns (bool);
+
+    /// @notice Returns the most recent block number that was marked credible.
+    /// @dev Returns 0 if no block has ever been marked credible.
+    /// @return The highest block number marked credible so far.
+    function lastCredibleBlock() external view returns (uint256);
+}

--- a/src/protection/safe/README.md
+++ b/src/protection/safe/README.md
@@ -1,9 +1,49 @@
-# Safe Assertions
+# Safe Protections
 
-This package contains Safe-native assertion packs. They are intentionally separate because they protect different surfaces:
+This package contains Safe-native protections. They cover different surfaces and run in different places:
 
-- `SafeConfigLockAssertion` checks the Safe configuration envelope after a transaction.
-- `SafeTxShapeAssertion` checks the direct actions a Safe is about to execute through owner or module entrypoints.
+- `SafeConfigLockAssertion` (Credible Layer assertion) checks the Safe configuration envelope after a transaction.
+- `SafeTxShapeAssertion` (Credible Layer assertion) checks the direct actions a Safe is about to execute through owner or module entrypoints.
+- `CredibleSafeGuard` (Safe transaction guard) allows Safe executions only while the current block is credible, and fails open when the credible builder set is offline.
+
+The two `*Assertion` contracts run inside the PhEvm. `CredibleSafeGuard` is a plain on-chain Gnosis Safe transaction guard installed on the Safe via `setGuard`.
+
+## Credible Safe Guard
+
+`CredibleSafeGuard` is a Gnosis Safe transaction guard that gates every owner-path Safe execution on block credibility, as reported by the on-chain [Credible Registry](https://github.com/phylaxsystems/credible-registry).
+
+Install it on a Safe with `setGuard(address(guard))`. Safe then calls `checkTransaction` before each `execTransaction`, and the guard reverts to block the execution.
+
+### What It Checks
+
+On every Safe transaction the guard reads the Credible Registry and decides:
+
+1. If the most recent credible block lags the current block by more than `failOpenBlockThreshold` blocks, the credible builder set is treated as offline, so the guard fails open and allows the transaction. This keeps a stalled builder set from locking the Safe.
+2. Otherwise the builder set is live, so the current block must be credible. If it is not, the transaction reverts with `NonCredibleBlock`.
+3. If the current block is credible, the transaction is allowed.
+
+### Config Options
+
+Both values are immutable constructor arguments:
+
+- `credibleRegistry`: address of the on-chain Credible Registry to query (`ICredibleRegistry`). Configurable per deployment; re-pointing means deploying a new guard and calling `setGuard` again.
+- `failOpenBlockThreshold`: number of blocks of builder silence tolerated before failing open.
+
+#### Choosing the fail-open threshold
+
+The target is to fail open after roughly 15 minutes with no credible blocks. The Credible Registry records credibility by block number and does not expose timestamps, so the window is expressed as the number of blocks the builder set produces in about 15 minutes on the target chain:
+
+| Block time | ~15 minutes |
+| ---------- | ----------- |
+| ~12s (Ethereum mainnet) | 75 blocks |
+| ~2s (typical L2) | 450 blocks |
+| ~1s | 900 blocks |
+
+### Material Effect
+
+- While the credible builder set is live, a Safe transaction cannot land in a non-credible block, such as one built by a builder that does not enforce assertions.
+- If the credible builder set goes offline for longer than the configured window, the Safe keeps working.
+- The guard gates only on block credibility and does not inspect the transaction target, value, calldata, or signatures. Pair it with `SafeConfigLockAssertion`, `SafeTxShapeAssertion`, or other assertions to constrain what the Safe may do within a credible block.
 
 ## Safe Tx Shape Assertion
 

--- a/src/protection/safe/README.md
+++ b/src/protection/safe/README.md
@@ -4,7 +4,7 @@ This package contains Safe-native protections. They cover different surfaces and
 
 - `SafeConfigLockAssertion` (Credible Layer assertion) checks the Safe configuration envelope after a transaction.
 - `SafeTxShapeAssertion` (Credible Layer assertion) checks the direct actions a Safe is about to execute through owner or module entrypoints.
-- `CredibleSafeGuard` (Safe transaction guard) allows Safe executions only while the current block is credible, and fails open when the credible builder set is offline.
+- `CredibleSafeGuard` (Safe transaction guard) allows owner/multisig Safe transactions only while the current block is credible, and fails open when the credible builder set is offline. It gates the owner-path `execTransaction` only; module executions bypass transaction guards (see [Scope](#scope)).
 
 The two `*Assertion` contracts run inside the PhEvm. `CredibleSafeGuard` is a plain on-chain Gnosis Safe transaction guard installed on the Safe via `setGuard`.
 
@@ -44,6 +44,10 @@ The target is to fail open after roughly 15 minutes with no credible blocks. The
 - While the credible builder set is live, a Safe transaction cannot land in a non-credible block, such as one built by a builder that does not enforce assertions.
 - If the credible builder set goes offline for longer than the configured window, the Safe keeps working.
 - The guard gates only on block credibility and does not inspect the transaction target, value, calldata, or signatures. Pair it with `SafeConfigLockAssertion`, `SafeTxShapeAssertion`, or other assertions to constrain what the Safe may do within a credible block.
+
+### Scope
+
+`CredibleSafeGuard` is a Safe *transaction* guard, so it gates only the owner/multisig `execTransaction` path. Module executions (`execTransactionFromModule` / `execTransactionFromModuleReturnData`) bypass transaction guards entirely, so an enabled module can still execute while the current block is not credible. To gate module executions, install a separate Safe module guard (the v1.5.0 `checkModuleTransaction` hook) or protect that path with a Credible Layer assertion such as `SafeTxShapeAssertion`.
 
 ## Safe Tx Shape Assertion
 

--- a/src/protection/safe/README.md
+++ b/src/protection/safe/README.md
@@ -18,9 +18,9 @@ Install it on a Safe with `setGuard(address(guard))`. Safe then calls `checkTran
 
 On every Safe transaction the guard reads the Credible Registry and decides:
 
-1. If the most recent credible block lags the current block by more than `failOpenBlockThreshold` blocks, the credible builder set is treated as offline, so the guard fails open and allows the transaction. This keeps a stalled builder set from locking the Safe.
-2. Otherwise the builder set is live, so the current block must be credible. If it is not, the transaction reverts with `NonCredibleBlock`.
-3. If the current block is credible, the transaction is allowed.
+1. If the current block is credible, the transaction is allowed.
+2. Otherwise, if the most recent credible block lags the current block by more than `failOpenBlockThreshold` blocks, the credible builder set is treated as offline, so the guard fails open and allows the transaction. This keeps a stalled builder set from locking the Safe.
+3. Otherwise the builder set is live and the current block is not credible, so the transaction reverts with `NonCredibleBlock`.
 
 ### Config Options
 

--- a/test/protection/safe/CredibleSafeGuard.t.sol
+++ b/test/protection/safe/CredibleSafeGuard.t.sol
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ICredibleRegistry} from "../../../src/protection/safe/ICredibleRegistry.sol";
+import {CredibleSafeGuard, Enum, IERC165, ITransactionGuard} from "../../../src/protection/safe/CredibleSafeGuard.sol";
+
+/// @notice Test double for the Credible Registry. Exposes fine-grained setters and a faithful
+///         `markCurrentBlockCredible()` replicating `phylaxsystems/credible-registry` semantics.
+contract MockCredibleRegistry is ICredibleRegistry {
+    mapping(uint256 blockNumber => bool credible) internal _credible;
+    uint256 internal _lastCredibleBlock;
+
+    function setCredibleBlock(uint256 blockNumber, bool credible) external {
+        _credible[blockNumber] = credible;
+    }
+
+    function setLastCredibleBlock(uint256 blockNumber) external {
+        _lastCredibleBlock = blockNumber;
+    }
+
+    /// @dev Mirrors the real registry: marks `block.number` credible and advances the pointer.
+    function markCurrentBlockCredible() external {
+        _credible[block.number] = true;
+        _lastCredibleBlock = block.number;
+    }
+
+    function isCredibleBlock(uint256 blockNumber) external view returns (bool) {
+        return _credible[blockNumber];
+    }
+
+    function lastCredibleBlock() external view returns (uint256) {
+        return _lastCredibleBlock;
+    }
+}
+
+/// @notice Minimal Safe stand-in that calls the guard before "executing", mimicking the
+///         relevant slice of `Safe.execTransaction`.
+contract MockSafe {
+    CredibleSafeGuard public immutable guard;
+    uint256 public executed;
+
+    constructor(CredibleSafeGuard guard_) {
+        guard = guard_;
+    }
+
+    function execTransaction(address to, uint256 value, bytes memory data, Enum.Operation operation) external {
+        guard.checkTransaction(to, value, data, operation, 0, 0, 0, address(0), payable(address(0)), "", msg.sender);
+        executed++;
+    }
+}
+
+contract CredibleSafeGuardTest is Test {
+    /// @dev Known Safe `type(Guard).interfaceId` / `type(ITransactionGuard).interfaceId`.
+    bytes4 internal constant SAFE_GUARD_INTERFACE_ID = 0xe6d7a83a;
+    bytes4 internal constant ERC165_INTERFACE_ID = 0x01ffc9a7;
+
+    /// @dev ~15 minutes of 12s blocks; chosen so boundaries are easy to reason about.
+    uint256 internal constant THRESHOLD = 75;
+    uint256 internal constant BASE_BLOCK = 1_000_000;
+
+    MockCredibleRegistry internal registry;
+    CredibleSafeGuard internal guard;
+
+    function setUp() public {
+        registry = new MockCredibleRegistry();
+        guard = new CredibleSafeGuard(registry, THRESHOLD);
+        vm.roll(BASE_BLOCK);
+    }
+
+    /// @dev Calls the guard with a representative full Safe transaction tuple.
+    function _check() internal view {
+        guard.checkTransaction(
+            address(0xBEEF),
+            1 ether,
+            hex"abcdef",
+            Enum.Operation.Call,
+            21_000,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            hex"1234",
+            address(0xCAFE)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------------
+
+    function test_constructor_storesArgs() public view {
+        assertEq(address(guard.credibleRegistry()), address(registry));
+        assertEq(guard.failOpenBlockThreshold(), THRESHOLD);
+    }
+
+    function test_constructor_revertsOnZeroRegistry() public {
+        vm.expectRevert(CredibleSafeGuard.ZeroCredibleRegistryAddress.selector);
+        new CredibleSafeGuard(ICredibleRegistry(address(0)), THRESHOLD);
+    }
+
+    function test_constructor_revertsOnZeroThreshold() public {
+        vm.expectRevert(CredibleSafeGuard.ZeroFailOpenBlockThreshold.selector);
+        new CredibleSafeGuard(registry, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // ERC-165 / Safe drop-in compatibility
+    // ---------------------------------------------------------------------
+
+    function test_supportsInterface_safeGuardAndErc165() public view {
+        assertTrue(guard.supportsInterface(SAFE_GUARD_INTERFACE_ID));
+        assertTrue(guard.supportsInterface(type(ITransactionGuard).interfaceId));
+        assertTrue(guard.supportsInterface(ERC165_INTERFACE_ID));
+        assertTrue(guard.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function test_supportsInterface_computedIdMatchesSafeConstant() public pure {
+        assertEq(type(ITransactionGuard).interfaceId, SAFE_GUARD_INTERFACE_ID);
+    }
+
+    function test_supportsInterface_rejectsOthers() public view {
+        // EIP-165 mandates returning false for 0xffffffff.
+        assertFalse(guard.supportsInterface(0xffffffff));
+        assertFalse(guard.supportsInterface(0xdeadbeef));
+        assertFalse(guard.supportsInterface(0x00000000));
+    }
+
+    // ---------------------------------------------------------------------
+    // Allow path: current block is credible
+    // ---------------------------------------------------------------------
+
+    function test_allows_whenCurrentBlockCredible() public {
+        registry.markCurrentBlockCredible();
+
+        _check();
+        assertTrue(guard.isCurrentBlockAllowed());
+        assertFalse(guard.failOpenActive());
+    }
+
+    function test_allows_whenCurrentBlockCredible_beatsHugeGapInRegistryPointer() public {
+        // Even if lastCredibleBlock happens to equal current block, gap is 0 -> not fail open,
+        // and credibility carries the allow.
+        registry.markCurrentBlockCredible();
+        assertEq(registry.lastCredibleBlock(), block.number);
+        _check();
+    }
+
+    // ---------------------------------------------------------------------
+    // Block path: builder set live, current block not credible
+    // ---------------------------------------------------------------------
+
+    function test_reverts_whenNotCredible_withinThreshold() public {
+        // Last credible block is 10 behind (<= 75) -> builder set still considered live.
+        registry.setLastCredibleBlock(block.number - 10);
+
+        assertFalse(guard.isCurrentBlockAllowed());
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        _check();
+    }
+
+    function test_reverts_atFailOpenBoundary() public {
+        // gap == threshold (75) is NOT strictly greater -> still live -> must be credible.
+        registry.setLastCredibleBlock(block.number - THRESHOLD);
+
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        _check();
+    }
+
+    // ---------------------------------------------------------------------
+    // Fail-open path: builder set offline
+    // ---------------------------------------------------------------------
+
+    function test_failsOpen_whenGapExceedsThreshold() public {
+        // gap == threshold + 1 (76) -> fail open even though current block is not credible.
+        registry.setLastCredibleBlock(block.number - (THRESHOLD + 1));
+
+        assertTrue(guard.failOpenActive());
+        assertTrue(guard.isCurrentBlockAllowed());
+        _check();
+    }
+
+    function test_failsOpen_whenRegistryNeverMarked_andBeyondThreshold() public {
+        // lastCredibleBlock defaults to 0; once current block exceeds the threshold, fail open.
+        vm.roll(THRESHOLD + 1);
+        assertTrue(guard.failOpenActive());
+        _check();
+    }
+
+    function test_reverts_whenRegistryNeverMarked_atThresholdBlock() public {
+        // At exactly the threshold block, gap (== block.number) is not strictly greater.
+        vm.roll(THRESHOLD);
+        assertFalse(guard.failOpenActive());
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        _check();
+    }
+
+    function test_checksCurrentBlockOnly_notPreviousCredibleBlock() public {
+        // Mark block N credible, then advance one block: N+1 is not credible and still within
+        // the live window, so the guard blocks.
+        registry.markCurrentBlockCredible();
+        vm.roll(block.number + 1);
+
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        _check();
+    }
+
+    // ---------------------------------------------------------------------
+    // Defensive: registry reports a last credible block at/after current block
+    // ---------------------------------------------------------------------
+
+    function test_noUnderflow_whenLastCredibleBlockInFuture() public {
+        registry.setLastCredibleBlock(block.number + 5);
+        // Not fail open, current block not credible -> clean NonCredibleBlock revert, no panic.
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        _check();
+    }
+
+    // ---------------------------------------------------------------------
+    // Post-execution hook is a no-op
+    // ---------------------------------------------------------------------
+
+    function test_checkAfterExecution_isNoop() public view {
+        guard.checkAfterExecution(bytes32(0), true);
+        guard.checkAfterExecution(keccak256("tx"), false);
+    }
+
+    // ---------------------------------------------------------------------
+    // Full ABI exercise, including delegatecall operation
+    // ---------------------------------------------------------------------
+
+    function test_checkTransaction_delegateCallOperation_allowedWhenCredible() public {
+        registry.markCurrentBlockCredible();
+        guard.checkTransaction(
+            address(0x1234),
+            0,
+            hex"deadbeef",
+            Enum.Operation.DelegateCall,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            "",
+            address(this)
+        );
+    }
+
+    function test_checkTransaction_delegateCallOperation_blockedWhenNotCredible() public {
+        registry.setLastCredibleBlock(block.number - 1);
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        guard.checkTransaction(
+            address(0x1234),
+            0,
+            hex"deadbeef",
+            Enum.Operation.DelegateCall,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            "",
+            address(this)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Integration via a mock Safe
+    // ---------------------------------------------------------------------
+
+    function test_integration_safeExecution_allowedInCredibleBlock() public {
+        MockSafe safe = new MockSafe(guard);
+        registry.markCurrentBlockCredible();
+
+        safe.execTransaction(address(0xABCD), 0, hex"00", Enum.Operation.Call);
+        assertEq(safe.executed(), 1);
+    }
+
+    function test_integration_safeExecution_blockedInNonCredibleBlock() public {
+        MockSafe safe = new MockSafe(guard);
+        registry.setLastCredibleBlock(block.number - 1);
+
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        safe.execTransaction(address(0xABCD), 0, hex"00", Enum.Operation.Call);
+        assertEq(safe.executed(), 0);
+    }
+
+    function test_integration_safeExecution_failsOpenWhenBuilderOffline() public {
+        MockSafe safe = new MockSafe(guard);
+        registry.setLastCredibleBlock(block.number - (THRESHOLD + 1));
+
+        safe.execTransaction(address(0xABCD), 0, hex"00", Enum.Operation.Call);
+        assertEq(safe.executed(), 1);
+    }
+
+    function test_integration_endToEnd_builderStallThenRecover() public {
+        MockSafe safe = new MockSafe(guard);
+
+        // Builder healthy: this block is credible -> allowed.
+        registry.markCurrentBlockCredible();
+        safe.execTransaction(address(0xABCD), 0, "", Enum.Operation.Call);
+
+        // Builder misses a few blocks but is still within the live window -> blocked.
+        vm.roll(block.number + 10);
+        vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+        safe.execTransaction(address(0xABCD), 0, "", Enum.Operation.Call);
+
+        // Builder stays silent past the window -> fail open -> allowed.
+        vm.roll(block.number + THRESHOLD);
+        safe.execTransaction(address(0xABCD), 0, "", Enum.Operation.Call);
+
+        // Builder recovers and marks the new current block -> allowed again.
+        registry.markCurrentBlockCredible();
+        safe.execTransaction(address(0xABCD), 0, "", Enum.Operation.Call);
+
+        assertEq(safe.executed(), 3);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz: decision is exactly "credible current block OR gap beyond threshold"
+    // ---------------------------------------------------------------------
+
+    function testFuzz_decisionMatchesSpec(uint256 gap, bool currentCredible) public {
+        gap = bound(gap, 0, 10 * THRESHOLD);
+        // Keep BASE_BLOCK large enough that block.number - gap never underflows.
+        registry.setLastCredibleBlock(block.number - gap);
+        if (currentCredible) registry.setCredibleBlock(block.number, true);
+
+        bool failOpen = gap > THRESHOLD; // block.number > last is guaranteed for gap > 0
+        bool expectedAllowed = failOpen || currentCredible;
+
+        assertEq(guard.failOpenActive(), failOpen);
+        assertEq(guard.isCurrentBlockAllowed(), expectedAllowed);
+
+        if (expectedAllowed) {
+            _check();
+        } else {
+            vm.expectRevert(CredibleSafeGuard.NonCredibleBlock.selector);
+            _check();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `CredibleSafeGuard`, a Gnosis Safe **transaction guard** that only allows Safe executions while the current block is credible — as reported by the on-chain [Credible Registry](https://github.com/phylaxsystems/credible-registry) — and **fails open** after a configurable window when the credible builder set is offline, so the Safe is never bricked.

Closes ENG-3671.

## How it works

Installed on a Safe via `setGuard`. On every owner-path `execTransaction`, Safe calls `checkTransaction`, which:

1. **Fails open** (allows) if the last credible block lags the current block by more than `failOpenBlockThreshold` — the credible builder set looks offline.
2. Otherwise requires the current block to be credible, reverting `NonCredibleBlock` if not.
3. Allows when the current block is itself credible.

Implements `ITransactionGuard` + ERC-165; `supportsInterface` returns `0xe6d7a83a` (equal to Safe's `type(Guard).interfaceId`), so it passes Safe's `setGuard` `GS300` check.

## Design notes

- **Registry interface**: vendored `ICredibleRegistry` (`isCredibleBlock`, `lastCredibleBlock`) mirroring the registry repo, so the guard is drop-in compatible.
- **"15 minutes" expressed in blocks**: the registry records credibility by block number with no timestamps, so the fail-open window is a configurable block count — the blocks a builder produces in ~15 min on the target chain (e.g. 75 @ 12s, 450 @ 2s). Documented in the Safe README.
- **Configurable**: registry address and fail-open threshold are immutable constructor args; zero values revert.

## Tests

- `test/protection/safe/CredibleSafeGuard.t.sol` — 23 unit tests against a mock registry: allow / block / fail-open, exact boundaries, ERC-165 (incl. EIP-165 `0xffffffff` → false), no-underflow, delegatecall ABI, a `MockSafe` call path, and a fuzz over the decision rule.
- `examples/safe-guard/` — 5 **real Gnosis Safe v1.4.1** end-to-end tests: install via signed `execTransaction` → `setGuard` (exercises Safe's real ERC-165 check), then real signed transactions through the credible / non-credible / **fail-open** / stall→recover paths.

The Safe integration suite runs on its own `safe-guard` profile (legacy pipeline: `optimizer`, no `via_ir`, since Safe does not compile under the root `via_ir` profiles) and is wired into the `examples-pcl` CI matrix. Safe is added as a test-only submodule pinned at `v1.4.1-3`.

```
FOUNDRY_PROFILE=ci forge test --match-path 'test/protection/safe/CredibleSafeGuard.t.sol'   # 23 passed
FOUNDRY_PROFILE=safe-guard forge test                                                        # 5 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
