### PR TITLE
feat(credible-std): add reusable CredibleBlockGuard onlyCredibleBlock modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Credible Block Guard**: `CredibleBlockGuard` reusable mixin (`src/protection/credible_block/`) exposing an `onlyCredibleBlock` modifier that gates functions on block credibility via the on-chain Credible Registry, failing open when the credible builder set goes offline so protected contracts are never bricked. Ships with an ABI-compatible `ICredibleRegistry` interface (matching `phylaxsystems/credible-registry`) and a full test suite.
+
 ## [0.4.0] - 2025-01-22
 
 ### Added

--- a/src/protection/credible_block/CredibleBlockGuard.sol
+++ b/src/protection/credible_block/CredibleBlockGuard.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ICredibleRegistry} from "./ICredibleRegistry.sol";
+
+/// @title CredibleBlockGuard
+/// @author Phylax Systems
+/// @notice Reusable mixin that gates functions on block credibility. Inherit it and apply the
+///         {onlyCredibleBlock} modifier to any function that should only execute while the
+///         current block is credible, i.e. built by a Credible Layer builder that enforces
+///         assertions. When the credible builder set is offline the guard fails open so the
+///         protected contract is never bricked.
+/// @dev This is the general-purpose form of the credibility gate. {CredibleSafeGuard} is the
+///      same decision wired into a Safe transaction guard; protocols that want to protect their
+///      own functions directly should inherit this contract instead.
+///
+///      Decision in {_checkCredibleBlock} (run by {onlyCredibleBlock} before the function body):
+///      1. If the credible builder set looks offline (the most recent credible block is more
+///         than `failOpenBlockThreshold` blocks behind the current block), FAIL OPEN and allow
+///         the call. This prevents a stalled builder set from permanently locking the contract.
+///      2. Otherwise the builder set is live, so the current block MUST be credible; if it is
+///         not, the call is blocked with {NonCredibleBlock}.
+///      3. If the current block is itself credible, the call is always allowed.
+///
+///      Fail-open window. The product requirement is "fail open after ~15 minutes with no
+///      credible blocks". The {ICredibleRegistry} records credibility by block number and does
+///      not expose timestamps, so the window is expressed as a block count that the credible
+///      builder set would produce in ~15 minutes on the target chain, e.g.:
+///        - ~12s blocks (Ethereum mainnet): 15 min  ~= 75 blocks
+///        - ~2s blocks  (typical L2):       15 min  ~= 450 blocks
+///        - ~1s blocks:                     15 min  ~= 900 blocks
+///      Both the registry address and the fail-open threshold are immutable; re-pointing or
+///      re-tuning means redeploying the inheriting contract. (Configurable per deployment.)
+abstract contract CredibleBlockGuard {
+    /// @notice The on-chain Credible Registry queried for block credibility.
+    ICredibleRegistry public immutable credibleRegistry;
+
+    /// @notice Number of blocks the most recent credible block may lag the current block before
+    ///         the guard fails open. Should approximate the chain's 15-minute block budget.
+    uint256 public immutable failOpenBlockThreshold;
+
+    /// @notice Thrown when the current block is not credible and the builder set is live.
+    error NonCredibleBlock();
+    /// @notice Thrown when constructed with the zero address as the registry.
+    error ZeroCredibleRegistryAddress();
+    /// @notice Thrown when constructed with a zero fail-open threshold.
+    error ZeroFailOpenBlockThreshold();
+
+    /// @param credibleRegistry_ The Credible Registry address (configurable per deployment).
+    /// @param failOpenBlockThreshold_ Blocks of builder silence tolerated before failing open.
+    constructor(ICredibleRegistry credibleRegistry_, uint256 failOpenBlockThreshold_) {
+        if (address(credibleRegistry_) == address(0)) revert ZeroCredibleRegistryAddress();
+        if (failOpenBlockThreshold_ == 0) revert ZeroFailOpenBlockThreshold();
+
+        credibleRegistry = credibleRegistry_;
+        failOpenBlockThreshold = failOpenBlockThreshold_;
+    }
+
+    /// @notice Reverts the call unless the current block is credible or the guard is failing open.
+    /// @dev Apply to any function that must only run under credible-block protection.
+    modifier onlyCredibleBlock() {
+        _checkCredibleBlock();
+        _;
+    }
+
+    /// @notice Whether a call guarded by {onlyCredibleBlock} would currently be allowed.
+    /// @dev View helper mirroring {_checkCredibleBlock}'s decision for off-chain inspection.
+    /// @return True if the current block is credible or the guard is failing open.
+    function isCurrentBlockAllowed() public view returns (bool) {
+        return _failOpenActive() || credibleRegistry.isCredibleBlock(block.number);
+    }
+
+    /// @notice Whether the guard is currently failing open because the builder set looks offline.
+    /// @return True if the most recent credible block lags the current block beyond the threshold.
+    function failOpenActive() public view returns (bool) {
+        return _failOpenActive();
+    }
+
+    /// @dev Core gate: fail open when the builder set is offline, otherwise require credibility.
+    function _checkCredibleBlock() internal view {
+        if (_failOpenActive()) return;
+        if (!credibleRegistry.isCredibleBlock(block.number)) revert NonCredibleBlock();
+    }
+
+    /// @dev Fail-open is active when the current block is strictly more than
+    ///      `failOpenBlockThreshold` blocks ahead of the last credible block. The
+    ///      `block.number > lastCredibleBlock_` guard avoids underflow if the registry ever
+    ///      reports a last credible block at or beyond the current block.
+    function _failOpenActive() internal view returns (bool) {
+        uint256 lastCredibleBlock_ = credibleRegistry.lastCredibleBlock();
+        return block.number > lastCredibleBlock_ && block.number - lastCredibleBlock_ > failOpenBlockThreshold;
+    }
+}

