### PR TITLE
test: arm matchingCalls through cl.assertion instead of routing around it

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install PCL
         run: |
-          curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.0/pcl-1.5.0-linux-x86_64.tar.gz | tar -xz
+          curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.1/pcl-1.5.1-linux-x86_64.tar.gz | tar -xz
           sudo install pcl/pcl /usr/local/bin/pcl
 
       - name: Run protection PCL tests
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install PCL
         run: |
-          curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.0/pcl-1.5.0-linux-x86_64.tar.gz | tar -xz
+          curl -sSL https://github.com/phylaxsystems/pcl/releases/download/1.5.1/pcl-1.5.1-linux-x86_64.tar.gz | tar -xz
           sudo install pcl/pcl /usr/local/bin/pcl
 
       - name: Run ${{ matrix.profile }} example PCL tests

--- a/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
+++ b/examples/fluid/src/FluidLiquidityFlowBreakerAssertion.sol
@@ -44,7 +44,9 @@ contract FluidLiquidityFlowBreakerAssertion is FluidLiquidityBase {
     }
 
     /// @notice Registers the warning and critical outflow watchers for each monitored token.
-    function triggers() external view override {
+    /// @dev Virtual so tests can subclass with a call trigger and arm the matchingCalls scan
+    ///      through `cl.assertion` (the outflow trigger itself is executor-driven).
+    function triggers() external view virtual override {
         uint256 length = tokens.length;
         for (uint256 i; i < length; ++i) {
             address token = tokens[i];

--- a/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
+++ b/examples/fluid/test/FluidLiquidityFlowBreakerAssertion.t.sol
@@ -3,18 +3,20 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
+import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {PhEvm} from "../../../src/PhEvm.sol";
 import {FluidLiquidityFlowBreakerAssertion} from "../src/FluidLiquidityFlowBreakerAssertion.sol";
 import {IFluidLiquidityLike} from "../src/FluidInterfaces.sol";
 
-/// @notice Exposes the breaker's pure borrow-detection policy so it can be exercised directly.
-/// @dev The `watchCumulativeOutflow` trigger that fires the live assertion, and the `ph.matchingCalls`
-///      query it feeds on, are driven by the executor's rolling-window accounting and are not
-///      simulated by local `pcl test`, so the warning-tier policy is validated through
-///      `operateBorrowsToken` rather than an armed `cl.assertion` call (mirroring the Lighter
-///      circuit-breaker example). Critically, the policy is exercised against the exact
-///      selector-stripped argument tail that `ph.matchingCalls(...).input` returns in production — see
-///      `_matchingCallsInput` — so the selector-offset regression this fix addresses is caught here.
+/// @notice Exposes the breaker's pure borrow-detection policy so edge cases can be exercised directly.
+/// @dev The `watchCumulativeOutflow` trigger that fires the live assertion is driven by the
+///      executor's rolling-window accounting and is not simulated by local `pcl test`, so the
+///      trigger side still uses this harness. The `ph.matchingCalls` scan itself, however, IS
+///      executed for real: `FluidFlowBreakerArmedTest` below arms the scan + policy through
+///      `cl.assertion`, so a pcl/executor without the precompile fails loudly instead of leaving
+///      this suite green (which is how the unimplemented cheatcode went unnoticed). The harness
+///      remains for pure-policy edge cases against the exact selector-stripped argument tail that
+///      `ph.matchingCalls(...).input` returns — see `_matchingCallsInput`.
 contract BreakerHarness is FluidLiquidityFlowBreakerAssertion {
     constructor(address[] memory tokens_) FluidLiquidityFlowBreakerAssertion(tokens_) {}
 
@@ -142,5 +144,88 @@ contract FluidLiquidityFlowBreakerAssertionTest is Test {
 
         vm.expectRevert(bytes("Fluid: external custody breaker unsupported"));
         new FluidLiquidityFlowBreakerAssertion(tokens);
+    }
+}
+
+/// @notice Armed variant: fires the real `ph.matchingCalls` scan + borrow policy on a call trigger.
+/// @dev Replicates `assertNoBorrowAfterLargeOutflow` minus `ph.outflowContext()` (the outflow
+///      trigger context is executor-driven and cannot be armed locally). Everything downstream of
+///      the context read — the filter, the precompile query, and the selector-stripped decode —
+///      is the production path, executed against real recorded calldata.
+contract ArmedBreakerAssertion is FluidLiquidityFlowBreakerAssertion {
+    constructor(address[] memory tokens_) FluidLiquidityFlowBreakerAssertion(tokens_) {}
+
+    function triggers() external view virtual override {
+        registerCallTrigger(this.assertNoBorrowOfWatchedToken.selector);
+    }
+
+    function assertNoBorrowOfWatchedToken() external view {
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(
+            _liquidity(), IFluidLiquidityLike.operate.selector, _successfulOperateCalls(), MAX_SUCCESSFUL_OPERATE_CALLS
+        );
+        // Fail closed: the armed tests always route one operate() through the adopter, so an empty
+        // scan means the precompile lost the trace, not that the market is safe.
+        require(calls.length != 0, "Fluid: expected operate calls in trace");
+        for (uint256 i; i < calls.length; ++i) {
+            if (_operateBorrowsToken(calls[i].input, tokens[0])) {
+                revert("Fluid: borrow disabled after large outflow");
+            }
+        }
+    }
+}
+
+/// @notice Minimal Liquidity Layer standing in as the assertion adopter for the armed scan.
+contract MockFluidLiquidity {
+    uint256 public ops;
+
+    function operate(address, int256, int256, address, address, bytes calldata)
+        external
+        payable
+        returns (uint256 supplyExchangePrice_, uint256 borrowExchangePrice_)
+    {
+        ops++;
+        return (0, 0);
+    }
+}
+
+/// @notice Executes the breaker's matchingCalls scan through a real `cl.assertion` arming.
+contract FluidFlowBreakerArmedTest is Test, CredibleTest {
+    address internal constant TOKEN = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // USDC
+    address internal constant OTHER = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // USDT
+
+    MockFluidLiquidity internal liquidity;
+
+    function setUp() public {
+        liquidity = new MockFluidLiquidity();
+    }
+
+    function _arm() internal {
+        address[] memory tokens = new address[](1);
+        tokens[0] = TOKEN;
+        bytes memory createData = abi.encodePacked(type(ArmedBreakerAssertion).creationCode, abi.encode(tokens));
+        cl.assertion(address(liquidity), createData, ArmedBreakerAssertion.assertNoBorrowOfWatchedToken.selector);
+    }
+
+    function testArmedBorrowOfWatchedTokenReverts() public {
+        _arm();
+        // Expecting the policy's exact message: a pcl without the precompile also reverts here, but
+        // with 'Precompile selector not found: 0x0dc1cc5d', which fails the expectation loudly.
+        vm.expectRevert(bytes("Fluid: borrow disabled after large outflow"));
+        liquidity.operate(TOKEN, int256(0), int256(100e6), address(0), address(0), bytes(""));
+    }
+
+    function testArmedRepayOfWatchedTokenPasses() public {
+        _arm();
+        liquidity.operate(TOKEN, int256(0), -int256(100e6), address(0), address(0), bytes(""));
+    }
+
+    function testArmedSupplyOnlyPasses() public {
+        _arm();
+        liquidity.operate(TOKEN, int256(100e6), int256(0), address(0), address(0), bytes(""));
+    }
+
+    function testArmedBorrowOfOtherTokenPasses() public {
+        _arm();
+        liquidity.operate(OTHER, int256(0), int256(100e6), address(0), address(0), bytes(""));
     }
 }

--- a/test/protection/MatchingCallsPrecompile.t.sol
+++ b/test/protection/MatchingCallsPrecompile.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../src/CredibleTest.sol";
+import {Assertion} from "../../src/Assertion.sol";
+import {PhEvm} from "../../src/PhEvm.sol";
+import {AssertionSpec} from "../../src/SpecRecorder.sol";
+
+/// @notice Armed end-to-end battery for the `ph.matchingCalls` precompile.
+/// @dev Every test here executes `ph.matchingCalls` through a real `cl.assertion` arming — never a
+///      harness fed with hand-built bytes — so a pcl/executor build without the precompile fails
+///      loudly with `Precompile selector not found: 0x0dc1cc5d` instead of staying silently green.
+///      This is the regression test for the gap where the cheatcode shipped in the interface, docs,
+///      and protection suites for months while no executor implemented it.
+contract MatchingCallsTarget {
+    uint256 public value;
+
+    /// @dev Fans out two nested self-calls so the trace has same-selector calls at depth > 1,
+    ///      and a caught reverted call whose subtree must be invisible to the precompile.
+    function driver() external {
+        try this.pokeReverting() {
+            revert("expected pokeReverting to revert");
+        } catch {}
+
+        this.outer(7);
+    }
+
+    function outer(uint256 seed) external {
+        this.inner(seed + 1);
+        this.inner(seed + 2);
+    }
+
+    function inner(uint256 v) external {
+        value = v;
+    }
+
+    function pokeReverting() external {
+        value = type(uint256).max;
+        revert("poke always reverts");
+    }
+}
+
+contract MatchingCallsBatteryAssertion is Assertion {
+    uint256 internal constant NO_PARENT = type(uint256).max;
+
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.assertTopLevelCallShape.selector);
+        registerCallTrigger(this.assertNestedDepthAndParent.selector);
+        registerCallTrigger(this.assertFiltersAndLimit.selector);
+        registerCallTrigger(this.assertRevertedSubtreeInvisible.selector);
+        registerCallTrigger(this.assertHelperMatchingCalls.selector);
+    }
+
+    function _anyFilter() internal pure returns (PhEvm.CallFilter memory filter) {
+        filter = PhEvm.CallFilter({
+            callType: 0,
+            minDepth: 0,
+            maxDepth: type(uint32).max,
+            topLevelOnly: false,
+            successOnly: true
+        });
+    }
+
+    /// @notice The top-level `driver()` call: depth 1, no parent, CALL type, decodable metadata.
+    function assertTopLevelCallShape() external view {
+        address adopter = ph.getAssertionAdopter();
+        PhEvm.TriggerCall[] memory calls =
+            ph.matchingCalls(adopter, MatchingCallsTarget.driver.selector, _anyFilter(), 32);
+
+        require(calls.length == 1, "driver: expected exactly one call");
+        require(calls[0].target == adopter, "driver: target mismatch");
+        require(calls[0].selector == MatchingCallsTarget.driver.selector, "driver: selector mismatch");
+        require(calls[0].depth == 1, "driver: depth != 1");
+        require(calls[0].parentCallId == NO_PARENT, "driver: top-level call must have no parent");
+        require(calls[0].callType == 1, "driver: callType != CALL");
+        require(calls[0].success, "driver: success != true");
+        require(calls[0].input.length == 0, "driver: input must be empty (no args)");
+    }
+
+    /// @notice Nested self-calls report increasing depth and chain to their enclosing call ids.
+    function assertNestedDepthAndParent() external view {
+        address adopter = ph.getAssertionAdopter();
+
+        PhEvm.TriggerCall[] memory driverCalls =
+            ph.matchingCalls(adopter, MatchingCallsTarget.driver.selector, _anyFilter(), 32);
+        PhEvm.TriggerCall[] memory outerCalls =
+            ph.matchingCalls(adopter, MatchingCallsTarget.outer.selector, _anyFilter(), 32);
+        PhEvm.TriggerCall[] memory innerCalls =
+            ph.matchingCalls(adopter, MatchingCallsTarget.inner.selector, _anyFilter(), 32);
+
+        require(driverCalls.length == 1 && outerCalls.length == 1, "expected one driver and one outer call");
+        require(innerCalls.length == 2, "expected two inner calls");
+
+        require(outerCalls[0].depth == 2, "outer: depth != 2");
+        require(outerCalls[0].parentCallId == driverCalls[0].callId, "outer: parent != driver");
+        require(abi.decode(outerCalls[0].input, (uint256)) == 7, "outer: input != 7");
+
+        // Execution order and selector-stripped ABI tails: inner(8) then inner(9).
+        require(innerCalls[0].depth == 3 && innerCalls[1].depth == 3, "inner: depth != 3");
+        require(innerCalls[0].parentCallId == outerCalls[0].callId, "inner[0]: parent != outer");
+        require(innerCalls[1].parentCallId == outerCalls[0].callId, "inner[1]: parent != outer");
+        require(abi.decode(innerCalls[0].input, (uint256)) == 8, "inner[0]: input != 8");
+        require(abi.decode(innerCalls[1].input, (uint256)) == 9, "inner[1]: input != 9");
+    }
+
+    /// @notice Depth filters, topLevelOnly, and limit behave as declared.
+    function assertFiltersAndLimit() external view {
+        address adopter = ph.getAssertionAdopter();
+
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.topLevelOnly = true;
+        require(
+            ph.matchingCalls(adopter, MatchingCallsTarget.inner.selector, filter, 32).length == 0,
+            "topLevelOnly must exclude nested inner calls"
+        );
+        require(
+            ph.matchingCalls(adopter, MatchingCallsTarget.driver.selector, filter, 32).length == 1,
+            "topLevelOnly must keep the top-level driver call"
+        );
+
+        filter = _anyFilter();
+        filter.minDepth = 3;
+        require(
+            ph.matchingCalls(adopter, MatchingCallsTarget.inner.selector, filter, 32).length == 2,
+            "minDepth 3 must keep both inner calls"
+        );
+        require(
+            ph.matchingCalls(adopter, MatchingCallsTarget.outer.selector, filter, 32).length == 0,
+            "minDepth 3 must exclude the depth-2 outer call"
+        );
+
+        PhEvm.TriggerCall[] memory limited =
+            ph.matchingCalls(adopter, MatchingCallsTarget.inner.selector, _anyFilter(), 1);
+        require(limited.length == 1, "limit 1 must cap results");
+        require(abi.decode(limited[0].input, (uint256)) == 8, "limit must keep execution order");
+    }
+
+    /// @notice A reverted-and-caught call's subtree is truncated at recording time and never
+    ///         observable — even with `successOnly` disabled.
+    function assertRevertedSubtreeInvisible() external view {
+        address adopter = ph.getAssertionAdopter();
+        PhEvm.CallFilter memory filter = _anyFilter();
+        filter.successOnly = false;
+
+        require(
+            ph.matchingCalls(adopter, MatchingCallsTarget.pokeReverting.selector, filter, 32).length == 0,
+            "reverted pokeReverting must not be recorded"
+        );
+    }
+
+    /// @notice The `Assertion._matchingCalls` convenience wrapper drives the same precompile.
+    function assertHelperMatchingCalls() external view {
+        PhEvm.TriggerCall[] memory calls =
+            _matchingCalls(ph.getAssertionAdopter(), MatchingCallsTarget.inner.selector, 32);
+        require(calls.length == 2, "_matchingCalls: expected both inner calls");
+    }
+}
+
+contract MatchingCallsPrecompileTest is Test, CredibleTest {
+    MatchingCallsTarget internal target;
+
+    function setUp() public {
+        target = new MatchingCallsTarget();
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        cl.assertion(address(target), type(MatchingCallsBatteryAssertion).creationCode, fnSelector);
+    }
+
+    function testTopLevelCallShape() public {
+        _arm(MatchingCallsBatteryAssertion.assertTopLevelCallShape.selector);
+        target.driver();
+    }
+
+    function testNestedDepthAndParent() public {
+        _arm(MatchingCallsBatteryAssertion.assertNestedDepthAndParent.selector);
+        target.driver();
+    }
+
+    function testFiltersAndLimit() public {
+        _arm(MatchingCallsBatteryAssertion.assertFiltersAndLimit.selector);
+        target.driver();
+    }
+
+    function testRevertedSubtreeInvisible() public {
+        _arm(MatchingCallsBatteryAssertion.assertRevertedSubtreeInvisible.selector);
+        target.driver();
+    }
+
+    function testHelperMatchingCalls() public {
+        _arm(MatchingCallsBatteryAssertion.assertHelperMatchingCalls.selector);
+        target.driver();
+    }
+}

--- a/test/protection/MatchingCallsPrecompile.t.sol
+++ b/test/protection/MatchingCallsPrecompile.t.sol
@@ -59,11 +59,7 @@ contract MatchingCallsBatteryAssertion is Assertion {
 
     function _anyFilter() internal pure returns (PhEvm.CallFilter memory filter) {
         filter = PhEvm.CallFilter({
-            callType: 0,
-            minDepth: 0,
-            maxDepth: type(uint32).max,
-            topLevelOnly: false,
-            successOnly: true
+            callType: 0, minDepth: 0, maxDepth: type(uint32).max, topLevelOnly: false, successOnly: true
         });
     }
 


### PR DESCRIPTION
## Why

`ph.matchingCalls` shipped in the PhEvm interface, the docs, and multiple protection suites in April — and no executor implemented it until phylaxsystems/credible-sdk#1137. Nothing in CI noticed for months because every test that touches it routes around the precompile: the fluid suite's own header comment said the query "is not simulated by local `pcl test`" and validated the decode policy through a harness fed hand-built bytes, and the perpetual/lending suites were switched to `getAllCallInputs`. The first thing that ever executed `matchingCalls` was a user's assertion, which reverted with `Precompile selector not found: 0x0dc1cc5d`.

This PR makes the tests execute the precompile for real, so interface/executor drift fails CI instead of surfacing as a user report.

## Changes

- **`test/protection/MatchingCallsPrecompile.t.sol`** (new): armed battery via `cl.assertion` pinning the full `TriggerCall` contract — depth/parent chaining across nested calls, execution order, selector-stripped `input`, `topLevelOnly`/`minDepth`/`limit` filters, reverted-subtree invisibility, and the `Assertion._matchingCalls` helper path.
- **`examples/fluid`**: new `FluidFlowBreakerArmedTest` arms the breaker's real `matchingCalls` scan + borrow policy through a call-trigger subclass (`ArmedBreakerAssertion`). Everything downstream of `ph.outflowContext()` — filter, precompile query, selector-stripped decode — is the production path against real recorded calldata; only the outflow trigger context stays harness-side (it's executor-driven and can't be armed locally). The borrow-blocked test expects the policy's **exact** revert message, so a missing precompile can't pass for the wrong reason. The misleading header comment is rewritten, and `triggers()` on the breaker is made `virtual` for the test subclass.
- Pure-policy harness tests are kept — they still cover decode edge cases cheaply.

## ⚠️ CI will be red until pcl ships the precompile — by design

The `protection-pcl` and `examples-pcl` (fluid) jobs pin pcl 1.5.0, which lacks the precompile, so the new tests fail there with `Precompile selector not found: 0x0dc1cc5d`. That failure is exactly the signal this PR exists to produce. Merge order: land phylaxsystems/credible-sdk#1137 → phylaxsystems/phoundry#88 → phylaxsystems/pcl#106, cut a pcl release, bump the pcl version in `.github/workflows`, then merge this.

## Verification

Against a pcl built from the pin-bump branch (pcl#106):
- `FOUNDRY_PROFILE=ci pcl test --match-path 'test/protection/**'` — 88/88 pass (5 new).
- `FOUNDRY_PROFILE=fluid pcl test` — 26/26 pass (4 new armed).

Against released pcl (no precompile): every armed test fails with `Precompile selector not found: 0x0dc1cc5d`, including the expectRevert test (message mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)