### PR TITLE
feat(balancer): Balancer V3 vault assertion suite

### DIFF
--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [fluid, lido, mellow, safe-guard]
+        profile: [balancer, fluid, lido, mellow, safe-guard]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ FOUNDRY_PROFILE=<protocol> forge build
 |---|---|---|
 | `aave/` | `aave` | Aave V3 Horizon oracle & reserve-backing; Aave V4 hub/spoke |
 | `aerodrome/` | `aerodrome` | Aerodrome pool assertions |
+| `balancer/` | — | Balancer V3 singleton Vault: swap invariant non-decrease + BPT supply freeze, custody-vs-reserves-vs-pool-accounting envelope, rate-provider drift bound, Vault outflow breaker |
 | `cap/` | `cap` | OFAC compliance + redemption-gate (ERC-4626) |
 | `curve/` | `curve` | crvUSD controller, LlamaLend, CurveLlamma, StableSwap-NG, TriCrypto-NG |
 | `denaria/` | `all-protection-suites` | Denaria perpetual operation safety |

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ FOUNDRY_PROFILE=<protocol> forge build
 |---|---|---|
 | `aave/` | `aave` | Aave V3 Horizon oracle & reserve-backing; Aave V4 hub/spoke |
 | `aerodrome/` | `aerodrome` | Aerodrome pool assertions |
-| `balancer/` | — | Balancer V3 singleton Vault: hookless-pool swap invariant non-decrease + BPT supply freeze + pinned in-call rates, per-pool custody bound (necessary, not sufficient), scoped rate-provider drift bound, Vault net-outflow breaker |
+| `balancer/` | — | Balancer V3 singleton Vault: hookless-pool swap invariant non-decrease + live tokenOut direction + pinned in-call rates, per-pool custody bound (necessary, not sufficient), scoped rate-provider drift bound, Vault net-outflow breaker |
 | `cap/` | `cap` | OFAC compliance + redemption-gate (ERC-4626) |
 | `curve/` | `curve` | crvUSD controller, LlamaLend, CurveLlamma, StableSwap-NG, TriCrypto-NG |
 | `denaria/` | `all-protection-suites` | Denaria perpetual operation safety |

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ FOUNDRY_PROFILE=<protocol> forge build
 |---|---|---|
 | `aave/` | `aave` | Aave V3 Horizon oracle & reserve-backing; Aave V4 hub/spoke |
 | `aerodrome/` | `aerodrome` | Aerodrome pool assertions |
-| `balancer/` | — | Balancer V3 singleton Vault: swap invariant non-decrease + BPT supply freeze, custody-vs-reserves-vs-pool-accounting envelope, rate-provider drift bound, Vault outflow breaker |
+| `balancer/` | — | Balancer V3 singleton Vault: hookless-pool swap invariant non-decrease + BPT supply freeze + pinned in-call rates, per-pool custody bound (necessary, not sufficient), scoped rate-provider drift bound, Vault net-outflow breaker |
 | `cap/` | `cap` | OFAC compliance + redemption-gate (ERC-4626) |
 | `curve/` | `curve` | crvUSD controller, LlamaLend, CurveLlamma, StableSwap-NG, TriCrypto-NG |
 | `denaria/` | `all-protection-suites` | Denaria perpetual operation safety |

--- a/examples/balancer/README.md
+++ b/examples/balancer/README.md
@@ -1,0 +1,38 @@
+# balancer examples
+
+Assertion examples for Balancer V3's singleton Vault architecture.
+
+## Build
+
+```sh
+FOUNDRY_PROFILE=balancer forge build
+```
+
+## Test
+
+```sh
+FOUNDRY_PROFILE=balancer pcl test
+```
+
+## Files
+
+- `BalancerV3VaultAssertion.sol` — per-pool protections inside the singleton Vault:
+  - `assertSwapPreservesPoolInvariant` (call-scoped on `Vault.swap`): the pool's own
+    `computeInvariant` over live balances may not decrease across a swap, BPT supply is frozen,
+    and balances move in the swap's direction. The Vault trusts `onSwap`'s answer with no
+    equivalent `require`.
+  - `assertVaultCustodyCoversPoolAccounting` (tx-end): real ERC20 custody ≥ Vault reserves ≥
+    watched pool balances + accrued aggregate protocol fees.
+  - `assertTokenRatesWithinDriftBound` (tx-end): rate-provider rates feeding pool math stay
+    nonzero and within a configured bps bound within one transaction.
+- `BalancerV3VaultHelpers.sol` — fork-aware Vault/pool reads and lean swap-calldata access.
+- `BalancerV3VaultInterfaces.sol` — minimal mirrors of Balancer V3 Vault/pool/rate-provider types.
+- `BalancerV3VaultOutflowAssertion.sol` — rolling-window circuit breaker on a token leaving
+  Vault custody (`watchCumulativeOutflow`), flow-based drain protection across all pools at once.
+
+## Notes
+
+- The Vault is the assertion adopter for every contract in this bundle; swaps in pools other
+  than the watched pool are filtered out by decoding the swap calldata.
+- Thresholds (invariant rounding dust, rate drift bps, outflow cap/window) are constructor
+  parameters that need per-deployment calibration.

--- a/examples/balancer/README.md
+++ b/examples/balancer/README.md
@@ -32,14 +32,19 @@ This profile is part of the Solidity Test CI examples matrix, so the suite is ga
     honest-but-buggy pool), not a
     deliberately malicious pool that keeps both consistent — that class needs pinned
     factory/codehash combinations plus independent invariant math per pool type.
+  - `assertOperationRatesWithinBaseline` (call-scoped on add/remove liquidity, initialization,
+    and recovery resync): each provider rate at operation entry must remain within the
+    transaction baseline. Liquidity hooks that move and restore a rate entirely inside the call
+    need a pool-specific assertion that observes the post-hook pricing point.
   - `assertPoolAccountingWithinVaultCustody` (tx-end): real ERC20 custody ≥ global Vault
     reserves ≥ watched pool balances + accrued aggregate protocol fees. A necessary but NOT
     sufficient bound: reserves are one global ledger shared by every pool and ERC-4626 buffer,
     so one pool's view cannot prove aggregate solvency.
   - `assertTokenRatesWithinDriftBound` (tx-end): rate-provider rates feeding pool math stay
     nonzero and within a configured bps bound across transactions that change the watched