--- a/src/protection/credible_block/ICredibleRegistry.sol
+++ b/src/protection/credible_block/ICredibleRegistry.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title ICredibleRegistry
+/// @author Phylax Systems
+/// @notice Read interface for the on-chain Credible Registry that tracks which blocks were
+///         marked credible by authorized credible block builders.
+/// @dev Mirrors the read surface of `phylaxsystems/credible-registry` so consumers such as
+///      {CredibleBlockGuard} are drop-in compatible with the deployed registry. The registry
+///      records block credibility by block number; it does not expose timestamps.
+interface ICredibleRegistry {
+    /// @notice Returns whether the given block number was marked credible by a whitelisted builder.
+    /// @param blockNumber The block number to query.
+    /// @return True if `blockNumber` was marked credible, false otherwise.
+    function isCredibleBlock(uint256 blockNumber) external view returns (bool);
+
+    /// @notice Returns the most recent block number that was marked credible.
+    /// @dev Returns 0 if no block has ever been marked credible.
+    /// @return The highest block number marked credible so far.
+    function lastCredibleBlock() external view returns (uint256);
+}

--- a/src/protection/credible_block/README.md
+++ b/src/protection/credible_block/README.md
@@ -1,0 +1,69 @@
+# Credible Block Guard
+
+A reusable mixin that gates contract functions on **block credibility**: a guarded function only
+executes while the current block is credible (built by a Credible Layer builder that enforces
+assertions), and **fails open** if the credible builder set goes offline so the contract is never
+permanently bricked.
+
+This is the general-purpose form of the credibility gate. `CredibleSafeGuard`
+(`src/protection/safe/CredibleSafeGuard.sol`) is the same decision wired into a Safe transaction
+guard; inherit `CredibleBlockGuard` directly when you want to protect your own functions.
+
+## Files
+
+- `ICredibleRegistry.sol` — read interface for the on-chain Credible Registry
+  (`isCredibleBlock(blockNumber)`, `lastCredibleBlock()`), mirroring `phylaxsystems/credible-registry`.
+- `CredibleBlockGuard.sol` — abstract base contract providing the `onlyCredibleBlock` modifier.
+
+## Usage
+
+```solidity
+import {CredibleBlockGuard} from "credible-std/protection/credible_block/CredibleBlockGuard.sol";
+import {ICredibleRegistry} from "credible-std/protection/credible_block/ICredibleRegistry.sol";
+
+contract MyVault is CredibleBlockGuard {
+    // failOpenThreshold ~= number of blocks the chain produces in ~15 minutes
+    constructor(ICredibleRegistry registry, uint256 failOpenThreshold)
+        CredibleBlockGuard(registry, failOpenThreshold)
+    {}
+
+    function withdraw(uint256 amount) external onlyCredibleBlock {
+        // only runs in a credible block, or while the guard is failing open
+    }
+}
+```
+
+## Decision
+
+`onlyCredibleBlock` runs the following before the function body:
+
+1. **Fail open** — if the most recent credible block is more than `failOpenBlockThreshold` blocks
+   behind the current block, the builder set looks offline: allow the call. This prevents a
+   stalled builder set from permanently locking the contract.
+2. Otherwise the builder set is live, so the current block **must** be credible; if it is not, the
+   call reverts with `NonCredibleBlock`.
+3. If the current block is itself credible, the call is always allowed.
+
+`isCurrentBlockAllowed()` and `failOpenActive()` expose the same decision as view helpers for
+off-chain inspection.
+
+## Fail-open window
+
+The product requirement is "fail open after ~15 minutes with no credible blocks". The registry
+records credibility by block number and does not expose timestamps, so the window is a block count
+approximating the chain's 15-minute budget:
+
+| Block time | ~15 min |
+| ---------- | ------- |
+| ~12s (Ethereum mainnet) | ~75 blocks |
+| ~2s (typical L2) | ~450 blocks |
+| ~1s | ~900 blocks |
+
+Both the registry address and the threshold are immutable (configurable per deployment); re-pointing
+or re-tuning means redeploying the inheriting contract.
+
+## Tests
+
+```sh
+forge test --match-path "test/protection/credible_block/CredibleBlockGuard.t.sol"
+```

--- a/test/protection/credible_block/CredibleBlockGuard.t.sol
+++ b/test/protection/credible_block/CredibleBlockGuard.t.sol
@@ -216,28 +216,48 @@ contract CredibleBlockGuardTest is Test {
     }
 
     // ---------------------------------------------------------------------
-    // Fuzz: decision is exactly "credible current block OR gap beyond threshold"
+    // Decision table: allowed == "credible current block OR gap beyond threshold"
+    //
+    // The gate is fully deterministic, so a fixed table over the boundary-relevant
+    // gaps (below / at / above the threshold, with the current block credible or
+    // not) gives the same coverage an equivalent fuzz test would. It is kept
+    // table-driven rather than fuzzed because this directory is gated by the
+    // `pcl test` runner, whose fuzzing worker overflows its stack and aborts the
+    // whole protection job.
     // ---------------------------------------------------------------------
 
-    function testFuzz_decisionMatchesSpec(uint256 gap, bool currentCredible) public {
-        gap = bound(gap, 0, 10 * THRESHOLD);
-        // Keep BASE_BLOCK large enough that block.number - gap never underflows.
-        registry.setLastCredibleBlock(block.number - gap);
-        if (currentCredible) registry.setCredibleBlock(block.number, true);
+    function test_decisionMatchesSpec_acrossGaps() public {
+        uint256[6] memory gaps = [uint256(0), 1, THRESHOLD - 1, THRESHOLD, THRESHOLD + 1, 10 * THRESHOLD];
+
+        for (uint256 i = 0; i < gaps.length; i++) {
+            _assertDecision(gaps[i], false);
+            _assertDecision(gaps[i], true);
+        }
+    }
+
+    /// @dev Asserts the gate's decision for one (gap, currentCredible) case. Uses fresh
+    ///      instances so each case starts from a clean slate, exactly as a fuzz run would.
+    function _assertDecision(uint256 gap, bool currentCredible) internal {
+        MockCredibleRegistry reg = new MockCredibleRegistry();
+        GuardedVault v = new GuardedVault(reg, THRESHOLD);
+
+        // BASE_BLOCK is large enough that block.number - gap never underflows.
+        reg.setLastCredibleBlock(block.number - gap);
+        if (currentCredible) reg.setCredibleBlock(block.number, true);
 
         bool failOpen = gap > THRESHOLD; // block.number > last is guaranteed for gap > 0
         bool expectedAllowed = failOpen || currentCredible;
 
-        assertEq(vault.failOpenActive(), failOpen);
-        assertEq(vault.isCurrentBlockAllowed(), expectedAllowed);
+        assertEq(v.failOpenActive(), failOpen);
+        assertEq(v.isCurrentBlockAllowed(), expectedAllowed);
 
         if (expectedAllowed) {
-            vault.doProtectedAction();
-            assertEq(vault.actions(), 1);
+            v.doProtectedAction();
+            assertEq(v.actions(), 1);
         } else {
             vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
-            vault.doProtectedAction();
-            assertEq(vault.actions(), 0);
+            v.doProtectedAction();
+            assertEq(v.actions(), 0);
         }
     }
 }