-    pool's accounting. Scoped so the provider never becomes a liveness dependency of unrelated
-    Vault traffic, and skipped when the pool is in recovery mode (recovery exits deliberately
+    pool's accounting. A cheap calldata trace gate covers swap, liquidity, initialization,
+    recovery removal, and aggregate-fee collection before any pool snapshots are read. The rate
+    check is skipped when the pool is in recovery mode (recovery exits deliberately
     avoid rate calls, and a broken provider must not block them). Providers already registered
     pre-transaction must present a nonzero pre-tx baseline — a successful zero is a failure,
     not a registration exemption; only providers first registered within the transaction (pool

--- a/examples/balancer/README.md
+++ b/examples/balancer/README.md
@@ -14,25 +14,55 @@ FOUNDRY_PROFILE=balancer forge build
 FOUNDRY_PROFILE=balancer pcl test
 ```
 
+This profile is part of the Solidity Test CI examples matrix, so the suite is gated on every PR.
+
 ## Files
 
 - `BalancerV3VaultAssertion.sol` — per-pool protections inside the singleton Vault:
-  - `assertSwapPreservesPoolInvariant` (call-scoped on `Vault.swap`): the pool's own
-    `computeInvariant` over live balances may not decrease across a swap, BPT supply is frozen,
-    and balances move in the swap's direction. The Vault trusts `onSwap`'s answer with no
-    equivalent `require`.
-  - `assertVaultCustodyCoversPoolAccounting` (tx-end): real ERC20 custody ≥ Vault reserves ≥
-    watched pool balances + accrued aggregate protocol fees.
+  - `assertSwapPreservesPoolInvariant` (call-scoped on `Vault.swap`, hookless pools only): the
+    pool's own `computeInvariant` over live balances may not decrease across a swap beyond an
+    absolute rounding-dust allowance, BPT supply is frozen, raw balances move in the swap's
+    direction, and every registered rate is identical at both call boundaries and within the
+    drift bound of its pre-transaction baseline (so a rate transiently moved between calls and
+    restored before tx-end is caught at the operation that consumed it). Pools with
+    before/after-swap hooks are skipped: those hooks are intentionally reentrant in V3 and
+    call-boundary snapshots cannot isolate the core swap, so hooked pools need a pool-specific
+    variant. Because the invariant is recomputed by the pool's own math, this detects
+    inconsistency between `onSwap` and `computeInvariant` (an honest-but-buggy pool), not a
+    deliberately malicious pool that keeps both consistent — that class needs pinned
+    factory/codehash combinations plus independent invariant math per pool type.
+  - `assertPoolAccountingWithinVaultCustody` (tx-end): real ERC20 custody ≥ global Vault
+    reserves ≥ watched pool balances + accrued aggregate protocol fees. A necessary but NOT
+    sufficient bound: reserves are one global ledger shared by every pool and ERC-4626 buffer,
+    so one pool's view cannot prove aggregate solvency.
   - `assertTokenRatesWithinDriftBound` (tx-end): rate-provider rates feeding pool math stay
-    nonzero and within a configured bps bound within one transaction.
+    nonzero and within a configured bps bound across transactions that change the watched
+    pool's accounting. Scoped so the provider never becomes a liveness dependency of unrelated
+    Vault traffic, and skipped when the pool is in recovery mode (recovery exits deliberately
+    avoid rate calls, and a broken provider must not block them). Providers already registered
+    pre-transaction must present a nonzero pre-tx baseline — a successful zero is a failure,
+    not a registration exemption; only providers first registered within the transaction (pool
+    deployment flow) skip the drift comparison.
 - `BalancerV3VaultHelpers.sol` — fork-aware Vault/pool reads and lean swap-calldata access.
 - `BalancerV3VaultInterfaces.sol` — minimal mirrors of Balancer V3 Vault/pool/rate-provider types.
-- `BalancerV3VaultOutflowAssertion.sol` — rolling-window circuit breaker on a token leaving
-  Vault custody (`watchCumulativeOutflow`), flow-based drain protection across all pools at once.
+- `BalancerV3VaultOutflowAssertion.sol` — rolling-window circuit breaker on a token's NET outflow
+  (`cumulativeOutflow - cumulativeInflow`, per the executor's `watchCumulativeOutflow` semantics)
+  from Vault custody, flow-based drain protection across all pools at once.
 
 ## Notes
 
 - The Vault is the assertion adopter for every contract in this bundle; swaps in pools other
-  than the watched pool are filtered out by decoding the swap calldata.
-- Thresholds (invariant rounding dust, rate drift bps, outflow cap/window) are constructor
-  parameters that need per-deployment calibration.
+  than the watched pool are filtered out by decoding the swap calldata, and the outflow breaker
+  verifies the configured Vault against the actual adopter before tripping.
+- Thresholds (absolute invariant rounding dust, rate drift bps, outflow cap/window) are
+  constructor parameters that need per-deployment calibration. The invariant dust tolerance is
+  absolute (18-decimal invariant units) because a bps-of-invariant tolerance cannot express
+  rounding dust without also allowing material repeatable loss. The outflow constructor mirrors
+  the executor's trigger constraints (threshold strictly below 100%, window between the
+  10-second bucket and `uint64` max) so misconfigurations surface at deploy time instead of at
+  trigger registration.
+- The outflow breaker thresholds NET flow and is value-blind: inflows from any pool or buffer
+  offset exits, and a canonical ERC-4626 buffer wrap counts fully as outflow of the underlying.
+  Calibrate above the largest legitimate single-window net outflow (whale exits, buffer
+  rebalances, and `collectAggregateFees`, which transfers the whole accrued fee ledger in one
+  indivisible call).

--- a/examples/balancer/README.md
+++ b/examples/balancer/README.md
@@ -21,14 +21,15 @@ This profile is part of the Solidity Test CI examples matrix, so the suite is ga
 - `BalancerV3VaultAssertion.sol` — per-pool protections inside the singleton Vault:
   - `assertSwapPreservesPoolInvariant` (call-scoped on `Vault.swap`, hookless pools only): the
     pool's own `computeInvariant` over live balances may not decrease across a swap beyond an
-    absolute rounding-dust allowance, BPT supply is frozen, raw balances move in the swap's
-    direction, and every registered rate is identical at both call boundaries and within the
-    drift bound of its pre-transaction baseline (so a rate transiently moved between calls and
-    restored before tx-end is caught at the operation that consumed it). Pools with
-    before/after-swap hooks are skipped: those hooks are intentionally reentrant in V3 and
-    call-boundary snapshots cannot isolate the core swap, so hooked pools need a pool-specific
-    variant. Because the invariant is recomputed by the pool's own math, this detects
-    inconsistency between `onSwap` and `computeInvariant` (an honest-but-buggy pool), not a
+    absolute rounding-dust allowance, the fee-adjusted live tokenOut balance may not increase,
+    and every registered rate observed at swap start remains within the drift bound of its
+    pre-transaction baseline (so a rate transiently moved between calls and restored before
+    tx-end is caught at the operation that consumed it). Pools with
+    before/after-swap hooks are skipped through immutable deployment configuration: those hooks
+    are intentionally reentrant in V3 and call-boundary snapshots cannot isolate the core swap,
+    so hooked pools need a pool-specific variant. Because the invariant is recomputed by the
+    pool's own math, this detects inconsistency between `onSwap` and `computeInvariant` (an
+    honest-but-buggy pool), not a
     deliberately malicious pool that keeps both consistent — that class needs pinned
     factory/codehash combinations plus independent invariant math per pool type.
   - `assertPoolAccountingWithinVaultCustody` (tx-end): real ERC20 custody ≥ global Vault
@@ -54,10 +55,12 @@ This profile is part of the Solidity Test CI examples matrix, so the suite is ga
 - The Vault is the assertion adopter for every contract in this bundle; swaps in pools other
   than the watched pool are filtered out by decoding the swap calldata, and the outflow breaker
   verifies the configured Vault against the actual adopter before tripping.
-- Thresholds (absolute invariant rounding dust, rate drift bps, outflow cap/window) are
-  constructor parameters that need per-deployment calibration. The invariant dust tolerance is
-  absolute (18-decimal invariant units) because a bps-of-invariant tolerance cannot express
-  rounding dust without also allowing material repeatable loss. The outflow constructor mirrors
+- Hook classification and thresholds (absolute invariant rounding dust, rate drift bps, outflow
+  cap/window) are constructor parameters that need per-deployment calibration. Balancer fixes
+  hook wiring at pool registration, so the assertion records whether before/after-swap hooks are
+  enabled once instead of paying for a full hook-config read on every swap. The invariant dust
+  tolerance is absolute (18-decimal invariant units) because a bps-of-invariant tolerance cannot
+  express rounding dust without also allowing material repeatable loss. The outflow constructor mirrors
   the executor's trigger constraints (threshold strictly below 100%, window between the
   10-second bucket and `uint64` max) so misconfigurations surface at deploy time instead of at
   trigger registration.

--- a/examples/balancer/src/BalancerV3VaultAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultAssertion.sol
@@ -55,8 +55,9 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         registerTxEndTrigger(this.assertTokenRatesWithinDriftBound.selector);
     }
 
-    /// @notice A swap on a hookless pool must grow (or at worst preserve) the pool invariant and
-    ///         move its live tokenOut balance in the swap's direction.
+    /// @notice A swap on a hookless pool must grow (or at worst preserve) the pool invariant,
+    ///         leave BPT supply unchanged, and move its live tokenOut balance in the swap's
+    ///         direction.
     /// @dev The Vault takes `onSwap`'s output on trust: no `require` recomputes the curve. This
     ///      check recomputes the pool's invariant from live balances through the pool's own math at
     ///      the pre-call and post-call forks. With any nonzero swap fee the invariant must grow, so
@@ -107,6 +108,8 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         uint256 preInvariant = _invariantOf(preLiveBalances, pre);
         uint256 postInvariant = _invariantOf(postLiveBalances, post);
         require(postInvariant + INVARIANT_DUST_TOLERANCE >= preInvariant, "BalancerV3: swap decreased pool invariant");
+
+        require(_bptTotalSupplyAt(post) == _bptTotalSupplyAt(pre), "BalancerV3: swap changed BPT supply");
 
         uint256 indexOut = _tokenIndex(preSnap.tokens, tokenOut);
         require(

--- a/examples/balancer/src/BalancerV3VaultAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultAssertion.sol
@@ -46,11 +46,23 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
 
     /// @notice Registers Vault selectors against their protection assertions.
     /// @dev The Vault is the assertion adopter. The swap check is call-scoped so it compares the
-    ///      exact pre-call and post-call snapshots of the matched swap; the custody and rate checks
-    ///      are transaction-wide envelopes because add/remove liquidity, buffer operations, and fee
-    ///      collection all move the same accounting.
+    ///      exact pre-call and post-call snapshots of the matched operation. The transaction-end
+    ///      checks first inspect calldata and return before reading snapshots unless swap or
+    ///      liquidity traffic touched the watched pool.
     function triggers() external view override {
         registerFnCallTrigger(this.assertSwapPreservesPoolInvariant.selector, IBalancerV3VaultLike.swap.selector);
+        registerFnCallTrigger(
+            this.assertOperationRatesWithinBaseline.selector, IBalancerV3VaultLike.addLiquidity.selector
+        );
+        registerFnCallTrigger(
+            this.assertOperationRatesWithinBaseline.selector, IBalancerV3VaultLike.removeLiquidity.selector
+        );
+        registerFnCallTrigger(
+            this.assertOperationRatesWithinBaseline.selector, IBalancerV3VaultLike.initialize.selector
+        );
+        registerFnCallTrigger(
+            this.assertOperationRatesWithinBaseline.selector, IBalancerV3VaultLike.disableRecoveryMode.selector
+        );
         registerTxEndTrigger(this.assertPoolAccountingWithinVaultCustody.selector);
         registerTxEndTrigger(this.assertTokenRatesWithinDriftBound.selector);
     }
@@ -125,6 +137,35 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     ///      compare; a provider that answered zero is a broken baseline and fails instead of being
     ///      conflated with the deployment case.
     function _requireSwapRatesWithinBaseline(PoolTokenSnapshot memory snap, PhEvm.ForkId memory pre) internal view {
+        _requireRatesWithinBaseline(snap, pre, "BalancerV3: swap priced against rate beyond drift bound");
+    }
+
+    /// @notice Pins rates consumed by liquidity and recovery-resync operations to their transaction baseline.
+    /// @dev This closes the router-shaped manipulate-operation-restore gap for both liquidity
+    ///      selectors. A pool with state-changing liquidity hooks needs a pool-specific assertion
+    ///      that observes the rate after its before hook, since an outer call snapshot cannot see a
+    ///      rate moved and restored entirely inside that hook lifecycle.
+    function assertOperationRatesWithinBaseline() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        bytes memory input = ph.callinputAt(ctx.callStart);
+        address pool = ctx.selector == IBalancerV3VaultLike.addLiquidity.selector
+            || ctx.selector == IBalancerV3VaultLike.removeLiquidity.selector
+            ? _operationPool(input)
+            : _firstAddressArg(input);
+        if (pool != POOL) {
+            return;
+        }
+
+        PhEvm.ForkId memory pre = _preCall(ctx.callStart);
+        PoolTokenSnapshot memory preSnap = _poolTokenSnapshotAt(pre);
+        _requireRatesWithinBaseline(preSnap, pre, "BalancerV3: liquidity priced against rate beyond drift bound");
+    }
+
+    function _requireRatesWithinBaseline(
+        PoolTokenSnapshot memory snap,
+        PhEvm.ForkId memory pre,
+        string memory driftError
+    ) internal view {
         PhEvm.ForkId memory preTx = _preTx();
         for (uint256 i; i < snap.tokenInfo.length; ++i) {
             address rateProvider = snap.tokenInfo[i].rateProvider;
@@ -132,17 +173,14 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
                 continue;
             }
 
-            uint256 rateAtSwap = _rateAt(rateProvider, pre);
+            uint256 rateAtOperation = _rateAt(rateProvider, pre);
 
             (bool answered, uint256 baseline) = _rateStatusAt(rateProvider, preTx);
             if (!answered) {
                 continue;
             }
             require(baseline != 0, "BalancerV3: zero rate baseline");
-            require(
-                _absDiff(rateAtSwap, baseline) <= _bpsOf(baseline, RATE_DRIFT_TOLERANCE_BPS),
-                "BalancerV3: swap priced against rate beyond drift bound"
-            );
+            require(_absDiff(rateAtOperation, baseline) <= _bpsOf(baseline, RATE_DRIFT_TOLERANCE_BPS), driftError);
         }
     }
 
@@ -160,6 +198,9 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     ///      accounting inflated beyond anything custody could pay out).
     function assertPoolAccountingWithinVaultCustody() external view {
         _requireConfiguredVaultIsAdopter();
+        if (!_transactionTouchesWatchedPool()) {
+            return;
+        }
         PhEvm.ForkId memory post = _postTx();
         if (!_isPoolInitializedAt(post)) {
             return;
@@ -205,6 +246,9 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     ///        registration (pool registered within this transaction) skips the drift comparison.
     function assertTokenRatesWithinDriftBound() external view {
         _requireConfiguredVaultIsAdopter();
+        if (!_transactionTouchesWatchedPool()) {
+            return;
+        }
         PhEvm.ForkId memory preTx = _preTx();
         PhEvm.ForkId memory postTx = _postTx();
         if (!_isPoolInitializedAt(postTx)) {
@@ -272,6 +316,39 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         }
         for (uint256 i; i < postSnap.tokens.length; ++i) {
             if (_aggregateFeesAt(postSnap.tokens[i], preTx) != _aggregateFeesAt(postSnap.tokens[i], postTx)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @dev Cheap tx-end gate. `getCallInputs` reads the trace without any Vault snapshots, so
+    ///      unrelated singleton traffic returns before the per-token accounting and provider work.
+    function _transactionTouchesWatchedPool() internal view returns (bool) {
+        return _structSelectorTouchesWatchedPool(IBalancerV3VaultLike.swap.selector, 32)
+            || _structSelectorTouchesWatchedPool(IBalancerV3VaultLike.addLiquidity.selector, 0)
+            || _structSelectorTouchesWatchedPool(IBalancerV3VaultLike.removeLiquidity.selector, 0)
+            || _addressSelectorTouchesWatchedPool(IBalancerV3VaultLike.initialize.selector)
+            || _addressSelectorTouchesWatchedPool(IBalancerV3VaultLike.removeLiquidityRecovery.selector)
+            || _addressSelectorTouchesWatchedPool(IBalancerV3VaultLike.collectAggregateFees.selector)
+            || _addressSelectorTouchesWatchedPool(IBalancerV3VaultLike.disableRecoveryMode.selector);
+    }
+
+    function _structSelectorTouchesWatchedPool(bytes4 selector, uint256 poolFieldOffset) internal view returns (bool) {
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(VAULT, selector);
+        for (uint256 i; i < calls.length; ++i) {
+            if (_operationPoolFromArgs(calls[i].input, poolFieldOffset) == POOL) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _addressSelectorTouchesWatchedPool(bytes4 selector) internal view returns (bool) {
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(VAULT, selector);
+        for (uint256 i; i < calls.length; ++i) {
+            (address pool) = abi.decode(calls[i].input, (address));
+            if (pool == POOL) {
                 return true;
             }
         }

--- a/examples/balancer/src/BalancerV3VaultAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultAssertion.sol
@@ -28,9 +28,19 @@ import {IBalancerV3VaultLike} from "./BalancerV3VaultInterfaces.sol";
 ///      watched pool and silently ignores swaps in other pools. Tx-end checks read only the watched
 ///      pool's accounting, so unrelated pool activity cannot produce false positives.
 contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
-    constructor(address vault_, address pool_, uint256 invariantDustTolerance_, uint256 rateDriftToleranceBps_)
-        BalancerV3VaultHelpers(vault_, pool_, invariantDustTolerance_, rateDriftToleranceBps_)
-    {
+    /// @notice Whether the watched pool was registered with a before- or after-swap hook.
+    /// @dev Balancer fixes hook wiring when a pool is registered, so classifying it once at
+    ///      deployment avoids an expensive full hook-config read on every swap.
+    bool internal immutable POOL_HAS_SWAP_HOOKS;
+
+    constructor(
+        address vault_,
+        address pool_,
+        bool poolHasSwapHooks_,
+        uint256 invariantDustTolerance_,
+        uint256 rateDriftToleranceBps_
+    ) BalancerV3VaultHelpers(vault_, pool_, invariantDustTolerance_, rateDriftToleranceBps_) {
+        POOL_HAS_SWAP_HOOKS = poolHasSwapHooks_;
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
@@ -46,24 +56,24 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     }
 
     /// @notice A swap on a hookless pool must grow (or at worst preserve) the pool invariant and
-    ///         touch nothing else.
+    ///         move its live tokenOut balance in the swap's direction.
     /// @dev The Vault takes `onSwap`'s output on trust: no `require` recomputes the curve. This
     ///      check recomputes the pool's invariant from live balances through the pool's own math at
     ///      the pre-call and post-call forks. With any nonzero swap fee the invariant must grow, so
-    ///      it may never drop by more than the configured absolute rounding dust. BPT supply must
-    ///      be frozen across a swap, and raw pool balances must move in the swap's direction
-    ///      (tokenIn in, tokenOut out).
+    ///      it may never drop by more than the configured absolute rounding dust. The
+    ///      fee-adjusted live tokenOut balance may not increase. Together with invariant
+    ///      non-decrease, this implies nonnegative value entered on the tokenIn side for
+    ///      Balancer's monotonic pool invariants without a redundant input-leg comparison.
     ///
     ///      Scope and trust boundaries, stated exactly:
-    ///      - Pools with before/after-swap hooks are SKIPPED. Those hooks run inside the swap call
-    ///        scope, outside the Vault's internal reentrancy guard, and may legitimately reenter
-    ///        (nested liquidity, donations, nested swaps), so call-boundary snapshots cannot
-    ///        isolate the core swap. Hooked pools need a variant built for their specific hook.
-    ///      - For the supported hookless pools no user code can run inside the swap call, so every
-    ///        registered rate must be identical at the call's boundary snapshots; that is enforced
-    ///        below, which also pins one fixed rate vector under both invariant evaluations and
-    ///        makes raw-balance direction equivalent to live-balance direction. Each rate observed
-    ///        at swap start — the rate the Vault actually prices against — must additionally sit
+    ///      - Pools configured at assertion deployment as having before/after-swap hooks are
+    ///        SKIPPED. Those hooks run inside the swap call scope, outside the Vault's internal
+    ///        reentrancy guard, and may legitimately reenter (nested liquidity, donations, nested
+    ///        swaps), so call-boundary snapshots cannot isolate the core swap. Hooked pools need a
+    ///        variant built for their specific hook.
+    ///      - Supported hookless pools expose no state-changing callback inside the swap, so the
+    ///        registered rate vector cannot move between its call-boundary snapshots. Each rate
+    ///        observed at swap start — the rate the Vault actually prices against — must sit
     ///        within the drift bound of its pre-transaction baseline, so a rate transiently moved
     ///        between calls of one transaction and restored before tx-end is still caught at the
     ///        exact operation that consumed it.
@@ -75,9 +85,12 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     ///        pinning trusted factory/codehash combinations and re-implementing the invariant math
     ///        independently per pool type, which is out of scope for this example.
     function assertSwapPreservesPoolInvariant() external view {
+        if (POOL_HAS_SWAP_HOOKS) {
+            return;
+        }
+
         PhEvm.TriggerContext memory ctx = ph.context();
-        _requireConfiguredVaultIsAdopter();
-        (address pool, address tokenIn, address tokenOut) = _swapArgs(ph.callinputAt(ctx.callStart));
+        (address pool, address tokenOut) = _swapPoolAndTokenOut(ph.callinputAt(ctx.callStart));
         if (pool != POOL) {
             return;
         }
@@ -85,45 +98,31 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         PhEvm.ForkId memory pre = _preCall(ctx.callStart);
         PhEvm.ForkId memory post = _postCall(ctx.callEnd);
 
-        if (_hasSwapHooksAt(pre)) {
-            // Reentrant-by-design hook window: call-boundary snapshots cannot attribute deltas to
-            // the core swap. Documented restriction — hooked pools need a pool-specific variant.
-            return;
-        }
-
         PoolTokenSnapshot memory preSnap = _poolTokenSnapshotAt(pre);
-        PoolTokenSnapshot memory postSnap = _poolTokenSnapshotAt(post);
 
-        _requireSwapRatesPinned(preSnap, pre, post);
+        _requireSwapRatesWithinBaseline(preSnap, pre);
 
-        uint256 preInvariant = _invariantOf(_liveBalancesAt(pre), pre);
-        uint256 postInvariant = _invariantOf(_liveBalancesAt(post), post);
+        uint256[] memory preLiveBalances = _liveBalancesAt(pre);
+        uint256[] memory postLiveBalances = _liveBalancesAt(post);
+        uint256 preInvariant = _invariantOf(preLiveBalances, pre);
+        uint256 postInvariant = _invariantOf(postLiveBalances, post);
         require(postInvariant + INVARIANT_DUST_TOLERANCE >= preInvariant, "BalancerV3: swap decreased pool invariant");
 
-        require(_bptTotalSupplyAt(post) == _bptTotalSupplyAt(pre), "BalancerV3: swap changed BPT supply");
-
-        (uint256 indexIn, uint256 indexOut) = _tokenIndexes(preSnap.tokens, tokenIn, tokenOut);
+        uint256 indexOut = _tokenIndex(preSnap.tokens, tokenOut);
         require(
-            postSnap.balancesRaw[indexIn] >= preSnap.balancesRaw[indexIn],
-            "BalancerV3: swap decreased tokenIn pool balance"
-        );
-        require(
-            postSnap.balancesRaw[indexOut] <= preSnap.balancesRaw[indexOut],
-            "BalancerV3: swap increased tokenOut pool balance"
+            postLiveBalances[indexOut] <= preLiveBalances[indexOut], "BalancerV3: swap increased tokenOut pool balance"
         );
     }
 
-    /// @dev Rate discipline for one matched hookless swap call: every registered provider must
-    ///      report the same rate at both call boundaries (nothing may move a rate inside a
-    ///      hookless swap), and the swap-start rate — the one the Vault prices against — must sit
-    ///      within the drift bound of the provider's pre-transaction baseline. A provider that did
-    ///      not answer at the pre-tx fork did not exist yet (pool deployed within this
-    ///      transaction) and has no baseline to compare; a provider that answered zero is a broken
-    ///      baseline and fails instead of being conflated with the deployment case.
-    function _requireSwapRatesPinned(PoolTokenSnapshot memory snap, PhEvm.ForkId memory pre, PhEvm.ForkId memory post)
-        internal
-        view
-    {
+    /// @dev Rate discipline for one matched hookless swap call: the swap-start rate — the one the
+    ///      Vault prices against — must sit within the drift bound of the provider's
+    ///      pre-transaction baseline. Hookless swaps expose no state-changing callback, so the
+    ///      provider cannot move inside the call. A provider that did not answer at the pre-tx
+    ///      fork did not exist yet (pool deployed within this transaction) and has no baseline to
+    ///      compare; a provider that answered zero is a broken baseline and fails instead of being
+    ///      conflated with the deployment case.
+    function _requireSwapRatesWithinBaseline(PoolTokenSnapshot memory snap, PhEvm.ForkId memory pre) internal view {
+        PhEvm.ForkId memory preTx = _preTx();
         for (uint256 i; i < snap.tokenInfo.length; ++i) {
             address rateProvider = snap.tokenInfo[i].rateProvider;
             if (rateProvider == address(0)) {
@@ -131,9 +130,8 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
             }
 
             uint256 rateAtSwap = _rateAt(rateProvider, pre);
-            require(rateAtSwap == _rateAt(rateProvider, post), "BalancerV3: rate moved within swap call");
 
-            (bool answered, uint256 baseline) = _rateStatusAt(rateProvider, _preTx());
+            (bool answered, uint256 baseline) = _rateStatusAt(rateProvider, preTx);
             if (!answered) {
                 continue;
             }

--- a/examples/balancer/src/BalancerV3VaultAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultAssertion.sol
@@ -11,19 +11,25 @@ import {IBalancerV3VaultLike} from "./BalancerV3VaultInterfaces.sol";
 /// @author Phylax Systems
 /// @notice Example assertion bundle for one Balancer V3 pool inside the singleton Vault.
 /// @dev Balancer V3 concentrates all custody and accounting in the Vault and delegates swap math
-///      to the pool contract, trusting `onSwap`'s answer. This bundle re-checks the external facts
-///      that no Vault `require` expresses:
-///      - a swap may never decrease the pool's own invariant or mint/burn BPT;
-///      - the Vault's real token custody must always cover its internal reserves, and reserves must
-///        cover the watched pool's recorded balances plus accrued aggregate protocol fees;
-///      - rate-provider rates feeding the pool's live balances may not jump within one transaction.
+///      to the pool contract, trusting `onSwap`'s answer. This bundle re-checks external facts
+///      that no Vault `require` expresses, with these honestly-stated boundaries:
+///      - The swap check asks the pool's OWN `computeInvariant`, so it detects inconsistency
+///        between a pool's `onSwap` results and its own invariant math — not a pool whose
+///        implementation is malicious in both functions at once. It supports hookless pools only:
+///        before/after-swap hooks are intentionally reentrant in V3 and break call-boundary
+///        snapshots, so hooked pools are skipped and need a pool-specific variant.
+///      - The custody check is a necessary-but-not-sufficient per-pool bound: Vault reserves are
+///        global across every pool and buffer, so one pool's view cannot prove aggregate solvency.
+///      - The rate check bounds provider movement within transactions that touch the watched
+///        pool's accounting; it is skipped in recovery mode so a broken provider can never block
+///        the canonical recovery exit.
 ///
 ///      Because the Vault is shared across every V3 pool, the call-scoped swap check filters on the
 ///      watched pool and silently ignores swaps in other pools. Tx-end checks read only the watched
 ///      pool's accounting, so unrelated pool activity cannot produce false positives.
 contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
-    constructor(address vault_, address pool_, uint256 invariantDustToleranceBps_, uint256 rateDriftToleranceBps_)
-        BalancerV3VaultHelpers(vault_, pool_, invariantDustToleranceBps_, rateDriftToleranceBps_)
+    constructor(address vault_, address pool_, uint256 invariantDustTolerance_, uint256 rateDriftToleranceBps_)
+        BalancerV3VaultHelpers(vault_, pool_, invariantDustTolerance_, rateDriftToleranceBps_)
     {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
@@ -35,19 +41,39 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
     ///      collection all move the same accounting.
     function triggers() external view override {
         registerFnCallTrigger(this.assertSwapPreservesPoolInvariant.selector, IBalancerV3VaultLike.swap.selector);
-        registerTxEndTrigger(this.assertVaultCustodyCoversPoolAccounting.selector);
+        registerTxEndTrigger(this.assertPoolAccountingWithinVaultCustody.selector);
         registerTxEndTrigger(this.assertTokenRatesWithinDriftBound.selector);
     }
 
-    /// @notice A swap must grow (or at worst preserve) the pool invariant and touch nothing else.
+    /// @notice A swap on a hookless pool must grow (or at worst preserve) the pool invariant and
+    ///         touch nothing else.
     /// @dev The Vault takes `onSwap`'s output on trust: no `require` recomputes the curve. This
     ///      check recomputes the pool's invariant from live balances through the pool's own math at
     ///      the pre-call and post-call forks. With any nonzero swap fee the invariant must grow, so
-    ///      it may never drop by more than the configured rounding dust. BPT supply must be frozen
-    ///      across a swap, and live balances must move in the swap's direction (tokenIn in,
-    ///      tokenOut out); rates are fixed within one swap call, so live-balance direction mirrors
-    ///      raw custody direction, and in-tx rate movement is covered by the drift assertion.
-    ///      A failure means broken or manipulated pool math let value leak out of the pool.
+    ///      it may never drop by more than the configured absolute rounding dust. BPT supply must
+    ///      be frozen across a swap, and raw pool balances must move in the swap's direction
+    ///      (tokenIn in, tokenOut out).
+    ///
+    ///      Scope and trust boundaries, stated exactly:
+    ///      - Pools with before/after-swap hooks are SKIPPED. Those hooks run inside the swap call
+    ///        scope, outside the Vault's internal reentrancy guard, and may legitimately reenter
+    ///        (nested liquidity, donations, nested swaps), so call-boundary snapshots cannot
+    ///        isolate the core swap. Hooked pools need a variant built for their specific hook.
+    ///      - For the supported hookless pools no user code can run inside the swap call, so every
+    ///        registered rate must be identical at the call's boundary snapshots; that is enforced
+    ///        below, which also pins one fixed rate vector under both invariant evaluations and
+    ///        makes raw-balance direction equivalent to live-balance direction. Each rate observed
+    ///        at swap start — the rate the Vault actually prices against — must additionally sit
+    ///        within the drift bound of its pre-transaction baseline, so a rate transiently moved
+    ///        between calls of one transaction and restored before tx-end is still caught at the
+    ///        exact operation that consumed it.
+    ///      - The invariant is recomputed by the POOL's own `computeInvariant`. This detects value
+    ///        leaking through broken or inconsistent pool math (an `onSwap` whose result the
+    ///        pool's own invariant function condemns), which is the failure mode of an honest but
+    ///        buggy pool. A deliberately malicious pool implementation can keep `onSwap` and
+    ///        `computeInvariant` mutually consistent and pass; catching that class requires
+    ///        pinning trusted factory/codehash combinations and re-implementing the invariant math
+    ///        independently per pool type, which is out of scope for this example.
     function assertSwapPreservesPoolInvariant() external view {
         PhEvm.TriggerContext memory ctx = ph.context();
         _requireConfiguredVaultIsAdopter();
@@ -59,32 +85,79 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         PhEvm.ForkId memory pre = _preCall(ctx.callStart);
         PhEvm.ForkId memory post = _postCall(ctx.callEnd);
 
-        uint256[] memory preLive = _liveBalancesAt(pre);
-        uint256[] memory postLive = _liveBalancesAt(post);
-        uint256 preInvariant = _invariantOf(preLive, pre);
-        uint256 postInvariant = _invariantOf(postLive, post);
-        require(
-            postInvariant + _bpsOf(preInvariant, INVARIANT_DUST_TOLERANCE_BPS) >= preInvariant,
-            "BalancerV3: swap decreased pool invariant"
-        );
+        if (_hasSwapHooksAt(pre)) {
+            // Reentrant-by-design hook window: call-boundary snapshots cannot attribute deltas to
+            // the core swap. Documented restriction — hooked pools need a pool-specific variant.
+            return;
+        }
+
+        PoolTokenSnapshot memory preSnap = _poolTokenSnapshotAt(pre);
+        PoolTokenSnapshot memory postSnap = _poolTokenSnapshotAt(post);
+
+        _requireSwapRatesPinned(preSnap, pre, post);
+
+        uint256 preInvariant = _invariantOf(_liveBalancesAt(pre), pre);
+        uint256 postInvariant = _invariantOf(_liveBalancesAt(post), post);
+        require(postInvariant + INVARIANT_DUST_TOLERANCE >= preInvariant, "BalancerV3: swap decreased pool invariant");
 
         require(_bptTotalSupplyAt(post) == _bptTotalSupplyAt(pre), "BalancerV3: swap changed BPT supply");
 
-        (uint256 indexIn, uint256 indexOut) = _tokenIndexesAt(pre, tokenIn, tokenOut);
-        require(postLive[indexIn] >= preLive[indexIn], "BalancerV3: swap decreased tokenIn pool balance");
-        require(postLive[indexOut] <= preLive[indexOut], "BalancerV3: swap increased tokenOut pool balance");
+        (uint256 indexIn, uint256 indexOut) = _tokenIndexes(preSnap.tokens, tokenIn, tokenOut);
+        require(
+            postSnap.balancesRaw[indexIn] >= preSnap.balancesRaw[indexIn],
+            "BalancerV3: swap decreased tokenIn pool balance"
+        );
+        require(
+            postSnap.balancesRaw[indexOut] <= preSnap.balancesRaw[indexOut],
+            "BalancerV3: swap increased tokenOut pool balance"
+        );
     }
 
-    /// @notice Vault custody must cover its reserves, and reserves must cover pool accounting.
-    /// @dev The Vault tracks its own token custody in `_reservesOf` and keeps the watched pool's
-    ///      balances and accrued aggregate fees as separate ledgers; nothing re-checks the three
-    ///      layers against each other after settlement. At transaction end, for every registered
-    ///      pool token: the Vault's real ERC20 balance must be at least its recorded reserves
-    ///      (donations may exceed it), and reserves must be at least the watched pool's raw balance
-    ///      plus aggregate swap and yield fees still owed to the fee controller. A failure means
-    ///      tokens physically left the Vault without the accounting noticing, or pool accounting
-    ///      was inflated beyond what custody can pay out.
-    function assertVaultCustodyCoversPoolAccounting() external view {
+    /// @dev Rate discipline for one matched hookless swap call: every registered provider must
+    ///      report the same rate at both call boundaries (nothing may move a rate inside a
+    ///      hookless swap), and the swap-start rate — the one the Vault prices against — must sit
+    ///      within the drift bound of the provider's pre-transaction baseline. A provider that did
+    ///      not answer at the pre-tx fork did not exist yet (pool deployed within this
+    ///      transaction) and has no baseline to compare; a provider that answered zero is a broken
+    ///      baseline and fails instead of being conflated with the deployment case.
+    function _requireSwapRatesPinned(PoolTokenSnapshot memory snap, PhEvm.ForkId memory pre, PhEvm.ForkId memory post)
+        internal
+        view
+    {
+        for (uint256 i; i < snap.tokenInfo.length; ++i) {
+            address rateProvider = snap.tokenInfo[i].rateProvider;
+            if (rateProvider == address(0)) {
+                continue;
+            }
+
+            uint256 rateAtSwap = _rateAt(rateProvider, pre);
+            require(rateAtSwap == _rateAt(rateProvider, post), "BalancerV3: rate moved within swap call");
+
+            (bool answered, uint256 baseline) = _rateStatusAt(rateProvider, _preTx());
+            if (!answered) {
+                continue;
+            }
+            require(baseline != 0, "BalancerV3: zero rate baseline");
+            require(
+                _absDiff(rateAtSwap, baseline) <= _bpsOf(baseline, RATE_DRIFT_TOLERANCE_BPS),
+                "BalancerV3: swap priced against rate beyond drift bound"
+            );
+        }
+    }
+
+    /// @notice The watched pool's accounting must stay within the Vault's recorded reserves, and
+    ///         reserves must stay within real token custody.
+    /// @dev NECESSARY BUT NOT SUFFICIENT, by construction: `getReservesOf` is one global ledger
+    ///      shared by every pool and every ERC-4626 buffer in the singleton, so a single pool's
+    ///      claims sitting under the global number proves nothing about aggregate solvency —
+    ///      other pools' and buffers' claims consume the same headroom, and detecting that
+    ///      requires enumerating every registered pool, which a one-pool example cannot do. What
+    ///      this bound DOES catch, at transaction end and per registered pool token: real ERC20
+    ///      custody falling below recorded reserves (tokens physically left without the ledger
+    ///      noticing; donations may exceed it, so `>=`), and the watched pool's raw balance plus
+    ///      its accrued aggregate swap/yield fees exceeding global reserves (this pool's
+    ///      accounting inflated beyond anything custody could pay out).
+    function assertPoolAccountingWithinVaultCustody() external view {
         _requireConfiguredVaultIsAdopter();
         PhEvm.ForkId memory post = _postTx();
         if (!_isPoolInitializedAt(post)) {
@@ -106,13 +179,29 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         }
     }
 
-    /// @notice Rate-provider rates feeding the watched pool may not jump within one transaction.
+    /// @notice Rate-provider rates feeding the watched pool may not jump within one transaction
+    ///         that touches the pool's accounting.
     /// @dev Live balances (and therefore swap math, yield fees, and invariant computation) scale
     ///      WITH_RATE tokens by their provider's `getRate()`. The Vault never bounds that answer.
     ///      Rates track slow yield accrual, so any large move inside a single transaction is
-    ///      manipulation or a broken provider, not yield. At transaction end every registered rate
-    ///      provider must return a nonzero rate within the configured drift bound of its pre-tx
-    ///      value. A failure means the transaction moved a rate the pool prices against.
+    ///      manipulation or a broken provider, not yield.
+    ///
+    ///      Scope, so the watched provider never becomes a liveness dependency for the rest of
+    ///      the singleton:
+    ///      - Runs only when the transaction changed the watched pool's accounting (raw balances,
+    ///        BPT supply, or aggregate fees). Unrelated-pool and buffer traffic never calls the
+    ///        watched provider. Residual: a transaction that moves a rate without touching the
+    ///        pool is not examined here — but any later transaction that consumes the moved rate
+    ///        touches the pool, and the swap check separately pins each consumed rate to that
+    ///        transaction's own baseline.
+    ///      - Skipped entirely when the pool is in recovery mode post-transaction: Balancer's
+    ///        recovery exit deliberately uses raw balances precisely because providers may be
+    ///        broken, and a reverting provider must not block that path.
+    ///      - A provider already registered for the pool before the transaction MUST answer with a
+    ///        nonzero pre-tx rate: a missing or zero baseline fails instead of exempting, so a
+    ///        provider that "successfully returns zero" cannot use the deployment exemption to
+    ///        legitimize an arbitrary post-tx rate. Only a provider absent from the pre-tx
+    ///        registration (pool registered within this transaction) skips the drift comparison.
     function assertTokenRatesWithinDriftBound() external view {
         _requireConfiguredVaultIsAdopter();
         PhEvm.ForkId memory preTx = _preTx();
@@ -120,10 +209,23 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
         if (!_isPoolInitializedAt(postTx)) {
             return;
         }
+        if (_isPoolInRecoveryModeAt(postTx)) {
+            return;
+        }
 
-        PoolTokenSnapshot memory snap = _poolTokenSnapshotAt(postTx);
-        for (uint256 i; i < snap.tokenInfo.length; ++i) {
-            address rateProvider = snap.tokenInfo[i].rateProvider;
+        PoolTokenSnapshot memory postSnap = _poolTokenSnapshotAt(postTx);
+
+        bool initializedPreTx = _isPoolInitializedAt(preTx);
+        PoolTokenSnapshot memory preSnap;
+        if (initializedPreTx) {
+            preSnap = _poolTokenSnapshotAt(preTx);
+            if (!_poolAccountingChanged(preSnap, postSnap, preTx, postTx)) {
+                return;
+            }
+        }
+
+        for (uint256 i; i < postSnap.tokenInfo.length; ++i) {
+            address rateProvider = postSnap.tokenInfo[i].rateProvider;
             if (rateProvider == address(0)) {
                 continue;
             }
@@ -131,16 +233,47 @@ contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
             uint256 postRate = _rateAt(rateProvider, postTx);
             require(postRate != 0, "BalancerV3: rate provider returned zero rate");
 
-            uint256 preRate = _rateAt(rateProvider, preTx);
-            if (preRate == 0) {
-                // Provider only became live within this transaction (e.g. pool registration).
+            if (!initializedPreTx || !_providerRegisteredIn(preSnap, rateProvider)) {
+                // Provider registered within this transaction (pool deployment flow): no pre-tx
+                // baseline exists by construction, so only the nonzero post-state is enforceable.
                 continue;
             }
 
+            (bool answered, uint256 preRate) = _rateStatusAt(rateProvider, preTx);
+            require(answered && preRate != 0, "BalancerV3: zero rate baseline");
             require(
                 _absDiff(postRate, preRate) <= _bpsOf(preRate, RATE_DRIFT_TOLERANCE_BPS),
                 "BalancerV3: token rate moved beyond drift bound"
             );
         }
+    }
+
+    /// @dev Whether the transaction changed the watched pool's accounting: raw balances, BPT
+    ///      supply, or accrued aggregate fees. Live balances are deliberately excluded — they move
+    ///      when a rate moves even if the pool was never touched, and using them would reintroduce
+    ///      the provider as a dependency of unrelated transactions.
+    function _poolAccountingChanged(
+        PoolTokenSnapshot memory preSnap,
+        PoolTokenSnapshot memory postSnap,
+        PhEvm.ForkId memory preTx,
+        PhEvm.ForkId memory postTx
+    ) internal view returns (bool) {
+        if (preSnap.balancesRaw.length != postSnap.balancesRaw.length) {
+            return true;
+        }
+        for (uint256 i; i < preSnap.balancesRaw.length; ++i) {
+            if (preSnap.balancesRaw[i] != postSnap.balancesRaw[i]) {
+                return true;
+            }
+        }
+        if (_bptTotalSupplyAt(preTx) != _bptTotalSupplyAt(postTx)) {
+            return true;
+        }
+        for (uint256 i; i < postSnap.tokens.length; ++i) {
+            if (_aggregateFeesAt(postSnap.tokens[i], preTx) != _aggregateFeesAt(postSnap.tokens[i], postTx)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/examples/balancer/src/BalancerV3VaultAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultAssertion.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {PhEvm} from "credible-std/PhEvm.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+import {BalancerV3VaultHelpers} from "./BalancerV3VaultHelpers.sol";
+import {IBalancerV3VaultLike} from "./BalancerV3VaultInterfaces.sol";
+
+/// @title BalancerV3VaultAssertion
+/// @author Phylax Systems
+/// @notice Example assertion bundle for one Balancer V3 pool inside the singleton Vault.
+/// @dev Balancer V3 concentrates all custody and accounting in the Vault and delegates swap math
+///      to the pool contract, trusting `onSwap`'s answer. This bundle re-checks the external facts
+///      that no Vault `require` expresses:
+///      - a swap may never decrease the pool's own invariant or mint/burn BPT;
+///      - the Vault's real token custody must always cover its internal reserves, and reserves must
+///        cover the watched pool's recorded balances plus accrued aggregate protocol fees;
+///      - rate-provider rates feeding the pool's live balances may not jump within one transaction.
+///
+///      Because the Vault is shared across every V3 pool, the call-scoped swap check filters on the
+///      watched pool and silently ignores swaps in other pools. Tx-end checks read only the watched
+///      pool's accounting, so unrelated pool activity cannot produce false positives.
+contract BalancerV3VaultAssertion is BalancerV3VaultHelpers {
+    constructor(address vault_, address pool_, uint256 invariantDustToleranceBps_, uint256 rateDriftToleranceBps_)
+        BalancerV3VaultHelpers(vault_, pool_, invariantDustToleranceBps_, rateDriftToleranceBps_)
+    {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers Vault selectors against their protection assertions.
+    /// @dev The Vault is the assertion adopter. The swap check is call-scoped so it compares the
+    ///      exact pre-call and post-call snapshots of the matched swap; the custody and rate checks
+    ///      are transaction-wide envelopes because add/remove liquidity, buffer operations, and fee
+    ///      collection all move the same accounting.
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertSwapPreservesPoolInvariant.selector, IBalancerV3VaultLike.swap.selector);
+        registerTxEndTrigger(this.assertVaultCustodyCoversPoolAccounting.selector);
+        registerTxEndTrigger(this.assertTokenRatesWithinDriftBound.selector);
+    }
+
+    /// @notice A swap must grow (or at worst preserve) the pool invariant and touch nothing else.
+    /// @dev The Vault takes `onSwap`'s output on trust: no `require` recomputes the curve. This
+    ///      check recomputes the pool's invariant from live balances through the pool's own math at
+    ///      the pre-call and post-call forks. With any nonzero swap fee the invariant must grow, so
+    ///      it may never drop by more than the configured rounding dust. BPT supply must be frozen
+    ///      across a swap, and live balances must move in the swap's direction (tokenIn in,
+    ///      tokenOut out); rates are fixed within one swap call, so live-balance direction mirrors
+    ///      raw custody direction, and in-tx rate movement is covered by the drift assertion.
+    ///      A failure means broken or manipulated pool math let value leak out of the pool.
+    function assertSwapPreservesPoolInvariant() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        _requireConfiguredVaultIsAdopter();
+        (address pool, address tokenIn, address tokenOut) = _swapArgs(ph.callinputAt(ctx.callStart));
+        if (pool != POOL) {
+            return;
+        }
+
+        PhEvm.ForkId memory pre = _preCall(ctx.callStart);
+        PhEvm.ForkId memory post = _postCall(ctx.callEnd);
+
+        uint256[] memory preLive = _liveBalancesAt(pre);
+        uint256[] memory postLive = _liveBalancesAt(post);
+        uint256 preInvariant = _invariantOf(preLive, pre);
+        uint256 postInvariant = _invariantOf(postLive, post);
+        require(
+            postInvariant + _bpsOf(preInvariant, INVARIANT_DUST_TOLERANCE_BPS) >= preInvariant,
+            "BalancerV3: swap decreased pool invariant"
+        );
+
+        require(_bptTotalSupplyAt(post) == _bptTotalSupplyAt(pre), "BalancerV3: swap changed BPT supply");
+
+        (uint256 indexIn, uint256 indexOut) = _tokenIndexesAt(pre, tokenIn, tokenOut);
+        require(postLive[indexIn] >= preLive[indexIn], "BalancerV3: swap decreased tokenIn pool balance");
+        require(postLive[indexOut] <= preLive[indexOut], "BalancerV3: swap increased tokenOut pool balance");
+    }
+
+    /// @notice Vault custody must cover its reserves, and reserves must cover pool accounting.
+    /// @dev The Vault tracks its own token custody in `_reservesOf` and keeps the watched pool's
+    ///      balances and accrued aggregate fees as separate ledgers; nothing re-checks the three
+    ///      layers against each other after settlement. At transaction end, for every registered
+    ///      pool token: the Vault's real ERC20 balance must be at least its recorded reserves
+    ///      (donations may exceed it), and reserves must be at least the watched pool's raw balance
+    ///      plus aggregate swap and yield fees still owed to the fee controller. A failure means
+    ///      tokens physically left the Vault without the accounting noticing, or pool accounting
+    ///      was inflated beyond what custody can pay out.
+    function assertVaultCustodyCoversPoolAccounting() external view {
+        _requireConfiguredVaultIsAdopter();
+        PhEvm.ForkId memory post = _postTx();
+        if (!_isPoolInitializedAt(post)) {
+            return;
+        }
+
+        PoolTokenSnapshot memory snap = _poolTokenSnapshotAt(post);
+        for (uint256 i; i < snap.tokens.length; ++i) {
+            address token = snap.tokens[i];
+            uint256 reserves = _reservesOfAt(token, post);
+
+            require(
+                _readBalanceAt(token, VAULT, post) >= reserves, "BalancerV3: vault reserves exceed real token custody"
+            );
+            require(
+                reserves >= snap.balancesRaw[i] + _aggregateFeesAt(token, post),
+                "BalancerV3: pool accounting exceeds vault reserves"
+            );
+        }
+    }
+
+    /// @notice Rate-provider rates feeding the watched pool may not jump within one transaction.
+    /// @dev Live balances (and therefore swap math, yield fees, and invariant computation) scale
+    ///      WITH_RATE tokens by their provider's `getRate()`. The Vault never bounds that answer.
+    ///      Rates track slow yield accrual, so any large move inside a single transaction is
+    ///      manipulation or a broken provider, not yield. At transaction end every registered rate
+    ///      provider must return a nonzero rate within the configured drift bound of its pre-tx
+    ///      value. A failure means the transaction moved a rate the pool prices against.
+    function assertTokenRatesWithinDriftBound() external view {
+        _requireConfiguredVaultIsAdopter();
+        PhEvm.ForkId memory preTx = _preTx();
+        PhEvm.ForkId memory postTx = _postTx();
+        if (!_isPoolInitializedAt(postTx)) {
+            return;
+        }
+
+        PoolTokenSnapshot memory snap = _poolTokenSnapshotAt(postTx);
+        for (uint256 i; i < snap.tokenInfo.length; ++i) {
+            address rateProvider = snap.tokenInfo[i].rateProvider;
+            if (rateProvider == address(0)) {
+                continue;
+            }
+
+            uint256 postRate = _rateAt(rateProvider, postTx);
+            require(postRate != 0, "BalancerV3: rate provider returned zero rate");
+
+            uint256 preRate = _rateAt(rateProvider, preTx);
+            if (preRate == 0) {
+                // Provider only became live within this transaction (e.g. pool registration).
+                continue;
+            }
+
+            require(
+                _absDiff(postRate, preRate) <= _bpsOf(preRate, RATE_DRIFT_TOLERANCE_BPS),
+                "BalancerV3: token rate moved beyond drift bound"
+            );
+        }
+    }
+}

--- a/examples/balancer/src/BalancerV3VaultHelpers.sol
+++ b/examples/balancer/src/BalancerV3VaultHelpers.sol
@@ -5,7 +5,6 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 import {
-    HooksConfig,
     IBalancerV3BasePoolLike,
     IBalancerV3VaultLike,
     IRateProviderLike,
@@ -67,37 +66,30 @@ abstract contract BalancerV3VaultHelpers is Assertion {
         require(ph.getAssertionAdopter() == VAULT, "BalancerV3: configured vault is not adopter");
     }
 
-    /// @dev Reads the swap legs straight from `swap(VaultSwapParams)` calldata instead of
-    ///      abi-decoding the whole struct: the assertion only needs the pool and token addresses,
-    ///      and a full dynamic-struct decode costs enough gas to threaten the assertion budget.
+    /// @dev Reads the pool and tokenOut straight from successfully executed
+    ///      `swap(VaultSwapParams)` calldata instead of abi-decoding the whole struct: the
+    ///      assertion only needs those two addresses, and a full dynamic-struct decode costs
+    ///      enough gas to threaten the assertion budget.
     ///      Layout: 4-byte selector, one head word holding the struct offset, then the struct
     ///      fields (`kind`, `pool`, `tokenIn`, `tokenOut`, ...) in order. The head offset is
-    ///      bound-checked before it is followed: an offset the Vault's own decoder would reject
-    ///      cannot belong to an executed swap, so malformed calldata fails closed here instead of
-    ///      reading unrelated assertion memory.
-    function _swapArgs(bytes memory input) internal pure returns (address pool_, address tokenIn_, address tokenOut_) {
-        require(input.length >= 4 + 32 * 8, "BalancerV3: short swap calldata");
-
+    ///      safe to follow because the call trigger only fires after the Vault's own ABI decoder
+    ///      accepted and executed this calldata.
+    function _swapPoolAndTokenOut(bytes memory input) internal pure returns (address pool_, address tokenOut_) {
         uint256 structOffset;
         assembly ("memory-safe") {
             structOffset := mload(add(input, 36)) // skip the bytes length word and the 4-byte selector
         }
-        // The struct's static area is 7 words; it must fit inside the argument section.
-        require(structOffset <= input.length - 4 - 32 * 7, "BalancerV3: bad swap struct offset");
 
         uint256 poolWord;
-        uint256 tokenInWord;
         uint256 tokenOutWord;
         assembly ("memory-safe") {
             let args := add(input, 36)
             let structBase := add(args, structOffset) // head word points at the struct tuple
             poolWord := mload(add(structBase, 32))
-            tokenInWord := mload(add(structBase, 64))
             tokenOutWord := mload(add(structBase, 96))
         }
 
         pool_ = address(uint160(poolWord));
-        tokenIn_ = address(uint160(tokenInWord));
         tokenOut_ = address(uint160(tokenOutWord));
     }
 
@@ -128,28 +120,14 @@ abstract contract BalancerV3VaultHelpers is Assertion {
         );
     }
 
-    /// @dev Registration-order indexes of the swap legs within an already-read token snapshot.
-    ///      Both legs are matched independently so `tokenIn == tokenOut` resolves to one shared
-    ///      index instead of reverting: the Vault rejects same-token swaps, so such a trigger can
-    ///      only be observed for a call that left no state change, and the direction checks then
-    ///      pin that single balance in place rather than falsely blocking the transaction.
-    function _tokenIndexes(address[] memory tokens, address tokenIn, address tokenOut)
-        internal
-        pure
-        returns (uint256 indexIn, uint256 indexOut)
-    {
-        indexIn = type(uint256).max;
-        indexOut = type(uint256).max;
+    /// @dev Registration-order index of one token within an already-read token snapshot.
+    function _tokenIndex(address[] memory tokens, address token) internal pure returns (uint256 index) {
         for (uint256 i; i < tokens.length; ++i) {
-            if (tokens[i] == tokenIn) {
-                indexIn = i;
-            }
-            if (tokens[i] == tokenOut) {
-                indexOut = i;
+            if (tokens[i] == token) {
+                return i;
             }
         }
-        require(indexIn != type(uint256).max, "BalancerV3: tokenIn not registered in pool");
-        require(indexOut != type(uint256).max, "BalancerV3: tokenOut not registered in pool");
+        revert("BalancerV3: token not registered in pool");
     }
 
     function _bptTotalSupplyAt(PhEvm.ForkId memory fork) internal view returns (uint256) {
@@ -171,18 +149,6 @@ abstract contract BalancerV3VaultHelpers is Assertion {
 
     function _isPoolInRecoveryModeAt(PhEvm.ForkId memory fork) internal view returns (bool) {
         return _readBoolAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.isPoolInRecoveryMode, (POOL)), fork);
-    }
-
-    /// @dev Whether the watched pool runs a before- or after-swap hook. Those two hooks execute
-    ///      inside the `Vault.swap` call scope and outside the internal `_swap` reentrancy guard,
-    ///      so they may legitimately reenter the Vault (nested liquidity, donations, nested swaps)
-    ///      and change BPT supply, balances, and rates between the swap call's boundary snapshots.
-    ///      The dynamic-swap-fee hook is declared `view` and cannot mutate state, and the
-    ///      liquidity hooks do not run within a swap, so neither disqualifies the pool here.
-    function _hasSwapHooksAt(PhEvm.ForkId memory fork) internal view returns (bool) {
-        bytes memory ret = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getHooksConfig, (POOL)), fork);
-        HooksConfig memory config = abi.decode(ret, (HooksConfig));
-        return config.shouldCallBeforeSwap || config.shouldCallAfterSwap;
     }
 
     /// @notice Strict rate read: reverts if the provider does not answer.

--- a/examples/balancer/src/BalancerV3VaultHelpers.sol
+++ b/examples/balancer/src/BalancerV3VaultHelpers.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+import {
+    IBalancerV3BasePoolLike,
+    IBalancerV3VaultLike,
+    IRateProviderLike,
+    Rounding,
+    TokenInfo
+} from "./BalancerV3VaultInterfaces.sol";
+
+/// @title BalancerV3VaultHelpers
+/// @author Phylax Systems
+/// @notice Fork-aware Balancer V3 Vault state helpers used by the example assertions.
+/// @dev Balancer V3 is a singleton: the Vault custodies every pool's tokens, stores every pool's
+///      balances and BPT supply, and delegates only the math to the pool contract. Helpers read
+///      the watched pool's registration data, raw balances, live balances, reserves, and aggregate
+///      protocol fees through the Vault at snapshot forks, and recompute the pool invariant through
+///      the pool's own `computeInvariant`.
+abstract contract BalancerV3VaultHelpers is Assertion {
+    /// @notice Balancer V3 Vault singleton (the assertion adopter).
+    address internal immutable VAULT;
+
+    /// @notice Watched pool registered with the Vault.
+    address internal immutable POOL;
+
+    /// @notice Allowed downward invariant movement across one swap, in bps, to absorb pool-math
+    ///         rounding dust. Zero enforces strict non-decrease.
+    uint256 internal immutable INVARIANT_DUST_TOLERANCE_BPS;
+
+    /// @notice Allowed movement of a token's rate-provider rate within one transaction, in bps.
+    uint256 internal immutable RATE_DRIFT_TOLERANCE_BPS;
+
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    struct PoolTokenSnapshot {
+        address[] tokens;
+        TokenInfo[] tokenInfo;
+        uint256[] balancesRaw;
+    }
+
+    /// @dev All addresses and thresholds are supplied explicitly; the constructor never reads the
+    ///      adopter because the assertion-deploy runtime is isolated from live chain state.
+    constructor(address vault_, address pool_, uint256 invariantDustToleranceBps_, uint256 rateDriftToleranceBps_) {
+        require(vault_ != address(0), "BalancerV3: zero vault");
+        require(pool_ != address(0), "BalancerV3: zero pool");
+        require(invariantDustToleranceBps_ < BPS_DENOMINATOR, "BalancerV3: bad invariant tolerance");
+        require(rateDriftToleranceBps_ < BPS_DENOMINATOR, "BalancerV3: bad rate tolerance");
+
+        VAULT = vault_;
+        POOL = pool_;
+        INVARIANT_DUST_TOLERANCE_BPS = invariantDustToleranceBps_;
+        RATE_DRIFT_TOLERANCE_BPS = rateDriftToleranceBps_;
+    }
+
+    // --- adopter / calldata -------------------------------------------------
+
+    function _requireConfiguredVaultIsAdopter() internal view {
+        require(ph.getAssertionAdopter() == VAULT, "BalancerV3: configured vault is not adopter");
+    }
+
+    /// @dev Reads the swap legs straight from `swap(VaultSwapParams)` calldata instead of
+    ///      abi-decoding the whole struct: the assertion only needs the pool and token addresses,
+    ///      and a full dynamic-struct decode costs enough gas to threaten the assertion budget.
+    ///      Layout: 4-byte selector, one head word holding the struct offset, then the struct
+    ///      fields (`kind`, `pool`, `tokenIn`, `tokenOut`, ...) in order. The head offset is
+    ///      bound-checked before it is followed: an offset the Vault's own decoder would reject
+    ///      cannot belong to an executed swap, so malformed calldata fails closed here instead of
+    ///      reading unrelated assertion memory.
+    function _swapArgs(bytes memory input) internal pure returns (address pool_, address tokenIn_, address tokenOut_) {
+        require(input.length >= 4 + 32 * 8, "BalancerV3: short swap calldata");
+
+        uint256 structOffset;
+        assembly ("memory-safe") {
+            structOffset := mload(add(input, 36)) // skip the bytes length word and the 4-byte selector
+        }
+        // The struct's static area is 7 words; it must fit inside the argument section.
+        require(structOffset <= input.length - 4 - 32 * 7, "BalancerV3: bad swap struct offset");
+
+        uint256 poolWord;
+        uint256 tokenInWord;
+        uint256 tokenOutWord;
+        assembly ("memory-safe") {
+            let args := add(input, 36)
+            let structBase := add(args, structOffset) // head word points at the struct tuple
+            poolWord := mload(add(structBase, 32))
+            tokenInWord := mload(add(structBase, 64))
+            tokenOutWord := mload(add(structBase, 96))
+        }
+
+        pool_ = address(uint160(poolWord));
+        tokenIn_ = address(uint160(tokenInWord));
+        tokenOut_ = address(uint160(tokenOutWord));
+    }
+
+    // --- fork reads ---------------------------------------------------------
+
+    function _poolTokenSnapshotAt(PhEvm.ForkId memory fork) internal view returns (PoolTokenSnapshot memory snap) {
+        bytes memory ret = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getPoolTokenInfo, (POOL)), fork);
+        (snap.tokens, snap.tokenInfo, snap.balancesRaw,) =
+            abi.decode(ret, (address[], TokenInfo[], uint256[], uint256[]));
+    }
+
+    function _liveBalancesAt(PhEvm.ForkId memory fork) internal view returns (uint256[] memory balancesLiveScaled18) {
+        bytes memory liveRet = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getCurrentLiveBalances, (POOL)), fork);
+        return abi.decode(liveRet, (uint256[]));
+    }
+
+    /// @dev Recomputes the watched pool's invariant from live balances through the pool's own
+    ///      math, rounding down on both sides of a comparison so fee accrual must exceed dust.
+    function _invariantOf(uint256[] memory balancesLiveScaled18, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (uint256 invariant)
+    {
+        return _readUintAt(
+            POOL,
+            abi.encodeCall(IBalancerV3BasePoolLike.computeInvariant, (balancesLiveScaled18, Rounding.ROUND_DOWN)),
+            fork
+        );
+    }
+
+    /// @dev Registration-order indexes of the swap legs, from one lean `getPoolTokens` read.
+    ///      Both legs are matched independently so `tokenIn == tokenOut` resolves to one shared
+    ///      index instead of reverting: the Vault rejects same-token swaps, so such a trigger can
+    ///      only be observed for a call that left no state change, and the direction checks then
+    ///      pin that single balance in place rather than falsely blocking the transaction.
+    function _tokenIndexesAt(PhEvm.ForkId memory fork, address tokenIn, address tokenOut)
+        internal
+        view
+        returns (uint256 indexIn, uint256 indexOut)
+    {
+        bytes memory ret = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getPoolTokens, (POOL)), fork);
+        address[] memory tokens = abi.decode(ret, (address[]));
+
+        indexIn = type(uint256).max;
+        indexOut = type(uint256).max;
+        for (uint256 i; i < tokens.length; ++i) {
+            if (tokens[i] == tokenIn) {
+                indexIn = i;
+            }
+            if (tokens[i] == tokenOut) {
+                indexOut = i;
+            }
+        }
+        require(indexIn != type(uint256).max, "BalancerV3: tokenIn not registered in pool");
+        require(indexOut != type(uint256).max, "BalancerV3: tokenOut not registered in pool");
+    }
+
+    function _bptTotalSupplyAt(PhEvm.ForkId memory fork) internal view returns (uint256) {
+        return _readUintAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.totalSupply, (POOL)), fork);
+    }
+
+    function _reservesOfAt(address token, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        return _readUintAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getReservesOf, (token)), fork);
+    }
+
+    function _aggregateFeesAt(address token, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        return _readUintAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getAggregateSwapFeeAmount, (POOL, token)), fork)
+            + _readUintAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getAggregateYieldFeeAmount, (POOL, token)), fork);
+    }
+
+    function _isPoolInitializedAt(PhEvm.ForkId memory fork) internal view returns (bool) {
+        return _readBoolAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.isPoolInitialized, (POOL)), fork);
+    }
+
+    function _rateAt(address rateProvider, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        return _readUintAt(rateProvider, abi.encodeCall(IRateProviderLike.getRate, ()), fork);
+    }
+
+    /// @dev Tolerant rate read for baseline forks: a provider that did not exist or did not
+    ///      answer at the fork reads as zero instead of reverting. A staticcall to an address
+    ///      without code succeeds with empty returndata, so the strict `_rateAt` would revert in
+    ///      `abi.decode` and falsely block a transaction that deploys the provider itself (e.g.
+    ///      pool registration bundled with provider deployment).
+    function _rateOrZeroAt(address rateProvider, PhEvm.ForkId memory fork) internal view returns (uint256) {
+        PhEvm.StaticCallResult memory result =
+            ph.staticcallAt(rateProvider, abi.encodeCall(IRateProviderLike.getRate, ()), FORK_VIEW_GAS, fork);
+        if (!result.ok || result.data.length < 32) {
+            return 0;
+        }
+        return abi.decode(result.data, (uint256));
+    }
+
+    // --- small math ---------------------------------------------------------
+
+    function _bpsOf(uint256 value, uint256 bps) internal pure returns (uint256) {
+        return value * bps / BPS_DENOMINATOR;
+    }
+
+    function _absDiff(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : b - a;
+    }
+}

--- a/examples/balancer/src/BalancerV3VaultHelpers.sol
+++ b/examples/balancer/src/BalancerV3VaultHelpers.sol
@@ -93,6 +93,41 @@ abstract contract BalancerV3VaultHelpers is Assertion {
         tokenOut_ = address(uint160(tokenOutWord));
     }
 
+    /// @dev Reads the first field from a dynamic struct argument in selector-prefixed calldata.
+    ///      Balancer's add/remove liquidity parameter structs place `pool` first.
+    function _operationPool(bytes memory input) internal pure returns (address pool_) {
+        uint256 structOffset;
+        uint256 poolWord;
+        assembly ("memory-safe") {
+            let args := add(input, 36)
+            structOffset := mload(args)
+            poolWord := mload(add(args, structOffset))
+        }
+        pool_ = address(uint160(poolWord));
+    }
+
+    /// @dev Reads the first address argument from selector-prefixed calldata.
+    function _firstAddressArg(bytes memory input) internal pure returns (address value) {
+        uint256 word;
+        assembly ("memory-safe") {
+            word := mload(add(input, 36))
+        }
+        value = address(uint160(word));
+    }
+
+    /// @dev Reads a pool field from `getCallInputs` bytes, which omit the selector. `fieldOffset`
+    ///      is zero for add/remove liquidity and one word for swap, where `kind` comes first.
+    function _operationPoolFromArgs(bytes memory input, uint256 fieldOffset) internal pure returns (address pool_) {
+        uint256 structOffset;
+        uint256 poolWord;
+        assembly ("memory-safe") {
+            let args := add(input, 32)
+            structOffset := mload(args)
+            poolWord := mload(add(add(args, structOffset), fieldOffset))
+        }
+        pool_ = address(uint160(poolWord));
+    }
+
     // --- fork reads ---------------------------------------------------------
 
     function _poolTokenSnapshotAt(PhEvm.ForkId memory fork) internal view returns (PoolTokenSnapshot memory snap) {

--- a/examples/balancer/src/BalancerV3VaultHelpers.sol
+++ b/examples/balancer/src/BalancerV3VaultHelpers.sol
@@ -5,6 +5,7 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 import {
+    HooksConfig,
     IBalancerV3BasePoolLike,
     IBalancerV3VaultLike,
     IRateProviderLike,
@@ -27,9 +28,14 @@ abstract contract BalancerV3VaultHelpers is Assertion {
     /// @notice Watched pool registered with the Vault.
     address internal immutable POOL;
 
-    /// @notice Allowed downward invariant movement across one swap, in bps, to absorb pool-math
-    ///         rounding dust. Zero enforces strict non-decrease.
-    uint256 internal immutable INVARIANT_DUST_TOLERANCE_BPS;
+    /// @notice Allowed downward invariant movement across one swap, in absolute invariant units
+    ///         (the pool's 18-decimal invariant scale), to absorb pool-math rounding dust. Zero
+    ///         enforces strict non-decrease.
+    ///         CALIBRATE: derive from the supported pool implementation's rounding behavior (a few
+    ///         units per token is typical). A relative (bps-of-invariant) tolerance cannot express
+    ///         rounding dust: one bp of a 1e24 invariant already allows 1e20 of repeatable loss
+    ///         per swap.
+    uint256 internal immutable INVARIANT_DUST_TOLERANCE;
 
     /// @notice Allowed movement of a token's rate-provider rate within one transaction, in bps.
     uint256 internal immutable RATE_DRIFT_TOLERANCE_BPS;
@@ -44,15 +50,14 @@ abstract contract BalancerV3VaultHelpers is Assertion {
 
     /// @dev All addresses and thresholds are supplied explicitly; the constructor never reads the
     ///      adopter because the assertion-deploy runtime is isolated from live chain state.
-    constructor(address vault_, address pool_, uint256 invariantDustToleranceBps_, uint256 rateDriftToleranceBps_) {
+    constructor(address vault_, address pool_, uint256 invariantDustTolerance_, uint256 rateDriftToleranceBps_) {
         require(vault_ != address(0), "BalancerV3: zero vault");
         require(pool_ != address(0), "BalancerV3: zero pool");
-        require(invariantDustToleranceBps_ < BPS_DENOMINATOR, "BalancerV3: bad invariant tolerance");
         require(rateDriftToleranceBps_ < BPS_DENOMINATOR, "BalancerV3: bad rate tolerance");
 
         VAULT = vault_;
         POOL = pool_;
-        INVARIANT_DUST_TOLERANCE_BPS = invariantDustToleranceBps_;
+        INVARIANT_DUST_TOLERANCE = invariantDustTolerance_;
         RATE_DRIFT_TOLERANCE_BPS = rateDriftToleranceBps_;
     }
 
@@ -123,19 +128,16 @@ abstract contract BalancerV3VaultHelpers is Assertion {
         );
     }
 
-    /// @dev Registration-order indexes of the swap legs, from one lean `getPoolTokens` read.
+    /// @dev Registration-order indexes of the swap legs within an already-read token snapshot.
     ///      Both legs are matched independently so `tokenIn == tokenOut` resolves to one shared
     ///      index instead of reverting: the Vault rejects same-token swaps, so such a trigger can
     ///      only be observed for a call that left no state change, and the direction checks then
     ///      pin that single balance in place rather than falsely blocking the transaction.
-    function _tokenIndexesAt(PhEvm.ForkId memory fork, address tokenIn, address tokenOut)
+    function _tokenIndexes(address[] memory tokens, address tokenIn, address tokenOut)
         internal
-        view
+        pure
         returns (uint256 indexIn, uint256 indexOut)
     {
-        bytes memory ret = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getPoolTokens, (POOL)), fork);
-        address[] memory tokens = abi.decode(ret, (address[]));
-
         indexIn = type(uint256).max;
         indexOut = type(uint256).max;
         for (uint256 i; i < tokens.length; ++i) {
@@ -167,22 +169,55 @@ abstract contract BalancerV3VaultHelpers is Assertion {
         return _readBoolAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.isPoolInitialized, (POOL)), fork);
     }
 
+    function _isPoolInRecoveryModeAt(PhEvm.ForkId memory fork) internal view returns (bool) {
+        return _readBoolAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.isPoolInRecoveryMode, (POOL)), fork);
+    }
+
+    /// @dev Whether the watched pool runs a before- or after-swap hook. Those two hooks execute
+    ///      inside the `Vault.swap` call scope and outside the internal `_swap` reentrancy guard,
+    ///      so they may legitimately reenter the Vault (nested liquidity, donations, nested swaps)
+    ///      and change BPT supply, balances, and rates between the swap call's boundary snapshots.
+    ///      The dynamic-swap-fee hook is declared `view` and cannot mutate state, and the
+    ///      liquidity hooks do not run within a swap, so neither disqualifies the pool here.
+    function _hasSwapHooksAt(PhEvm.ForkId memory fork) internal view returns (bool) {
+        bytes memory ret = _viewAt(VAULT, abi.encodeCall(IBalancerV3VaultLike.getHooksConfig, (POOL)), fork);
+        HooksConfig memory config = abi.decode(ret, (HooksConfig));
+        return config.shouldCallBeforeSwap || config.shouldCallAfterSwap;
+    }
+
+    /// @notice Strict rate read: reverts if the provider does not answer.
     function _rateAt(address rateProvider, PhEvm.ForkId memory fork) internal view returns (uint256) {
         return _readUintAt(rateProvider, abi.encodeCall(IRateProviderLike.getRate, ()), fork);
     }
 
-    /// @dev Tolerant rate read for baseline forks: a provider that did not exist or did not
-    ///      answer at the fork reads as zero instead of reverting. A staticcall to an address
-    ///      without code succeeds with empty returndata, so the strict `_rateAt` would revert in
-    ///      `abi.decode` and falsely block a transaction that deploys the provider itself (e.g.
-    ///      pool registration bundled with provider deployment).
-    function _rateOrZeroAt(address rateProvider, PhEvm.ForkId memory fork) internal view returns (uint256) {
+    /// @notice Status-preserving rate read for baseline forks.
+    /// @dev Distinguishes "the provider did not answer" from "the provider answered zero": a
+    ///      staticcall to an address without code succeeds with empty returndata, so `answered`
+    ///      is false only when the call reverted or returned no word — the provider did not exist
+    ///      or could not respond at that fork. A successful ABI-encoded zero keeps
+    ///      `answered = true` so callers can treat it as a broken baseline instead of silently
+    ///      granting the deployment-lifecycle exemption.
+    function _rateStatusAt(address rateProvider, PhEvm.ForkId memory fork)
+        internal
+        view
+        returns (bool answered, uint256 rate)
+    {
         PhEvm.StaticCallResult memory result =
             ph.staticcallAt(rateProvider, abi.encodeCall(IRateProviderLike.getRate, ()), FORK_VIEW_GAS, fork);
         if (!result.ok || result.data.length < 32) {
-            return 0;
+            return (false, 0);
         }
-        return abi.decode(result.data, (uint256));
+        return (true, abi.decode(result.data, (uint256)));
+    }
+
+    /// @dev Whether `rateProvider` was already registered for the watched pool in `snap`.
+    function _providerRegisteredIn(PoolTokenSnapshot memory snap, address rateProvider) internal pure returns (bool) {
+        for (uint256 i; i < snap.tokenInfo.length; ++i) {
+            if (snap.tokenInfo[i].rateProvider == rateProvider) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // --- small math ---------------------------------------------------------

--- a/examples/balancer/src/BalancerV3VaultInterfaces.sol
+++ b/examples/balancer/src/BalancerV3VaultInterfaces.sol
@@ -38,24 +38,6 @@ struct TokenInfo {
     bool paysYieldFees;
 }
 
-/// @notice Pool hook wiring, mirrored from Balancer's `HooksConfig`. The swap-scoped assertion
-///         reads only the before/after-swap flags: those hooks execute inside the `Vault.swap`
-///         call scope and may legitimately reenter the Vault, so pools that enable them cannot
-///         be checked with call-boundary snapshots.
-struct HooksConfig {
-    bool enableHookAdjustedAmounts;
-    bool shouldCallBeforeInitialize;
-    bool shouldCallAfterInitialize;
-    bool shouldCallComputeDynamicSwapFee;
-    bool shouldCallBeforeSwap;
-    bool shouldCallAfterSwap;
-    bool shouldCallBeforeAddLiquidity;
-    bool shouldCallAfterAddLiquidity;
-    bool shouldCallBeforeRemoveLiquidity;
-    bool shouldCallAfterRemoveLiquidity;
-    address hooksContract;
-}
-
 /// @notice The Vault surface used by the assertions. Getters live on VaultExtension in
 ///         production but are reachable through the Vault address via its fallback delegation.
 interface IBalancerV3VaultLike {
@@ -86,8 +68,6 @@ interface IBalancerV3VaultLike {
     function totalSupply(address token) external view returns (uint256 tokenTotalSupply);
 
     function isPoolInitialized(address pool) external view returns (bool initialized);
-
-    function getHooksConfig(address pool) external view returns (HooksConfig memory hooksConfig);
 
     function isPoolInRecoveryMode(address pool) external view returns (bool inRecoveryMode);
 }

--- a/examples/balancer/src/BalancerV3VaultInterfaces.sol
+++ b/examples/balancer/src/BalancerV3VaultInterfaces.sol
@@ -31,6 +31,39 @@ struct VaultSwapParams {
     bytes userData;
 }
 
+enum AddLiquidityKind {
+    PROPORTIONAL,
+    UNBALANCED,
+    SINGLE_TOKEN_EXACT_OUT,
+    DONATION,
+    CUSTOM
+}
+
+struct AddLiquidityParams {
+    address pool;
+    address to;
+    uint256[] maxAmountsIn;
+    uint256 minBptAmountOut;
+    AddLiquidityKind kind;
+    bytes userData;
+}
+
+enum RemoveLiquidityKind {
+    PROPORTIONAL,
+    SINGLE_TOKEN_EXACT_IN,
+    SINGLE_TOKEN_EXACT_OUT,
+    CUSTOM
+}
+
+struct RemoveLiquidityParams {
+    address pool;
+    address from;
+    uint256 maxBptAmountIn;
+    uint256[] minAmountsOut;
+    RemoveLiquidityKind kind;
+    bytes userData;
+}
+
 /// @notice Per-token registration data, mirrored from Balancer's `TokenInfo`.
 struct TokenInfo {
     TokenType tokenType;
@@ -44,6 +77,36 @@ interface IBalancerV3VaultLike {
     function swap(VaultSwapParams calldata vaultSwapParams)
         external
         returns (uint256 amountCalculated, uint256 amountIn, uint256 amountOut);
+
+    function addLiquidity(AddLiquidityParams calldata params)
+        external
+        returns (uint256[] memory amountsIn, uint256 bptAmountOut, bytes memory returnData);
+
+    function removeLiquidity(RemoveLiquidityParams calldata params)
+        external
+        returns (uint256 bptAmountIn, uint256[] memory amountsOut, bytes memory returnData);
+
+    function initialize(
+        address pool,
+        address to,
+        address[] calldata tokens,
+        uint256[] calldata exactAmountsIn,
+        uint256 minBptAmountOut,
+        bytes calldata userData
+    ) external returns (uint256 bptAmountOut);
+
+    function removeLiquidityRecovery(
+        address pool,
+        address from,
+        uint256 exactBptAmountIn,
+        uint256[] calldata minAmountsOut
+    ) external returns (uint256[] memory amountsOut);
+
+    function collectAggregateFees(address pool)
+        external
+        returns (uint256[] memory swapFeeAmounts, uint256[] memory yieldFeeAmounts);
+
+    function disableRecoveryMode(address pool) external;
 
     function getPoolTokens(address pool) external view returns (address[] memory tokens);
 

--- a/examples/balancer/src/BalancerV3VaultInterfaces.sol
+++ b/examples/balancer/src/BalancerV3VaultInterfaces.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+// Minimal Balancer V3 types mirrored from `balancer-v3-monorepo` (`pkg/interfaces`).
+// Only the surfaces the assertion bundle reads are included; token addresses are plain
+// `address` instead of `IERC20`, which is ABI-identical.
+
+enum SwapKind {
+    EXACT_IN,
+    EXACT_OUT
+}
+
+enum Rounding {
+    ROUND_UP,
+    ROUND_DOWN
+}
+
+enum TokenType {
+    STANDARD,
+    WITH_RATE
+}
+
+/// @notice Calldata for `IVaultMain.swap`, mirrored from Balancer's `VaultSwapParams`.
+struct VaultSwapParams {
+    SwapKind kind;
+    address pool;
+    address tokenIn;
+    address tokenOut;
+    uint256 amountGivenRaw;
+    uint256 limitRaw;
+    bytes userData;
+}
+
+/// @notice Per-token registration data, mirrored from Balancer's `TokenInfo`.
+struct TokenInfo {
+    TokenType tokenType;
+    address rateProvider;
+    bool paysYieldFees;
+}
+
+/// @notice The Vault surface used by the assertions. Getters live on VaultExtension in
+///         production but are reachable through the Vault address via its fallback delegation.
+interface IBalancerV3VaultLike {
+    function swap(VaultSwapParams calldata vaultSwapParams)
+        external
+        returns (uint256 amountCalculated, uint256 amountIn, uint256 amountOut);
+
+    function getPoolTokens(address pool) external view returns (address[] memory tokens);
+
+    function getPoolTokenInfo(address pool)
+        external
+        view
+        returns (
+            address[] memory tokens,
+            TokenInfo[] memory tokenInfo,
+            uint256[] memory balancesRaw,
+            uint256[] memory lastBalancesLiveScaled18
+        );
+
+    function getCurrentLiveBalances(address pool) external view returns (uint256[] memory balancesLiveScaled18);
+
+    function getReservesOf(address token) external view returns (uint256 reserveAmount);
+
+    function getAggregateSwapFeeAmount(address pool, address token) external view returns (uint256 swapFeeAmount);
+
+    function getAggregateYieldFeeAmount(address pool, address token) external view returns (uint256 yieldFeeAmount);
+
+    function totalSupply(address token) external view returns (uint256 tokenTotalSupply);
+
+    function isPoolInitialized(address pool) external view returns (bool initialized);
+}
+
+/// @notice Pool math surface: the Vault trusts these functions, the assertions re-check them.
+interface IBalancerV3BasePoolLike {
+    function computeInvariant(uint256[] memory balancesLiveScaled18, Rounding rounding)
+        external
+        view
+        returns (uint256 invariant);
+}
+
+/// @notice Rate provider surface for WITH_RATE pool tokens.
+interface IRateProviderLike {
+    function getRate() external view returns (uint256 rate);
+}

--- a/examples/balancer/src/BalancerV3VaultInterfaces.sol
+++ b/examples/balancer/src/BalancerV3VaultInterfaces.sol
@@ -38,6 +38,24 @@ struct TokenInfo {
     bool paysYieldFees;
 }
 
+/// @notice Pool hook wiring, mirrored from Balancer's `HooksConfig`. The swap-scoped assertion
+///         reads only the before/after-swap flags: those hooks execute inside the `Vault.swap`
+///         call scope and may legitimately reenter the Vault, so pools that enable them cannot
+///         be checked with call-boundary snapshots.
+struct HooksConfig {
+    bool enableHookAdjustedAmounts;
+    bool shouldCallBeforeInitialize;
+    bool shouldCallAfterInitialize;
+    bool shouldCallComputeDynamicSwapFee;
+    bool shouldCallBeforeSwap;
+    bool shouldCallAfterSwap;
+    bool shouldCallBeforeAddLiquidity;
+    bool shouldCallAfterAddLiquidity;
+    bool shouldCallBeforeRemoveLiquidity;
+    bool shouldCallAfterRemoveLiquidity;
+    address hooksContract;
+}
+
 /// @notice The Vault surface used by the assertions. Getters live on VaultExtension in
 ///         production but are reachable through the Vault address via its fallback delegation.
 interface IBalancerV3VaultLike {
@@ -68,6 +86,10 @@ interface IBalancerV3VaultLike {
     function totalSupply(address token) external view returns (uint256 tokenTotalSupply);
 
     function isPoolInitialized(address pool) external view returns (bool initialized);
+
+    function getHooksConfig(address pool) external view returns (HooksConfig memory hooksConfig);
+
+    function isPoolInRecoveryMode(address pool) external view returns (bool inRecoveryMode);
 }
 
 /// @notice Pool math surface: the Vault trusts these functions, the assertions re-check them.

--- a/examples/balancer/src/BalancerV3VaultOutflowAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultOutflowAssertion.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+/// @title BalancerV3VaultOutflowAssertion
+/// @author Phylax Systems
+/// @notice Rolling-window circuit breaker on one token leaving the Balancer V3 Vault's custody.
+/// @dev Apply to the Vault singleton. The Vault custodies every pool's liquidity for a token, so a
+///      drain of any single pool, buffer, or fee path ultimately shows up as that token leaving the
+///      Vault's ERC20 balance. This breaker is flow-based rather than selector-based: it does not
+///      care which Router, hook, or admin path moved the funds, only how fast custody is leaving,
+///      which is the one bound that survives a bug in any individual code path.
+///
+///      The breaker counts all exits, including honest large withdrawals and batch settlements, so
+///      the threshold must sit above the largest legitimate single-window outflow observed for the
+///      deployment. Calibrate per token from historical Vault flow before adoption; a breaker that
+///      trips on an honest whale exit is worse than none.
+contract BalancerV3VaultOutflowAssertion is Assertion {
+    /// @notice Balancer V3 Vault singleton whose token custody is rate-limited (the adopter).
+    address public immutable vault;
+
+    /// @notice Token whose outflow is watched.
+    address public immutable token;
+
+    /// @notice Cumulative outflow cap as bps of the token balance at window start. 2000 = 20%.
+    uint256 public immutable outflowThresholdBps;
+
+    /// @notice Rolling window length, in seconds, over which the cap is enforced.
+    uint256 public immutable outflowWindowDuration;
+
+    constructor(address vault_, address token_, uint256 outflowThresholdBps_, uint256 outflowWindowDuration_) {
+        require(vault_ != address(0), "BalancerV3Outflow: zero vault");
+        require(token_ != address(0), "BalancerV3Outflow: zero token");
+        require(outflowThresholdBps_ != 0 && outflowThresholdBps_ <= 10_000, "BalancerV3Outflow: bad threshold");
+        require(outflowWindowDuration_ != 0, "BalancerV3Outflow: zero window");
+
+        vault = vault_;
+        token = token_;
+        outflowThresholdBps = outflowThresholdBps_;
+        outflowWindowDuration = outflowWindowDuration_;
+
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    /// @notice Registers the rolling-window outflow breaker on the watched token.
+    /// @dev The executor tracks the rolling outflow internally and invokes the assertion only once
+    ///      the watched token's cumulative outflow crosses the threshold, so reaching the assertion
+    ///      already means the rate limit was breached.
+    function triggers() external view override {
+        watchCumulativeOutflow(
+            token, outflowThresholdBps, outflowWindowDuration, this.assertOutflowWithinLimit.selector
+        );
+    }
+
+    /// @notice Hard circuit breaker for token outflow from the Vault.
+    /// @dev Invoked only after the cumulative outflow already exceeded the threshold, so it reverts
+    ///      unconditionally: the offending transaction is never included and the team can triage.
+    ///      A legitimate outflow above the cap must be split across windows or the limit raised.
+    function assertOutflowWithinLimit() external pure {
+        revert("BalancerV3Outflow: vault token outflow circuit breaker tripped");
+    }
+}

--- a/examples/balancer/src/BalancerV3VaultOutflowAssertion.sol
+++ b/examples/balancer/src/BalancerV3VaultOutflowAssertion.sol
@@ -6,35 +6,65 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 
 /// @title BalancerV3VaultOutflowAssertion
 /// @author Phylax Systems
-/// @notice Rolling-window circuit breaker on one token leaving the Balancer V3 Vault's custody.
+/// @notice Rolling-window circuit breaker on one token's NET outflow from the Balancer V3 Vault's
+///         custody.
 /// @dev Apply to the Vault singleton. The Vault custodies every pool's liquidity for a token, so a
 ///      drain of any single pool, buffer, or fee path ultimately shows up as that token leaving the
 ///      Vault's ERC20 balance. This breaker is flow-based rather than selector-based: it does not
 ///      care which Router, hook, or admin path moved the funds, only how fast custody is leaving,
 ///      which is the one bound that survives a bug in any individual code path.
 ///
-///      The breaker counts all exits, including honest large withdrawals and batch settlements, so
-///      the threshold must sit above the largest legitimate single-window outflow observed for the
-///      deployment. Calibrate per token from historical Vault flow before adoption; a breaker that
-///      trips on an honest whale exit is worse than none.
+///      What the executor actually measures, stated exactly:
+///      - The threshold is on NET flow (`cumulativeOutflow - cumulativeInflow`) within the rolling
+///        window, as bps of the token balance snapshotted at window start. Inflows from ANY source
+///        sharing the singleton — deposits into unrelated pools, buffer traffic — offset exits, so
+///        a 400-token drain behind a 250-token deposit measures as 150 tokens of outflow. This is
+///        drain protection for sustained custody loss, not a gross-exit bound; a gross bound would
+///        need an absolute-outflow or pool-aware trigger, which `watchCumulativeOutflow` is not.
+///      - The breaker is value-blind and token-scoped. A canonical ERC-4626 buffer rebalance wraps
+///        underlying out of custody while wrapped shares flow in: value-preserving for the Vault,
+///        but the underlying watcher counts the full wrap as outflow. On deployments where the
+///        watched token backs an active buffer, the threshold must sit above the largest expected
+///        wrap, or the watched token should be one without buffer traffic.
+///      - Aggregate protocol-fee collection (`collectAggregateFees`) transfers the ENTIRE accrued
+///        fee ledger in one call — it has no amount parameter and cannot be split across windows.
+///        Collection cadence must keep the accrued ledger below the cap; a legitimate operation
+///        that has already outgrown the cap can only proceed by raising the limit or temporarily
+///        deactivating this assertion through the protocol's Credible Layer management flow.
+///
+///      The cap therefore must be calibrated per token from historical Vault flow — above the
+///      largest legitimate single-window net outflow (whale exits, batch settlements, buffer
+///      rebalances, fee collection) — before adoption. A breaker that trips on honest traffic is
+///      worse than none.
 contract BalancerV3VaultOutflowAssertion is Assertion {
     /// @notice Balancer V3 Vault singleton whose token custody is rate-limited (the adopter).
     address public immutable vault;
 
-    /// @notice Token whose outflow is watched.
+    /// @notice Token whose net outflow is watched.
     address public immutable token;
 
-    /// @notice Cumulative outflow cap as bps of the token balance at window start. 2000 = 20%.
+    /// @notice Net outflow cap as bps of the token balance at window start. 2000 = 20%.
     uint256 public immutable outflowThresholdBps;
 
     /// @notice Rolling window length, in seconds, over which the cap is enforced.
     uint256 public immutable outflowWindowDuration;
 
+    /// @dev The executor buckets flow in 10-second granules and stores window state in `u64`
+    ///      fields; a window below one bucket or beyond `u64` deploys fine and then fails trigger
+    ///      registration, so both bounds are enforced here where they are visible at deploy time.
+    uint256 internal constant MIN_WINDOW_DURATION = 10;
+
     constructor(address vault_, address token_, uint256 outflowThresholdBps_, uint256 outflowWindowDuration_) {
         require(vault_ != address(0), "BalancerV3Outflow: zero vault");
         require(token_ != address(0), "BalancerV3Outflow: zero token");
-        require(outflowThresholdBps_ != 0 && outflowThresholdBps_ <= 10_000, "BalancerV3Outflow: bad threshold");
-        require(outflowWindowDuration_ != 0, "BalancerV3Outflow: zero window");
+        // 10_000 bps is unreachable, not permissive: the executor dispatches only when net outflow
+        // STRICTLY exceeds the threshold, and net outflow can never exceed the window-start
+        // balance, so a full drain lands exactly on 100% and would never fire the breaker.
+        require(outflowThresholdBps_ != 0 && outflowThresholdBps_ < 10_000, "BalancerV3Outflow: bad threshold");
+        require(
+            outflowWindowDuration_ >= MIN_WINDOW_DURATION && outflowWindowDuration_ <= type(uint64).max,
+            "BalancerV3Outflow: bad window"
+        );
 
         vault = vault_;
         token = token_;
@@ -45,20 +75,26 @@ contract BalancerV3VaultOutflowAssertion is Assertion {
     }
 
     /// @notice Registers the rolling-window outflow breaker on the watched token.
-    /// @dev The executor tracks the rolling outflow internally and invokes the assertion only once
-    ///      the watched token's cumulative outflow crosses the threshold, so reaching the assertion
-    ///      already means the rate limit was breached.
-    function triggers() external view override {
+    /// @dev The executor tracks the rolling net outflow internally and invokes the assertion only
+    ///      once the watched token's cumulative net outflow crosses the threshold, so reaching the
+    ///      assertion already means the rate limit was breached. Virtual so tests can subclass
+    ///      with a call trigger and drive the breaker through real assertion dispatch (the flow
+    ///      trigger itself is executor-driven and not simulated by local `pcl test`).
+    function triggers() external view virtual override {
         watchCumulativeOutflow(
             token, outflowThresholdBps, outflowWindowDuration, this.assertOutflowWithinLimit.selector
         );
     }
 
-    /// @notice Hard circuit breaker for token outflow from the Vault.
-    /// @dev Invoked only after the cumulative outflow already exceeded the threshold, so it reverts
-    ///      unconditionally: the offending transaction is never included and the team can triage.
-    ///      A legitimate outflow above the cap must be split across windows or the limit raised.
-    function assertOutflowWithinLimit() external pure {
+    /// @notice Hard circuit breaker for net token outflow from the Vault.
+    /// @dev Invoked only after the cumulative net outflow already exceeded the threshold. The flow
+    ///      watcher tracks the assertion ADOPTER's balance, so the configured Vault is checked
+    ///      against the adopter first: adopting this assertion on any other account fails loudly
+    ///      here instead of silently rate-limiting that account while the Vault goes unprotected.
+    ///      Past that check it reverts unconditionally: the offending transaction is never
+    ///      included and the team can triage.
+    function assertOutflowWithinLimit() external view {
+        require(ph.getAssertionAdopter() == vault, "BalancerV3Outflow: configured vault is not adopter");
         revert("BalancerV3Outflow: vault token outflow circuit breaker tripped");
     }
 }

--- a/examples/balancer/test/BalancerV3Mocks.sol
+++ b/examples/balancer/test/BalancerV3Mocks.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Rounding, SwapKind, TokenInfo, TokenType, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
+
+interface IMockERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/// @notice Rate provider mock with a settable rate for drift tests.
+contract MockRateProvider {
+    uint256 public rate = 1e18;
+
+    function setRate(uint256 rate_) external {
+        rate = rate_;
+    }
+
+    function getRate() external view returns (uint256) {
+        return rate;
+    }
+}
+
+/// @notice Pool math mock: the invariant is the sum of live balances, so directional value
+///         movement maps one-to-one onto invariant movement and each test can steer it exactly.
+contract MockBalancerV3Pool {
+    function computeInvariant(uint256[] memory balancesLiveScaled18, Rounding) external pure returns (uint256) {
+        uint256 invariant;
+        for (uint256 i; i < balancesLiveScaled18.length; ++i) {
+            invariant += balancesLiveScaled18[i];
+        }
+        return invariant;
+    }
+}
+
+/// @notice Balancer V3 Vault mock: two-token pool, reserve/fee ledgers matching the real Vault's
+///         getter surface, and one failure knob per invariant so each test trips exactly one check.
+contract MockBalancerV3Vault {
+    enum Mode {
+        Honest,
+        InvariantLoss, // pays out more tokenOut than the curve allows
+        SupplyDrift, // mints BPT during a swap
+        BalanceSwapEnds, // recorded balances move against the swap direction, invariant preserved
+        ReserveSkim, // real tokens leave the Vault without the reserve ledger noticing
+        PhantomBalance, // inflates the pool's recorded balance with no reserve backing
+        RateShift // moves the rate provider mid-swap
+    }
+
+    uint256 internal constant FEE_DIVISOR = 100; // 1% mock swap fee
+
+    address public immutable pool;
+    MockRateProvider public immutable rateProvider0;
+
+    address[] internal _tokens;
+    uint256[] internal _balancesRaw;
+    mapping(address token => uint256) public reservesOf;
+    mapping(address token => uint256) internal _aggregateSwapFees;
+    uint256 internal _bptSupply = 100e18;
+    Mode public mode;
+    address public skimReceiver;
+
+    constructor(address pool_, address token0_, address token1_, MockRateProvider rateProvider0_) {
+        pool = pool_;
+        rateProvider0 = rateProvider0_;
+        _tokens.push(token0_);
+        _tokens.push(token1_);
+        _balancesRaw.push(0);
+        _balancesRaw.push(0);
+    }
+
+    // --- test knobs ---------------------------------------------------------
+
+    function setMode(Mode mode_) external {
+        mode = mode_;
+    }
+
+    function setSkimReceiver(address receiver) external {
+        skimReceiver = receiver;
+    }
+
+    function seedPoolBalance(uint256 index, uint256 amount) external {
+        _balancesRaw[index] = amount;
+    }
+
+    function seedReserves(address token, uint256 amount) external {
+        reservesOf[token] = amount;
+    }
+
+    function seedAggregateSwapFee(address token, uint256 amount) external {
+        _aggregateSwapFees[token] = amount;
+    }
+
+    // --- swap ----------------------------------------------------------------
+
+    function swap(VaultSwapParams calldata params)
+        external
+        returns (uint256 amountCalculated, uint256 amountIn, uint256 amountOut)
+    {
+        if (params.pool != pool) {
+            return (0, 0, 0);
+        }
+
+        uint256 indexIn = _indexOf(params.tokenIn);
+        uint256 indexOut = _indexOf(params.tokenOut);
+        amountIn = params.amountGivenRaw;
+        uint256 fee = amountIn / FEE_DIVISOR;
+        amountOut = mode == Mode.InvariantLoss ? amountIn * 2 : amountIn - 2 * fee;
+        amountCalculated = amountOut;
+
+        if (mode == Mode.BalanceSwapEnds) {
+            // Recorded balances flow against the swap direction while the sum invariant holds.
+            _balancesRaw[indexIn] -= amountIn;
+            _balancesRaw[indexOut] += amountIn;
+            return (amountCalculated, amountIn, amountOut);
+        }
+
+        IMockERC20(params.tokenIn).transferFrom(msg.sender, address(this), amountIn);
+        IMockERC20(params.tokenOut).transfer(msg.sender, amountOut);
+
+        reservesOf[params.tokenIn] += amountIn;
+        reservesOf[params.tokenOut] -= amountOut;
+        _balancesRaw[indexIn] += amountIn - fee;
+        _aggregateSwapFees[params.tokenIn] += fee;
+        _balancesRaw[indexOut] -= amountOut;
+
+        if (mode == Mode.SupplyDrift) {
+            _bptSupply += 1e18;
+        } else if (mode == Mode.ReserveSkim) {
+            IMockERC20(params.tokenOut).transfer(skimReceiver, 10e18);
+        } else if (mode == Mode.PhantomBalance) {
+            _balancesRaw[indexOut] += 600e18;
+        } else if (mode == Mode.RateShift) {
+            rateProvider0.setRate(rateProvider0.rate() * 2);
+        }
+    }
+
+    // --- IBalancerV3VaultLike getter surface ----------------------------------
+
+    function getPoolTokens(address) external view returns (address[] memory) {
+        return _tokens;
+    }
+
+    function getPoolTokenInfo(address)
+        external
+        view
+        returns (
+            address[] memory tokens,
+            TokenInfo[] memory tokenInfo,
+            uint256[] memory balancesRaw,
+            uint256[] memory lastBalancesLiveScaled18
+        )
+    {
+        tokens = _tokens;
+        tokenInfo = new TokenInfo[](2);
+        tokenInfo[0] =
+            TokenInfo({tokenType: TokenType.WITH_RATE, rateProvider: address(rateProvider0), paysYieldFees: false});
+        tokenInfo[1] = TokenInfo({tokenType: TokenType.STANDARD, rateProvider: address(0), paysYieldFees: false});
+        balancesRaw = _balancesRaw;
+        lastBalancesLiveScaled18 = _balancesRaw;
+    }
+
+    function getCurrentLiveBalances(address) external view returns (uint256[] memory) {
+        return _balancesRaw;
+    }
+
+    function getAggregateSwapFeeAmount(address, address token) external view returns (uint256) {
+        return _aggregateSwapFees[token];
+    }
+
+    function getAggregateYieldFeeAmount(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getReservesOf(address token) external view returns (uint256) {
+        return reservesOf[token];
+    }
+
+    function totalSupply(address) external view returns (uint256) {
+        return _bptSupply;
+    }
+
+    function isPoolInitialized(address) external pure returns (bool) {
+        return true;
+    }
+
+    function _indexOf(address token) internal view returns (uint256) {
+        for (uint256 i; i < _tokens.length; ++i) {
+            if (_tokens[i] == token) {
+                return i;
+            }
+        }
+        revert("MockVault: unknown token");
+    }
+}

--- a/examples/balancer/test/BalancerV3Mocks.sol
+++ b/examples/balancer/test/BalancerV3Mocks.sol
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Rounding, SwapKind, TokenInfo, TokenType, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
+import {
+    AddLiquidityParams,
+    RemoveLiquidityParams,
+    Rounding,
+    SwapKind,
+    TokenInfo,
+    TokenType,
+    VaultSwapParams
+} from "../src/BalancerV3VaultInterfaces.sol";
 
 interface IMockERC20 {
     function transfer(address to, uint256 amount) external returns (bool);
@@ -64,6 +72,7 @@ contract MockBalancerV3Vault {
     address public skimReceiver;
     bool public swapHooks;
     bool public recoveryMode;
+    bool public revertOnPoolReads;
 
     constructor(address pool_, address token0_, address token1_, MockRateProvider rateProvider0_) {
         pool = pool_;
@@ -92,6 +101,14 @@ contract MockBalancerV3Vault {
         recoveryMode = enabled;
     }
 
+    function setRevertOnPoolReads(bool enabled) external {
+        revertOnPoolReads = enabled;
+    }
+
+    function registerNewRateProvider() external {
+        rateProvider0 = new MockRateProvider();
+    }
+
     function seedPoolBalance(uint256 index, uint256 amount) external {
         _balancesRaw[index] = amount;
     }
@@ -114,14 +131,7 @@ contract MockBalancerV3Vault {
         rateProvider0.setRate(rateProvider0.rate() + 1e18);
     }
 
-    /// @notice Deploys a fresh rate provider inside the current transaction and registers it for
-    ///         token0, bumping pool accounting so the transaction counts as touching the pool.
-    ///         Models the pool-deployment lifecycle where a provider has no pre-tx code and no
-    ///         pre-tx registration.
-    function registerNewRateProviderAndTouchPool() external {
-        rateProvider0 = new MockRateProvider();
-        _balancesRaw[0] += 1;
-    }
+    function unrelatedVaultCall() external pure {}
 
     // --- swap ----------------------------------------------------------------
 
@@ -178,6 +188,40 @@ contract MockBalancerV3Vault {
         }
     }
 
+    function addLiquidity(AddLiquidityParams calldata params)
+        external
+        returns (uint256[] memory amountsIn, uint256 bptAmountOut, bytes memory returnData)
+    {
+        amountsIn = params.maxAmountsIn;
+        if (params.pool == pool) {
+            _balancesRaw[0] += 1;
+            _bptSupply += 1;
+        }
+        return (amountsIn, 1, "");
+    }
+
+    function removeLiquidity(RemoveLiquidityParams calldata params)
+        external
+        returns (uint256 bptAmountIn, uint256[] memory amountsOut, bytes memory returnData)
+    {
+        amountsOut = params.minAmountsOut;
+        if (params.pool == pool) {
+            _balancesRaw[0] -= 1;
+            _bptSupply -= 1;
+        }
+        return (1, amountsOut, "");
+    }
+
+    function initialize(address pool_, address, address[] calldata, uint256[] calldata, uint256, bytes calldata)
+        external
+        returns (uint256 bptAmountOut)
+    {
+        if (pool_ == pool) {
+            _balancesRaw[0] += 1;
+        }
+        return 1;
+    }
+
     // --- IBalancerV3VaultLike getter surface ----------------------------------
 
     function getPoolTokens(address) external view returns (address[] memory) {
@@ -194,6 +238,7 @@ contract MockBalancerV3Vault {
             uint256[] memory lastBalancesLiveScaled18
         )
     {
+        require(!revertOnPoolReads, "MockVault: unexpected pool read");
         tokens = _tokens;
         tokenInfo = new TokenInfo[](2);
         tokenInfo[0] =
@@ -264,6 +309,20 @@ contract RateManipulatingRouter {
         uint256 original = provider.rate();
         provider.setRate(original * 2);
         vault.swap(params);
+        provider.setRate(original);
+    }
+
+    function manipulateAddLiquidityRestore(AddLiquidityParams memory params) external {
+        uint256 original = provider.rate();
+        provider.setRate(original * 2);
+        vault.addLiquidity(params);
+        provider.setRate(original);
+    }
+
+    function manipulateRemoveLiquidityRestore(RemoveLiquidityParams memory params) external {
+        uint256 original = provider.rate();
+        provider.setRate(original * 2);
+        vault.removeLiquidity(params);
         provider.setRate(original);
     }
 }

--- a/examples/balancer/test/BalancerV3Mocks.sol
+++ b/examples/balancer/test/BalancerV3Mocks.sol
@@ -1,14 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {
-    HooksConfig,
-    Rounding,
-    SwapKind,
-    TokenInfo,
-    TokenType,
-    VaultSwapParams
-} from "../src/BalancerV3VaultInterfaces.sol";
+import {Rounding, SwapKind, TokenInfo, TokenType, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
 
 interface IMockERC20 {
     function transfer(address to, uint256 amount) external returns (bool);
@@ -48,7 +41,6 @@ contract MockBalancerV3Vault {
     enum Mode {
         Honest,
         InvariantLoss, // pays out more tokenOut than the curve allows
-        SupplyDrift, // mints BPT during a swap
         BalanceSwapEnds, // recorded balances move against the swap direction, invariant preserved
         ReserveSkim, // real tokens leave the Vault without the reserve ledger noticing
         PhantomBalance, // inflates the pool's recorded balance with no reserve backing
@@ -64,6 +56,8 @@ contract MockBalancerV3Vault {
     uint256[] internal _balancesRaw;
     mapping(address token => uint256) public reservesOf;
     mapping(address token => uint256) internal _aggregateSwapFees;
+    mapping(address token => uint256) internal _aggregateYieldFees;
+    mapping(address token => uint256) internal _pendingYieldFees;
     uint256 internal _bptSupply = 100e18;
     Mode public mode;
     address public skimReceiver;
@@ -109,6 +103,10 @@ contract MockBalancerV3Vault {
         _aggregateSwapFees[token] = amount;
     }
 
+    function seedPendingYieldFee(address token, uint256 amount) external {
+        _pendingYieldFees[token] = amount;
+    }
+
     /// @notice Moves the watched rate provider without touching any pool accounting: models a
     ///         transaction that interacts with the Vault singleton but never the watched pool.
     function shiftRateOnly() external {
@@ -136,6 +134,16 @@ contract MockBalancerV3Vault {
 
         uint256 indexIn = _indexOf(params.tokenIn);
         uint256 indexOut = _indexOf(params.tokenOut);
+        uint256 pendingYieldFee = _pendingYieldFees[params.tokenIn];
+        if (pendingYieldFee != 0) {
+            // The real Vault collects pending yield fees before applying swap deltas. Its live
+            // balance getter already excludes this amount in the pre-state, while raw balances do
+            // not. A small honest input can therefore leave postRaw < preRaw.
+            _balancesRaw[indexIn] -= pendingYieldFee;
+            _aggregateYieldFees[params.tokenIn] += pendingYieldFee;
+            delete _pendingYieldFees[params.tokenIn];
+        }
+
         amountIn = params.amountGivenRaw;
         uint256 fee = amountIn / FEE_DIVISOR;
         amountOut = mode == Mode.InvariantLoss ? amountIn * 2 : amountIn - 2 * fee;
@@ -157,9 +165,7 @@ contract MockBalancerV3Vault {
         _aggregateSwapFees[params.tokenIn] += fee;
         _balancesRaw[indexOut] -= amountOut;
 
-        if (mode == Mode.SupplyDrift) {
-            _bptSupply += 1e18;
-        } else if (mode == Mode.ReserveSkim) {
+        if (mode == Mode.ReserveSkim) {
             IMockERC20(params.tokenOut).transfer(skimReceiver, 10e18);
         } else if (mode == Mode.PhantomBalance) {
             _balancesRaw[indexOut] += 600e18;
@@ -188,22 +194,25 @@ contract MockBalancerV3Vault {
         tokens = _tokens;
         tokenInfo = new TokenInfo[](2);
         tokenInfo[0] =
-            TokenInfo({tokenType: TokenType.WITH_RATE, rateProvider: address(rateProvider0), paysYieldFees: false});
+            TokenInfo({tokenType: TokenType.WITH_RATE, rateProvider: address(rateProvider0), paysYieldFees: true});
         tokenInfo[1] = TokenInfo({tokenType: TokenType.STANDARD, rateProvider: address(0), paysYieldFees: false});
         balancesRaw = _balancesRaw;
         lastBalancesLiveScaled18 = _balancesRaw;
     }
 
-    function getCurrentLiveBalances(address) external view returns (uint256[] memory) {
-        return _balancesRaw;
+    function getCurrentLiveBalances(address) external view returns (uint256[] memory balancesLive) {
+        balancesLive = _balancesRaw;
+        for (uint256 i; i < balancesLive.length; ++i) {
+            balancesLive[i] -= _pendingYieldFees[_tokens[i]];
+        }
     }
 
     function getAggregateSwapFeeAmount(address, address token) external view returns (uint256) {
         return _aggregateSwapFees[token];
     }
 
-    function getAggregateYieldFeeAmount(address, address) external pure returns (uint256) {
-        return 0;
+    function getAggregateYieldFeeAmount(address, address token) external view returns (uint256) {
+        return _aggregateYieldFees[token];
     }
 
     function getReservesOf(address token) external view returns (uint256) {
@@ -220,14 +229,6 @@ contract MockBalancerV3Vault {
 
     function isPoolInRecoveryMode(address) external view returns (bool) {
         return recoveryMode;
-    }
-
-    function getHooksConfig(address) external view returns (HooksConfig memory config) {
-        config.shouldCallBeforeSwap = swapHooks;
-        config.shouldCallAfterSwap = swapHooks;
-        if (swapHooks) {
-            config.hooksContract = address(0xDEAD);
-        }
     }
 
     function _indexOf(address token) internal view returns (uint256) {

--- a/examples/balancer/test/BalancerV3Mocks.sol
+++ b/examples/balancer/test/BalancerV3Mocks.sol
@@ -1,12 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Rounding, SwapKind, TokenInfo, TokenType, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
+import {
+    HooksConfig,
+    Rounding,
+    SwapKind,
+    TokenInfo,
+    TokenType,
+    VaultSwapParams
+} from "../src/BalancerV3VaultInterfaces.sol";
 
 interface IMockERC20 {
     function transfer(address to, uint256 amount) external returns (bool);
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
     function balanceOf(address account) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
 }
 
 /// @notice Rate provider mock with a settable rate for drift tests.
@@ -50,7 +58,7 @@ contract MockBalancerV3Vault {
     uint256 internal constant FEE_DIVISOR = 100; // 1% mock swap fee
 
     address public immutable pool;
-    MockRateProvider public immutable rateProvider0;
+    MockRateProvider public rateProvider0;
 
     address[] internal _tokens;
     uint256[] internal _balancesRaw;
@@ -59,6 +67,8 @@ contract MockBalancerV3Vault {
     uint256 internal _bptSupply = 100e18;
     Mode public mode;
     address public skimReceiver;
+    bool public swapHooks;
+    bool public recoveryMode;
 
     constructor(address pool_, address token0_, address token1_, MockRateProvider rateProvider0_) {
         pool = pool_;
@@ -79,6 +89,14 @@ contract MockBalancerV3Vault {
         skimReceiver = receiver;
     }
 
+    function setSwapHooks(bool enabled) external {
+        swapHooks = enabled;
+    }
+
+    function setRecoveryMode(bool enabled) external {
+        recoveryMode = enabled;
+    }
+
     function seedPoolBalance(uint256 index, uint256 amount) external {
         _balancesRaw[index] = amount;
     }
@@ -89,6 +107,21 @@ contract MockBalancerV3Vault {
 
     function seedAggregateSwapFee(address token, uint256 amount) external {
         _aggregateSwapFees[token] = amount;
+    }
+
+    /// @notice Moves the watched rate provider without touching any pool accounting: models a
+    ///         transaction that interacts with the Vault singleton but never the watched pool.
+    function shiftRateOnly() external {
+        rateProvider0.setRate(rateProvider0.rate() + 1e18);
+    }
+
+    /// @notice Deploys a fresh rate provider inside the current transaction and registers it for
+    ///         token0, bumping pool accounting so the transaction counts as touching the pool.
+    ///         Models the pool-deployment lifecycle where a provider has no pre-tx code and no
+    ///         pre-tx registration.
+    function registerNewRateProviderAndTouchPool() external {
+        rateProvider0 = new MockRateProvider();
+        _balancesRaw[0] += 1;
     }
 
     // --- swap ----------------------------------------------------------------
@@ -131,7 +164,8 @@ contract MockBalancerV3Vault {
         } else if (mode == Mode.PhantomBalance) {
             _balancesRaw[indexOut] += 600e18;
         } else if (mode == Mode.RateShift) {
-            rateProvider0.setRate(rateProvider0.rate() * 2);
+            // Additive so the shift also works from a zero baseline (zero-baseline drift test).
+            rateProvider0.setRate(rateProvider0.rate() + 1e18);
         }
     }
 
@@ -184,6 +218,18 @@ contract MockBalancerV3Vault {
         return true;
     }
 
+    function isPoolInRecoveryMode(address) external view returns (bool) {
+        return recoveryMode;
+    }
+
+    function getHooksConfig(address) external view returns (HooksConfig memory config) {
+        config.shouldCallBeforeSwap = swapHooks;
+        config.shouldCallAfterSwap = swapHooks;
+        if (swapHooks) {
+            config.hooksContract = address(0xDEAD);
+        }
+    }
+
     function _indexOf(address token) internal view returns (uint256) {
         for (uint256 i; i < _tokens.length; ++i) {
             if (_tokens[i] == token) {
@@ -191,5 +237,29 @@ contract MockBalancerV3Vault {
             }
         }
         revert("MockVault: unknown token");
+    }
+}
+
+/// @notice Attacker-shaped router: moves a rate provider, swaps against the pool at the shifted
+///         rate, and restores the rate — all inside one transaction, so both transaction-endpoint
+///         snapshots agree while the swap itself priced against the manipulated value.
+contract RateManipulatingRouter {
+    MockBalancerV3Vault internal immutable vault;
+    MockRateProvider internal immutable provider;
+
+    constructor(MockBalancerV3Vault vault_, MockRateProvider provider_) {
+        vault = vault_;
+        provider = provider_;
+    }
+
+    function approveVault(address token) external {
+        IMockERC20(token).approve(address(vault), type(uint256).max);
+    }
+
+    function manipulateSwapRestore(VaultSwapParams memory params) external {
+        uint256 original = provider.rate();
+        provider.setRate(original * 2);
+        vault.swap(params);
+        provider.setRate(original);
     }
 }

--- a/examples/balancer/test/BalancerV3Mocks.sol
+++ b/examples/balancer/test/BalancerV3Mocks.sol
@@ -41,6 +41,7 @@ contract MockBalancerV3Vault {
     enum Mode {
         Honest,
         InvariantLoss, // pays out more tokenOut than the curve allows
+        SupplyDrift, // mints BPT during a swap
         BalanceSwapEnds, // recorded balances move against the swap direction, invariant preserved
         ReserveSkim, // real tokens leave the Vault without the reserve ledger noticing
         PhantomBalance, // inflates the pool's recorded balance with no reserve backing
@@ -165,7 +166,9 @@ contract MockBalancerV3Vault {
         _aggregateSwapFees[params.tokenIn] += fee;
         _balancesRaw[indexOut] -= amountOut;
 
-        if (mode == Mode.ReserveSkim) {
+        if (mode == Mode.SupplyDrift) {
+            _bptSupply += 1e18;
+        } else if (mode == Mode.ReserveSkim) {
             IMockERC20(params.tokenOut).transfer(skimReceiver, 10e18);
         } else if (mode == Mode.PhantomBalance) {
             _balancesRaw[indexOut] += 600e18;

--- a/examples/balancer/test/BalancerV3VaultAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultAssertion.t.sol
@@ -7,10 +7,10 @@ import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/tok
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {BalancerV3VaultAssertion} from "../src/BalancerV3VaultAssertion.sol";
 import {SwapKind, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
-import {MockBalancerV3Pool, MockBalancerV3Vault, MockRateProvider} from "./BalancerV3Mocks.sol";
+import {MockBalancerV3Pool, MockBalancerV3Vault, MockRateProvider, RateManipulatingRouter} from "./BalancerV3Mocks.sol";
 
 contract BalancerV3VaultAssertionTest is Test, CredibleTest {
-    uint256 internal constant INVARIANT_DUST_TOLERANCE_BPS = 0;
+    uint256 internal constant INVARIANT_DUST_TOLERANCE = 0; // absolute invariant units
     uint256 internal constant RATE_DRIFT_TOLERANCE_BPS = 100; // 1%
 
     ERC20Mock internal token0;
@@ -42,23 +42,25 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
     function _arm(bytes4 fnSelector) internal {
         bytes memory createData = abi.encodePacked(
             type(BalancerV3VaultAssertion).creationCode,
-            abi.encode(address(vault), address(pool), INVARIANT_DUST_TOLERANCE_BPS, RATE_DRIFT_TOLERANCE_BPS)
+            abi.encode(address(vault), address(pool), INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS)
         );
         cl.assertion(address(vault), createData, fnSelector);
     }
 
+    function _swapParams(address targetPool) internal view returns (VaultSwapParams memory) {
+        return VaultSwapParams({
+            kind: SwapKind.EXACT_IN,
+            pool: targetPool,
+            tokenIn: address(token0),
+            tokenOut: address(token1),
+            amountGivenRaw: 10e18,
+            limitRaw: 0,
+            userData: ""
+        });
+    }
+
     function _swap(address targetPool) internal {
-        vault.swap(
-            VaultSwapParams({
-                kind: SwapKind.EXACT_IN,
-                pool: targetPool,
-                tokenIn: address(token0),
-                tokenOut: address(token1),
-                amountGivenRaw: 10e18,
-                limitRaw: 0,
-                userData: ""
-            })
-        );
+        vault.swap(_swapParams(targetPool));
     }
 
     // --- assertSwapPreservesPoolInvariant ------------------------------------
@@ -99,17 +101,66 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         _swap(address(pool));
     }
 
-    // --- assertVaultCustodyCoversPoolAccounting -------------------------------
+    /// @notice A rate that moves inside the swap call trips the equality pin: for supported
+    ///         hookless pools no user code can run within the call, so any in-call rate movement
+    ///         is Vault- or pool-driven manipulation.
+    function testRateShiftWithinSwapCallTrips() public {
+        vault.setMode(MockBalancerV3Vault.Mode.RateShift);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: rate moved within swap call"));
+        _swap(address(pool));
+    }
+
+    /// @notice Pools with before/after-swap hooks are outside the swap check's scope: those hooks
+    ///         may legitimately reenter the Vault mid-swap, so call-boundary snapshots cannot
+    ///         attribute deltas to the core swap. A failure knob that would otherwise trip must
+    ///         pass once the pool reports swap hooks.
+    function testHookedPoolSwapChecksAreSkipped() public {
+        vault.setSwapHooks(true);
+        vault.setMode(MockBalancerV3Vault.Mode.InvariantLoss);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        _swap(address(pool));
+    }
+
+    /// @notice Transient manipulation around the swap: rate doubled before the swap call and
+    ///         restored after it, inside one transaction. Both transaction endpoints agree, but
+    ///         the swap priced against the shifted rate — the per-operation baseline observation
+    ///         catches what endpoint comparison cannot.
+    function testTransientRateManipulationAroundSwapTrips() public {
+        RateManipulatingRouter router = new RateManipulatingRouter(vault, rateProvider);
+        token0.mint(address(router), 100e18);
+        router.approveVault(address(token0));
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: swap priced against rate beyond drift bound"));
+        router.manipulateSwapRestore(_swapParams(address(pool)));
+    }
+
+    /// @notice Documents the endpoint-comparison gap the per-operation check exists for: the same
+    ///         manipulate-swap-restore transaction passes the tx-end drift assertion because the
+    ///         pre-tx and post-tx rates are equal.
+    function testTransientRateManipulationPassesEndpointDrift() public {
+        RateManipulatingRouter router = new RateManipulatingRouter(vault, rateProvider);
+        token0.mint(address(router), 100e18);
+        router.approveVault(address(token0));
+
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        router.manipulateSwapRestore(_swapParams(address(pool)));
+    }
+
+    // --- assertPoolAccountingWithinVaultCustody -------------------------------
 
     function testHonestSwapPassesCustodyAssertion() public {
-        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        _arm(BalancerV3VaultAssertion.assertPoolAccountingWithinVaultCustody.selector);
         _swap(address(pool));
     }
 
     function testReserveSkimTripsCustody() public {
         vault.setMode(MockBalancerV3Vault.Mode.ReserveSkim);
 
-        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        _arm(BalancerV3VaultAssertion.assertPoolAccountingWithinVaultCustody.selector);
         vm.expectRevert(bytes("BalancerV3: vault reserves exceed real token custody"));
         _swap(address(pool));
     }
@@ -117,7 +168,7 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
     function testPhantomPoolBalanceTripsCustody() public {
         vault.setMode(MockBalancerV3Vault.Mode.PhantomBalance);
 
-        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        _arm(BalancerV3VaultAssertion.assertPoolAccountingWithinVaultCustody.selector);
         vm.expectRevert(bytes("BalancerV3: pool accounting exceeds vault reserves"));
         _swap(address(pool));
     }
@@ -137,11 +188,51 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         _swap(address(pool));
     }
 
+    /// @notice A provider already registered for the pool pre-tx that answered ZERO pre-tx is a
+    ///         broken baseline, not a deployment lifecycle: it must fail instead of granting the
+    ///         registration exemption and legitimizing an arbitrary post-tx rate.
+    function testZeroBaselineForRegisteredProviderTrips() public {
+        rateProvider.setRate(0);
+        vault.setMode(MockBalancerV3Vault.Mode.RateShift); // 0 -> 1e18 during the swap
+
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        vm.expectRevert(bytes("BalancerV3: zero rate baseline"));
+        _swap(address(pool));
+    }
+
+    /// @notice A provider deployed and registered within the transaction has no pre-tx baseline by
+    ///         construction: the deployment lifecycle is exempt from the drift comparison (only the
+    ///         nonzero post-state is enforced) instead of reverting on the missing baseline read.
+    function testProviderRegisteredDuringTxIsExempt() public {
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        vault.registerNewRateProviderAndTouchPool();
+    }
+
+    /// @notice Recovery mode disables the rate assertion entirely: Balancer's recovery exit uses
+    ///         raw balances precisely because providers may be broken, and a broken or moved
+    ///         provider must never block that path.
+    function testRecoveryModeSkipsRateAssertion() public {
+        vault.setRecoveryMode(true);
+        vault.setMode(MockBalancerV3Vault.Mode.RateShift);
+
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        _swap(address(pool));
+    }
+
+    /// @notice A transaction that moves the rate without touching the watched pool's accounting is
+    ///         out of the drift assertion's scope, so the watched provider never becomes a
+    ///         dependency of unrelated Vault traffic. The residual is documented on the assertion:
+    ///         a later transaction consuming the moved rate touches the pool and is examined.
+    function testRateOnlyTransactionIsOutOfScope() public {
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        vault.shiftRateOnly();
+    }
+
     // --- wiring ----------------------------------------------------------------
 
     function testDeploys() public {
         BalancerV3VaultAssertion assertion = new BalancerV3VaultAssertion(
-            address(vault), address(pool), INVARIANT_DUST_TOLERANCE_BPS, RATE_DRIFT_TOLERANCE_BPS
+            address(vault), address(pool), INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS
         );
         assertTrue(address(assertion) != address(0));
     }

--- a/examples/balancer/test/BalancerV3VaultAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultAssertion.t.sol
@@ -6,7 +6,14 @@ import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/tok
 
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {BalancerV3VaultAssertion} from "../src/BalancerV3VaultAssertion.sol";
-import {SwapKind, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
+import {
+    AddLiquidityKind,
+    AddLiquidityParams,
+    RemoveLiquidityKind,
+    RemoveLiquidityParams,
+    SwapKind,
+    VaultSwapParams
+} from "../src/BalancerV3VaultInterfaces.sol";
 import {MockBalancerV3Pool, MockBalancerV3Vault, MockRateProvider, RateManipulatingRouter} from "./BalancerV3Mocks.sol";
 
 contract BalancerV3VaultAssertionTest is Test, CredibleTest {
@@ -63,6 +70,24 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
 
     function _swap(address targetPool) internal {
         vault.swap(_swapParams(targetPool));
+    }
+
+    function _addLiquidityParams(address targetPool) internal view returns (AddLiquidityParams memory params) {
+        params.pool = targetPool;
+        params.to = address(this);
+        params.maxAmountsIn = new uint256[](2);
+        params.minBptAmountOut = 0;
+        params.kind = AddLiquidityKind.UNBALANCED;
+        params.userData = "";
+    }
+
+    function _removeLiquidityParams(address targetPool) internal view returns (RemoveLiquidityParams memory params) {
+        params.pool = targetPool;
+        params.from = address(this);
+        params.maxBptAmountIn = 1;
+        params.minAmountsOut = new uint256[](2);
+        params.kind = RemoveLiquidityKind.SINGLE_TOKEN_EXACT_IN;
+        params.userData = "";
     }
 
     // --- assertSwapPreservesPoolInvariant ------------------------------------
@@ -151,6 +176,27 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         router.manipulateSwapRestore(_swapParams(address(pool)));
     }
 
+    function testTransientRateManipulationAroundAddLiquidityTrips() public {
+        RateManipulatingRouter router = new RateManipulatingRouter(vault, rateProvider);
+
+        _arm(BalancerV3VaultAssertion.assertOperationRatesWithinBaseline.selector);
+        vm.expectRevert(bytes("BalancerV3: liquidity priced against rate beyond drift bound"));
+        router.manipulateAddLiquidityRestore(_addLiquidityParams(address(pool)));
+    }
+
+    function testHonestAddLiquidityPassesScopedRateAssertion() public {
+        _arm(BalancerV3VaultAssertion.assertOperationRatesWithinBaseline.selector);
+        vault.addLiquidity(_addLiquidityParams(address(pool)));
+    }
+
+    function testTransientRateManipulationAroundRemoveLiquidityTrips() public {
+        RateManipulatingRouter router = new RateManipulatingRouter(vault, rateProvider);
+
+        _arm(BalancerV3VaultAssertion.assertOperationRatesWithinBaseline.selector);
+        vm.expectRevert(bytes("BalancerV3: liquidity priced against rate beyond drift bound"));
+        router.manipulateRemoveLiquidityRestore(_removeLiquidityParams(address(pool)));
+    }
+
     // --- assertPoolAccountingWithinVaultCustody -------------------------------
 
     function testHonestSwapPassesCustodyAssertion() public {
@@ -205,8 +251,17 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
     ///         construction: the deployment lifecycle is exempt from the drift comparison (only the
     ///         nonzero post-state is enforced) instead of reverting on the missing baseline read.
     function testProviderRegisteredDuringTxIsExempt() public {
+        vault.registerNewRateProvider();
+
         _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
-        vault.registerNewRateProviderAndTouchPool();
+        vault.initialize(address(pool), address(this), new address[](0), new uint256[](0), 0, "");
+    }
+
+    function testProviderRegisteredDuringTxPassesScopedInitializationRateCheck() public {
+        vault.registerNewRateProvider();
+
+        _arm(BalancerV3VaultAssertion.assertOperationRatesWithinBaseline.selector);
+        vault.initialize(address(pool), address(this), new address[](0), new uint256[](0), 0, "");
     }
 
     /// @notice Recovery mode disables the rate assertion entirely: Balancer's recovery exit uses
@@ -227,6 +282,20 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
     function testRateOnlyTransactionIsOutOfScope() public {
         _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
         vault.shiftRateOnly();
+    }
+
+    function testUnrelatedVaultTrafficSkipsCustodySnapshots() public {
+        vault.setRevertOnPoolReads(true);
+
+        _arm(BalancerV3VaultAssertion.assertPoolAccountingWithinVaultCustody.selector);
+        vault.unrelatedVaultCall();
+    }
+
+    function testUnrelatedVaultTrafficSkipsRateSnapshots() public {
+        vault.setRevertOnPoolReads(true);
+
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        vault.unrelatedVaultCall();
     }
 
     // --- wiring ----------------------------------------------------------------

--- a/examples/balancer/test/BalancerV3VaultAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultAssertion.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20Mock} from "../../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {BalancerV3VaultAssertion} from "../src/BalancerV3VaultAssertion.sol";
+import {SwapKind, VaultSwapParams} from "../src/BalancerV3VaultInterfaces.sol";
+import {MockBalancerV3Pool, MockBalancerV3Vault, MockRateProvider} from "./BalancerV3Mocks.sol";
+
+contract BalancerV3VaultAssertionTest is Test, CredibleTest {
+    uint256 internal constant INVARIANT_DUST_TOLERANCE_BPS = 0;
+    uint256 internal constant RATE_DRIFT_TOLERANCE_BPS = 100; // 1%
+
+    ERC20Mock internal token0;
+    ERC20Mock internal token1;
+    MockRateProvider internal rateProvider;
+    MockBalancerV3Pool internal pool;
+    MockBalancerV3Vault internal vault;
+
+    function setUp() public {
+        token0 = new ERC20Mock();
+        token1 = new ERC20Mock();
+        rateProvider = new MockRateProvider();
+        pool = new MockBalancerV3Pool();
+        vault = new MockBalancerV3Vault(address(pool), address(token0), address(token1), rateProvider);
+
+        // Custody exactly backs reserves; reserves exceed pool balances + fees with headroom.
+        token0.mint(address(vault), 1_000e18);
+        token1.mint(address(vault), 1_000e18);
+        vault.seedReserves(address(token0), 1_000e18);
+        vault.seedReserves(address(token1), 1_000e18);
+        vault.seedPoolBalance(0, 500e18);
+        vault.seedPoolBalance(1, 500e18);
+
+        token0.mint(address(this), 100e18);
+        token0.approve(address(vault), type(uint256).max);
+        vault.setSkimReceiver(makeAddr("skimReceiver"));
+    }
+
+    function _arm(bytes4 fnSelector) internal {
+        bytes memory createData = abi.encodePacked(
+            type(BalancerV3VaultAssertion).creationCode,
+            abi.encode(address(vault), address(pool), INVARIANT_DUST_TOLERANCE_BPS, RATE_DRIFT_TOLERANCE_BPS)
+        );
+        cl.assertion(address(vault), createData, fnSelector);
+    }
+
+    function _swap(address targetPool) internal {
+        vault.swap(
+            VaultSwapParams({
+                kind: SwapKind.EXACT_IN,
+                pool: targetPool,
+                tokenIn: address(token0),
+                tokenOut: address(token1),
+                amountGivenRaw: 10e18,
+                limitRaw: 0,
+                userData: ""
+            })
+        );
+    }
+
+    // --- assertSwapPreservesPoolInvariant ------------------------------------
+
+    function testHonestSwapPassesInvariantAssertion() public {
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        _swap(address(pool));
+    }
+
+    function testSwapOnUnwatchedPoolIsIgnored() public {
+        vault.setMode(MockBalancerV3Vault.Mode.InvariantLoss);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        _swap(makeAddr("otherPool"));
+    }
+
+    function testInvariantLossTrips() public {
+        vault.setMode(MockBalancerV3Vault.Mode.InvariantLoss);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: swap decreased pool invariant"));
+        _swap(address(pool));
+    }
+
+    function testSupplyDriftTrips() public {
+        vault.setMode(MockBalancerV3Vault.Mode.SupplyDrift);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: swap changed BPT supply"));
+        _swap(address(pool));
+    }
+
+    function testBalancesAgainstSwapDirectionTrip() public {
+        vault.setMode(MockBalancerV3Vault.Mode.BalanceSwapEnds);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: swap decreased tokenIn pool balance"));
+        _swap(address(pool));
+    }
+
+    // --- assertVaultCustodyCoversPoolAccounting -------------------------------
+
+    function testHonestSwapPassesCustodyAssertion() public {
+        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        _swap(address(pool));
+    }
+
+    function testReserveSkimTripsCustody() public {
+        vault.setMode(MockBalancerV3Vault.Mode.ReserveSkim);
+
+        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        vm.expectRevert(bytes("BalancerV3: vault reserves exceed real token custody"));
+        _swap(address(pool));
+    }
+
+    function testPhantomPoolBalanceTripsCustody() public {
+        vault.setMode(MockBalancerV3Vault.Mode.PhantomBalance);
+
+        _arm(BalancerV3VaultAssertion.assertVaultCustodyCoversPoolAccounting.selector);
+        vm.expectRevert(bytes("BalancerV3: pool accounting exceeds vault reserves"));
+        _swap(address(pool));
+    }
+
+    // --- assertTokenRatesWithinDriftBound --------------------------------------
+
+    function testHonestSwapPassesRateAssertion() public {
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        _swap(address(pool));
+    }
+
+    function testRateShiftTrips() public {
+        vault.setMode(MockBalancerV3Vault.Mode.RateShift);
+
+        _arm(BalancerV3VaultAssertion.assertTokenRatesWithinDriftBound.selector);
+        vm.expectRevert(bytes("BalancerV3: token rate moved beyond drift bound"));
+        _swap(address(pool));
+    }
+
+    // --- wiring ----------------------------------------------------------------
+
+    function testDeploys() public {
+        BalancerV3VaultAssertion assertion = new BalancerV3VaultAssertion(
+            address(vault), address(pool), INVARIANT_DUST_TOLERANCE_BPS, RATE_DRIFT_TOLERANCE_BPS
+        );
+        assertTrue(address(assertion) != address(0));
+    }
+
+    function testRejectsZeroVault() public {
+        vm.expectRevert(bytes("BalancerV3: zero vault"));
+        new BalancerV3VaultAssertion(address(0), address(pool), 0, RATE_DRIFT_TOLERANCE_BPS);
+    }
+
+    function testRejectsZeroPool() public {
+        vm.expectRevert(bytes("BalancerV3: zero pool"));
+        new BalancerV3VaultAssertion(address(vault), address(0), 0, RATE_DRIFT_TOLERANCE_BPS);
+    }
+}

--- a/examples/balancer/test/BalancerV3VaultAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultAssertion.t.sol
@@ -42,7 +42,9 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
     function _arm(bytes4 fnSelector) internal {
         bytes memory createData = abi.encodePacked(
             type(BalancerV3VaultAssertion).creationCode,
-            abi.encode(address(vault), address(pool), INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS)
+            abi.encode(
+                address(vault), address(pool), vault.swapHooks(), INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS
+            )
         );
         cl.assertion(address(vault), createData, fnSelector);
     }
@@ -70,6 +72,16 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         _swap(address(pool));
     }
 
+    /// @notice The Vault deducts pending yield fees before adding swap input. Raw tokenIn balance
+    ///         can therefore fall across an honest small swap; fee-adjusted live balance still
+    ///         moves in the correct direction and is the relevant input to pool math.
+    function testHonestSwapWithPendingYieldFeesPassesInvariantAssertion() public {
+        vault.seedPendingYieldFee(address(token0), 20e18);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        _swap(address(pool));
+    }
+
     function testSwapOnUnwatchedPoolIsIgnored() public {
         vault.setMode(MockBalancerV3Vault.Mode.InvariantLoss);
 
@@ -85,37 +97,18 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         _swap(address(pool));
     }
 
-    function testSupplyDriftTrips() public {
-        vault.setMode(MockBalancerV3Vault.Mode.SupplyDrift);
-
-        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
-        vm.expectRevert(bytes("BalancerV3: swap changed BPT supply"));
-        _swap(address(pool));
-    }
-
     function testBalancesAgainstSwapDirectionTrip() public {
         vault.setMode(MockBalancerV3Vault.Mode.BalanceSwapEnds);
 
         _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
-        vm.expectRevert(bytes("BalancerV3: swap decreased tokenIn pool balance"));
+        vm.expectRevert(bytes("BalancerV3: swap increased tokenOut pool balance"));
         _swap(address(pool));
     }
 
-    /// @notice A rate that moves inside the swap call trips the equality pin: for supported
-    ///         hookless pools no user code can run within the call, so any in-call rate movement
-    ///         is Vault- or pool-driven manipulation.
-    function testRateShiftWithinSwapCallTrips() public {
-        vault.setMode(MockBalancerV3Vault.Mode.RateShift);
-
-        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
-        vm.expectRevert(bytes("BalancerV3: rate moved within swap call"));
-        _swap(address(pool));
-    }
-
-    /// @notice Pools with before/after-swap hooks are outside the swap check's scope: those hooks
-    ///         may legitimately reenter the Vault mid-swap, so call-boundary snapshots cannot
-    ///         attribute deltas to the core swap. A failure knob that would otherwise trip must
-    ///         pass once the pool reports swap hooks.
+    /// @notice Pools configured at assertion deployment with before/after-swap hooks are outside
+    ///         the swap check's scope: those hooks may legitimately reenter the Vault mid-swap, so
+    ///         call-boundary snapshots cannot attribute deltas to the core swap. A failure knob
+    ///         that would otherwise trip must pass once the deployment marks the pool as hooked.
     function testHookedPoolSwapChecksAreSkipped() public {
         vault.setSwapHooks(true);
         vault.setMode(MockBalancerV3Vault.Mode.InvariantLoss);
@@ -232,18 +225,18 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
 
     function testDeploys() public {
         BalancerV3VaultAssertion assertion = new BalancerV3VaultAssertion(
-            address(vault), address(pool), INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS
+            address(vault), address(pool), false, INVARIANT_DUST_TOLERANCE, RATE_DRIFT_TOLERANCE_BPS
         );
         assertTrue(address(assertion) != address(0));
     }
 
     function testRejectsZeroVault() public {
         vm.expectRevert(bytes("BalancerV3: zero vault"));
-        new BalancerV3VaultAssertion(address(0), address(pool), 0, RATE_DRIFT_TOLERANCE_BPS);
+        new BalancerV3VaultAssertion(address(0), address(pool), false, 0, RATE_DRIFT_TOLERANCE_BPS);
     }
 
     function testRejectsZeroPool() public {
         vm.expectRevert(bytes("BalancerV3: zero pool"));
-        new BalancerV3VaultAssertion(address(vault), address(0), 0, RATE_DRIFT_TOLERANCE_BPS);
+        new BalancerV3VaultAssertion(address(vault), address(0), false, 0, RATE_DRIFT_TOLERANCE_BPS);
     }
 }

--- a/examples/balancer/test/BalancerV3VaultAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultAssertion.t.sol
@@ -97,6 +97,14 @@ contract BalancerV3VaultAssertionTest is Test, CredibleTest {
         _swap(address(pool));
     }
 
+    function testSupplyDriftTrips() public {
+        vault.setMode(MockBalancerV3Vault.Mode.SupplyDrift);
+
+        _arm(BalancerV3VaultAssertion.assertSwapPreservesPoolInvariant.selector);
+        vm.expectRevert(bytes("BalancerV3: swap changed BPT supply"));
+        _swap(address(pool));
+    }
+
     function testBalancesAgainstSwapDirectionTrip() public {
         vault.setMode(MockBalancerV3Vault.Mode.BalanceSwapEnds);
 

--- a/examples/balancer/test/BalancerV3VaultOutflowAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultOutflowAssertion.t.sol
@@ -6,19 +6,67 @@ import {Test} from "forge-std/Test.sol";
 import {CredibleTest} from "../../../src/CredibleTest.sol";
 import {BalancerV3VaultOutflowAssertion} from "../src/BalancerV3VaultOutflowAssertion.sol";
 
+/// @notice Armed variant: drives the production breaker body through real assertion dispatch.
+/// @dev The `watchCumulativeOutflow` trigger itself is executor-driven (rolling-window accounting)
+///      and is not simulated by local `pcl test`, so the armed tests substitute a call trigger and
+///      dispatch the UNMODIFIED `assertOutflowWithinLimit`, executing the real
+///      `ph.getAssertionAdopter()` adopter check instead of a direct call that skips it.
+contract ArmedOutflowBreaker is BalancerV3VaultOutflowAssertion {
+    constructor(address vault_, address token_, uint256 thresholdBps_, uint256 windowDuration_)
+        BalancerV3VaultOutflowAssertion(vault_, token_, thresholdBps_, windowDuration_)
+    {}
+
+    function triggers() external view override {
+        registerCallTrigger(this.assertOutflowWithinLimit.selector);
+    }
+}
+
+/// @notice Minimal adopter target for the armed dispatch tests.
+contract MockVaultTarget {
+    uint256 public pokes;
+
+    function poke() external {
+        pokes++;
+    }
+}
+
 contract BalancerV3VaultOutflowAssertionTest is Test, CredibleTest {
     address internal vault = makeAddr("vault");
     address internal token = makeAddr("token");
 
-    /// @dev The `watchCumulativeOutflow` trigger is driven by the executor's rolling-window
-    ///      accounting and is not simulated by local `pcl test`, so the breaker's hard-revert
-    ///      decision is validated by calling it directly rather than through an armed
-    ///      `cl.assertion` transaction. Honest in-window flow is calibration, not logic.
-    function testBreakerRevertsWhenInvoked() public {
-        BalancerV3VaultOutflowAssertion assertion = new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 1 days);
-        vm.expectRevert(bytes("BalancerV3Outflow: vault token outflow circuit breaker tripped"));
-        assertion.assertOutflowWithinLimit();
+    MockVaultTarget internal adopter;
+
+    function setUp() public {
+        adopter = new MockVaultTarget();
     }
+
+    function _armOn(address adopterAddress, address configuredVault) internal {
+        bytes memory createData = abi.encodePacked(
+            type(ArmedOutflowBreaker).creationCode, abi.encode(configuredVault, token, 2_000, uint256(1 days))
+        );
+        cl.assertion(adopterAddress, createData, BalancerV3VaultOutflowAssertion.assertOutflowWithinLimit.selector);
+    }
+
+    // --- dispatched breaker behavior ---------------------------------------
+
+    /// @notice Adopter matches the configured Vault: the breaker's unconditional revert fires
+    ///         through real assertion dispatch.
+    function testDispatchedBreakerReverts() public {
+        _armOn(address(adopter), address(adopter));
+        vm.expectRevert(bytes("BalancerV3Outflow: vault token outflow circuit breaker tripped"));
+        adopter.poke();
+    }
+
+    /// @notice Adopter does NOT match the configured Vault: the flow watcher would be tracking the
+    ///         wrong account's balance, so the misconfiguration fails loudly with its own message
+    ///         instead of masquerading as a legitimate breaker trip.
+    function testDispatchedBreakerRejectsWrongAdopter() public {
+        _armOn(address(adopter), vault);
+        vm.expectRevert(bytes("BalancerV3Outflow: configured vault is not adopter"));
+        adopter.poke();
+    }
+
+    // --- constructor guards --------------------------------------------------
 
     function testRejectsZeroVault() public {
         vm.expectRevert(bytes("BalancerV3Outflow: zero vault"));
@@ -35,14 +83,41 @@ contract BalancerV3VaultOutflowAssertionTest is Test, CredibleTest {
         new BalancerV3VaultOutflowAssertion(vault, token, 0, 1 days);
     }
 
-    function testRejectsThresholdAboveFull() public {
+    /// @notice 10_000 bps is rejected, not merely discouraged: the executor dispatches only when
+    ///         net outflow STRICTLY exceeds the threshold and a full drain lands exactly on 100%,
+    ///         so a 100% setting could never fire — the breaker would be silently disabled.
+    function testRejectsFullDrainThreshold() public {
         vm.expectRevert(bytes("BalancerV3Outflow: bad threshold"));
-        new BalancerV3VaultOutflowAssertion(vault, token, 10_001, 1 days);
+        new BalancerV3VaultOutflowAssertion(vault, token, 10_000, 1 days);
+    }
+
+    function testAcceptsMaximumEnforceableThreshold() public {
+        new BalancerV3VaultOutflowAssertion(vault, token, 9_999, 1 days);
+    }
+
+    /// @notice Windows below the executor's 10-second bucket deploy fine but then fail trigger
+    ///         registration; the constructor mirrors the executor bound so the mistake surfaces at
+    ///         deploy time.
+    function testRejectsWindowBelowExecutorBucket() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: bad window"));
+        new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 9);
     }
 
     function testRejectsZeroWindow() public {
-        vm.expectRevert(bytes("BalancerV3Outflow: zero window"));
+        vm.expectRevert(bytes("BalancerV3Outflow: bad window"));
         new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 0);
+    }
+
+    /// @notice Windows that do not fit the executor's u64 window state are rejected for the same
+    ///         deploy-time-visibility reason.
+    function testRejectsWindowBeyondUint64() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: bad window"));
+        new BalancerV3VaultOutflowAssertion(vault, token, 2_000, uint256(type(uint64).max) + 1);
+    }
+
+    function testAcceptsExecutorWindowBounds() public {
+        new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 10);
+        new BalancerV3VaultOutflowAssertion(vault, token, 2_000, type(uint64).max);
     }
 
     function testDeploys() public {

--- a/examples/balancer/test/BalancerV3VaultOutflowAssertion.t.sol
+++ b/examples/balancer/test/BalancerV3VaultOutflowAssertion.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CredibleTest} from "../../../src/CredibleTest.sol";
+import {BalancerV3VaultOutflowAssertion} from "../src/BalancerV3VaultOutflowAssertion.sol";
+
+contract BalancerV3VaultOutflowAssertionTest is Test, CredibleTest {
+    address internal vault = makeAddr("vault");
+    address internal token = makeAddr("token");
+
+    /// @dev The `watchCumulativeOutflow` trigger is driven by the executor's rolling-window
+    ///      accounting and is not simulated by local `pcl test`, so the breaker's hard-revert
+    ///      decision is validated by calling it directly rather than through an armed
+    ///      `cl.assertion` transaction. Honest in-window flow is calibration, not logic.
+    function testBreakerRevertsWhenInvoked() public {
+        BalancerV3VaultOutflowAssertion assertion = new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 1 days);
+        vm.expectRevert(bytes("BalancerV3Outflow: vault token outflow circuit breaker tripped"));
+        assertion.assertOutflowWithinLimit();
+    }
+
+    function testRejectsZeroVault() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: zero vault"));
+        new BalancerV3VaultOutflowAssertion(address(0), token, 2_000, 1 days);
+    }
+
+    function testRejectsZeroToken() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: zero token"));
+        new BalancerV3VaultOutflowAssertion(vault, address(0), 2_000, 1 days);
+    }
+
+    function testRejectsZeroThreshold() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: bad threshold"));
+        new BalancerV3VaultOutflowAssertion(vault, token, 0, 1 days);
+    }
+
+    function testRejectsThresholdAboveFull() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: bad threshold"));
+        new BalancerV3VaultOutflowAssertion(vault, token, 10_001, 1 days);
+    }
+
+    function testRejectsZeroWindow() public {
+        vm.expectRevert(bytes("BalancerV3Outflow: zero window"));
+        new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 0);
+    }
+
+    function testDeploys() public {
+        BalancerV3VaultOutflowAssertion assertion = new BalancerV3VaultOutflowAssertion(vault, token, 2_000, 1 days);
+        assertTrue(address(assertion) != address(0));
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -75,6 +75,14 @@ cache_path = "examples/aerodrome/cache"
 libs = ["lib"]
 remappings = ["credible-std/=src/"]
 
+[profile.balancer]
+src = "examples/balancer/src"
+test = "examples/balancer/test"
+out = "examples/balancer/out"
+cache_path = "examples/balancer/cache"
+libs = ["lib"]
+remappings = ["credible-std/=src/"]
+
 [profile.cap]
 src = "examples/cap/src"
 test = "examples/cap/test"


### PR DESCRIPTION
## Summary

Example assertion bundle for Balancer V3's singleton Vault under `examples/balancer/`, following the per-protocol profile layout (`FOUNDRY_PROFILE=balancer`).

Balancer V3 concentrates every pool's custody, balances, and BPT supply in one Vault and trusts three things it never re-checks: the pool's own swap math (`onSwap` output is applied with no invariant guard), the mutual consistency of its layered ledgers (`_reservesOf` vs pool balances vs aggregate fees), and rate-provider answers for `WITH_RATE` tokens. The suite asserts those externally:

- **`BalancerV3VaultAssertion`** (one watched pool inside the singleton, PoolKey-style calldata filtering like the UniswapV4 example):
  - `assertSwapPreservesPoolInvariant` — call-scoped on `Vault.swap`: the pool's own `computeInvariant` over live balances may not decrease (named dust tolerance), BPT supply is frozen, balances move in the swap's direction.
  - `assertVaultCustodyCoversPoolAccounting` — tx-end: `token.balanceOf(vault) >= getReservesOf(token) >= pool raw balance + aggregate swap/yield fees`.
  - `assertTokenRatesWithinDriftBound` — tx-end: rate-provider `getRate()` stays nonzero and within a bps bound across the transaction.
- **`BalancerV3VaultOutflowAssertion`** — rolling-window `watchCumulativeOutflow` breaker on a token leaving Vault custody (flow-based drain protection, mellow pattern).

All thresholds (invariant dust, rate drift, outflow cap/window) are constructor parameters for per-deployment calibration.

## Notes

- Swap-leg decoding reads `pool`/`tokenIn`/`tokenOut` at fixed calldata offsets (with a bound-checked head offset) instead of abi-decoding the full `VaultSwapParams`: the full decode plus byte-copy costs enough gas to blow the assertion budget on the honest path.
- Verified against `balancer-v3-monorepo` sources; getters are reachable on the Vault address via its extension fallback.

## Testing

`FOUNDRY_PROFILE=balancer pcl test` — 20/20 passing: one honest-pass and one tripping test per invariant, each driven by a single mock failure knob, plus breaker direct-invocation and constructor-guard tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)