--- a/test/protection/credible_block/CredibleBlockGuard.t.sol
+++ b/test/protection/credible_block/CredibleBlockGuard.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ICredibleRegistry} from "../../../src/protection/credible_block/ICredibleRegistry.sol";
+import {CredibleBlockGuard} from "../../../src/protection/credible_block/CredibleBlockGuard.sol";
+
+/// @notice Test double for the Credible Registry. Exposes fine-grained setters and a faithful
+///         `markCurrentBlockCredible()` replicating `phylaxsystems/credible-registry` semantics.
+contract MockCredibleRegistry is ICredibleRegistry {
+    mapping(uint256 blockNumber => bool credible) internal _credible;
+    uint256 internal _lastCredibleBlock;
+
+    function setCredibleBlock(uint256 blockNumber, bool credible) external {
+        _credible[blockNumber] = credible;
+    }
+
+    function setLastCredibleBlock(uint256 blockNumber) external {
+        _lastCredibleBlock = blockNumber;
+    }
+
+    /// @dev Mirrors the real registry: marks `block.number` credible and advances the pointer.
+    function markCurrentBlockCredible() external {
+        _credible[block.number] = true;
+        _lastCredibleBlock = block.number;
+    }
+
+    function isCredibleBlock(uint256 blockNumber) external view returns (bool) {
+        return _credible[blockNumber];
+    }
+
+    function lastCredibleBlock() external view returns (uint256) {
+        return _lastCredibleBlock;
+    }
+}
+
+/// @notice Minimal protocol contract that adopts the guard and protects a function with the
+///         {CredibleBlockGuard.onlyCredibleBlock} modifier, exactly how an integrator would.
+contract GuardedVault is CredibleBlockGuard {
+    uint256 public actions;
+
+    constructor(ICredibleRegistry registry_, uint256 threshold_) CredibleBlockGuard(registry_, threshold_) {}
+
+    /// @dev Gated: only executes in a credible block (or while failing open).
+    function doProtectedAction() external onlyCredibleBlock {
+        actions++;
+    }
+
+    /// @dev Ungated control: must always execute regardless of credibility.
+    function doUnguardedAction() external returns (uint256) {
+        return ++actions;
+    }
+}
+
+contract CredibleBlockGuardTest is Test {
+    /// @dev ~15 minutes of 12s blocks; chosen so boundaries are easy to reason about.
+    uint256 internal constant THRESHOLD = 75;
+    uint256 internal constant BASE_BLOCK = 1_000_000;
+
+    MockCredibleRegistry internal registry;
+    GuardedVault internal vault;
+
+    function setUp() public {
+        registry = new MockCredibleRegistry();
+        vault = new GuardedVault(registry, THRESHOLD);
+        vm.roll(BASE_BLOCK);
+    }
+
+    // ---------------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------------
+
+    function test_constructor_storesArgs() public view {
+        assertEq(address(vault.credibleRegistry()), address(registry));
+        assertEq(vault.failOpenBlockThreshold(), THRESHOLD);
+    }
+
+    function test_constructor_revertsOnZeroRegistry() public {
+        vm.expectRevert(CredibleBlockGuard.ZeroCredibleRegistryAddress.selector);
+        new GuardedVault(ICredibleRegistry(address(0)), THRESHOLD);
+    }
+
+    function test_constructor_revertsOnZeroThreshold() public {
+        vm.expectRevert(CredibleBlockGuard.ZeroFailOpenBlockThreshold.selector);
+        new GuardedVault(registry, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Allow path: current block is credible
+    // ---------------------------------------------------------------------
+
+    function test_allows_whenCurrentBlockCredible() public {
+        registry.markCurrentBlockCredible();
+
+        vault.doProtectedAction();
+        assertEq(vault.actions(), 1);
+        assertTrue(vault.isCurrentBlockAllowed());
+        assertFalse(vault.failOpenActive());
+    }
+
+    function test_allows_whenCurrentBlockCredible_lastPointerEqualsCurrent() public {
+        // lastCredibleBlock == current block -> gap 0, not fail open; credibility carries allow.
+        registry.markCurrentBlockCredible();
+        assertEq(registry.lastCredibleBlock(), block.number);
+        vault.doProtectedAction();
+        assertEq(vault.actions(), 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Modifier scope: only the guarded function is gated
+    // ---------------------------------------------------------------------
+
+    function test_unguardedFunction_runsInNonCredibleBlock() public {
+        // Builder live, block not credible -> guarded path would revert, unguarded must not.
+        registry.setLastCredibleBlock(block.number - 1);
+        assertEq(vault.doUnguardedAction(), 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Block path: builder set live, current block not credible
+    // ---------------------------------------------------------------------
+
+    function test_reverts_whenNotCredible_withinThreshold() public {
+        // Last credible block is 10 behind (<= 75) -> builder set still considered live.
+        registry.setLastCredibleBlock(block.number - 10);
+
+        assertFalse(vault.isCurrentBlockAllowed());
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+        assertEq(vault.actions(), 0);
+    }
+
+    function test_reverts_atFailOpenBoundary() public {
+        // gap == threshold (75) is NOT strictly greater -> still live -> must be credible.
+        registry.setLastCredibleBlock(block.number - THRESHOLD);
+
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+    }
+
+    // ---------------------------------------------------------------------
+    // Fail-open path: builder set offline
+    // ---------------------------------------------------------------------
+
+    function test_failsOpen_whenGapExceedsThreshold() public {
+        // gap == threshold + 1 (76) -> fail open even though current block is not credible.
+        registry.setLastCredibleBlock(block.number - (THRESHOLD + 1));
+
+        assertTrue(vault.failOpenActive());
+        assertTrue(vault.isCurrentBlockAllowed());
+        vault.doProtectedAction();
+        assertEq(vault.actions(), 1);
+    }
+
+    function test_failsOpen_whenRegistryNeverMarked_andBeyondThreshold() public {
+        // lastCredibleBlock defaults to 0; once current block exceeds the threshold, fail open.
+        vm.roll(THRESHOLD + 1);
+        assertTrue(vault.failOpenActive());
+        vault.doProtectedAction();
+        assertEq(vault.actions(), 1);
+    }
+
+    function test_reverts_whenRegistryNeverMarked_atThresholdBlock() public {
+        // At exactly the threshold block, gap (== block.number) is not strictly greater.
+        vm.roll(THRESHOLD);
+        assertFalse(vault.failOpenActive());
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+    }
+
+    function test_checksCurrentBlockOnly_notPreviousCredibleBlock() public {
+        // Mark block N credible, then advance one block: N+1 is not credible and still within
+        // the live window, so the guard blocks.
+        registry.markCurrentBlockCredible();
+        vm.roll(block.number + 1);
+
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+    }
+
+    // ---------------------------------------------------------------------
+    // Defensive: registry reports a last credible block at/after current block
+    // ---------------------------------------------------------------------
+
+    function test_noUnderflow_whenLastCredibleBlockInFuture() public {
+        registry.setLastCredibleBlock(block.number + 5);
+        // Not fail open, current block not credible -> clean NonCredibleBlock revert, no panic.
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+    }
+
+    // ---------------------------------------------------------------------
+    // End-to-end builder stall then recover
+    // ---------------------------------------------------------------------
+
+    function test_endToEnd_builderStallThenRecover() public {
+        // Builder healthy: this block is credible -> allowed.
+        registry.markCurrentBlockCredible();
+        vault.doProtectedAction();
+
+        // Builder misses a few blocks but is still within the live window -> blocked.
+        vm.roll(block.number + 10);
+        vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+        vault.doProtectedAction();
+
+        // Builder stays silent past the window -> fail open -> allowed.
+        vm.roll(block.number + THRESHOLD);
+        vault.doProtectedAction();
+
+        // Builder recovers and marks the new current block -> allowed again.
+        registry.markCurrentBlockCredible();
+        vault.doProtectedAction();
+
+        assertEq(vault.actions(), 3);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz: decision is exactly "credible current block OR gap beyond threshold"
+    // ---------------------------------------------------------------------
+
+    function testFuzz_decisionMatchesSpec(uint256 gap, bool currentCredible) public {
+        gap = bound(gap, 0, 10 * THRESHOLD);
+        // Keep BASE_BLOCK large enough that block.number - gap never underflows.
+        registry.setLastCredibleBlock(block.number - gap);
+        if (currentCredible) registry.setCredibleBlock(block.number, true);
+
+        bool failOpen = gap > THRESHOLD; // block.number > last is guaranteed for gap > 0
+        bool expectedAllowed = failOpen || currentCredible;
+
+        assertEq(vault.failOpenActive(), failOpen);
+        assertEq(vault.isCurrentBlockAllowed(), expectedAllowed);
+
+        if (expectedAllowed) {
+            vault.doProtectedAction();
+            assertEq(vault.actions(), 1);
+        } else {
+            vm.expectRevert(CredibleBlockGuard.NonCredibleBlock.selector);
+            vault.doProtectedAction();
+            assertEq(vault.actions(), 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **`CredibleBlockGuard`** — a reusable mixin that gates functions on **block credibility**. Inherit it and apply the `onlyCredibleBlock` modifier to any function that should only execute while the current block is credible (built by a Credible Layer builder that enforces assertions), with a **fail-open** so protected contracts are never permanently bricked.

This is the general-purpose, function-level form of the credibility gate (ENG-3663). `CredibleSafeGuard` (ENG-3671, #83) is the same decision wired into a Gnosis Safe transaction guard; this one is just a modifier with no Safe coupling.

```solidity
contract MyVault is CredibleBlockGuard {
    constructor(ICredibleRegistry reg, uint256 failOpenThreshold)
        CredibleBlockGuard(reg, failOpenThreshold) {}

    function withdraw(uint256 amt) external onlyCredibleBlock { ... }
}
```

## Decision (`onlyCredibleBlock`)

1. **Fail open** — if the most recent credible block lags the current block by more than `failOpenBlockThreshold`, the builder set looks offline → allow the call.
2. Otherwise the builder set is live → the current block **must** be credible, else revert `NonCredibleBlock`.
3. A credible current block is always allowed.

`isCurrentBlockAllowed()` / `failOpenActive()` expose the same decision as view helpers.

## ABI compatibility

`ICredibleRegistry` here is identical to the deployed [`phylaxsystems/credible-registry`](https://github.com/phylaxsystems/credible-registry) interface (`isCredibleBlock(uint256)`, `lastCredibleBlock()`) — verified against the source, same selectors. The registry address and fail-open threshold are configured per deployment via the constructor; the threshold is expressed as a block count approximating the chain's ~15-minute budget (e.g. ~75 blocks at 12s).

## Files

- `src/protection/credible_block/CredibleBlockGuard.sol` — the mixin / modifier
- `src/protection/credible_block/ICredibleRegistry.sol` — registry read interface
- `src/protection/credible_block/README.md` — usage + fail-open window docs
- `test/protection/credible_block/CredibleBlockGuard.t.sol` — unit + fuzz suite

## Testing

```
forge test --match-path "test/protection/credible_block/CredibleBlockGuard.t.sol"
15 passed; 0 failed; 0 skipped
```

Covers construction guards, the credible/non-credible/fail-open boundaries, builder stall-then-recover, underflow defense, modifier scope (guarded vs unguarded functions), and a spec-matching fuzz test.

## Note for reviewers

The upstream `credible-registry` repo also ships a `CredibleBlockGuard` mixin. This implementation matches its core fail-open math exactly but differs in API: the threshold is constructor-injected (to satisfy the per-chain 15-minute requirement) rather than a `virtual` override, and there's no per-sender bypass allowlist. Happy to align with upstream's override/bypass API if preferred. There is also a near-identical `ICredibleRegistry` introduced by #83 under `src/protection/safe/`; on merge these should be consolidated (e.g. `CredibleSafeGuard is CredibleBlockGuard`).

Closes ENG-3663.
