### PR TITLE
fix(vault): bound the ERC4626 tx-wide share-price envelope to avoid PrecompileOOG

### DIFF
--- a/src/protection/vault/ERC4626SharePriceAssertion.sol
+++ b/src/protection/vault/ERC4626SharePriceAssertion.sol
@@ -30,14 +30,35 @@ abstract contract ERC4626SharePriceAssertion is ERC4626BaseAssertion {
         sharePriceToleranceBps = _toleranceBps;
     }
 
-    /// @notice Register the default trigger set for share-price invariants.
-    /// @dev Uses registerTxEndTrigger for the tx-wide envelope and registerFnCallTrigger
-    ///      for per-call checks. Call this inside your `triggers()`.
+    /// @notice Register the default trigger set: the exhaustive tx-wide envelope + per-call checks.
+    /// @dev The tx-wide envelope (`assertSharePriceEnvelope`) uses the all-fork-points
+    ///      `assetsMatchSharePrice` scan, which re-reads `totalAssets()`/`totalSupply()` at
+    ///      ~1+2*callFrames fork points. This is fine for vaults with a cheap `totalAssets()`.
+    ///      Vaults with an expensive computed `totalAssets()` (e.g. MetaMorpho, which loops the
+    ///      Morpho Blue supply queue) should instead use `_registerBoundedSharePriceTriggers()`:
+    ///      the exhaustive scan can exhaust the assertion gas limit on unrelated high-call-count
+    ///      transactions that merely touch the vault and revert (PrecompileOOG) — a false invalidation.
     function _registerSharePriceTriggers() internal view {
-        // Tx-wide envelope — fires once after the transaction completes
         registerTxEndTrigger(this.assertSharePriceEnvelope.selector);
+        _registerPerCallSharePriceTriggers();
+    }
 
-        // Per-call check — fires once per matching ERC-4626 operation
+    /// @notice Register a gas-bounded trigger set: a pre/post tx-wide envelope + per-call checks.
+    /// @dev The tx-wide check (`assertSharePriceEnvelopeBounded`) compares share price only between
+    ///      the pre-tx and post-tx forks — 2 fork points, O(1) in call-frame count — so it never
+    ///      triggers the all-forks scan that OOGs on expensive-`totalAssets()` vaults. It is
+    ///      two-sided: it catches both dilution (share price down) and unexpected inflation (share
+    ///      price up, e.g. a donation / direct-transfer manipulation) reached through ANY entrypoint,
+    ///      including non-ERC-4626 selectors the per-call check never observes.
+    function _registerBoundedSharePriceTriggers() internal view {
+        registerTxEndTrigger(this.assertSharePriceEnvelopeBounded.selector);
+        _registerPerCallSharePriceTriggers();
+    }
+
+    /// @notice Register only the per-call share-price checks (deposit/mint/withdraw/redeem).
+    /// @dev Each fires once per matching ERC-4626 operation and uses the cheap 2-fork
+    ///      `assetsMatchSharePriceAt` around that call.
+    function _registerPerCallSharePriceTriggers() internal view {
         registerFnCallTrigger(this.assertPerCallSharePrice.selector, IERC4626.deposit.selector);
         registerFnCallTrigger(this.assertPerCallSharePrice.selector, IERC4626.mint.selector);
         registerFnCallTrigger(this.assertPerCallSharePrice.selector, IERC4626.withdraw.selector);
@@ -66,6 +87,20 @@ abstract contract ERC4626SharePriceAssertion is ERC4626BaseAssertion {
         require(
             ph.ratioGe(postAssets, postShares, preAssets, preShares, sharePriceToleranceBps),
             "ERC4626: share price decreased beyond tolerance"
+        );
+    }
+
+    /// @notice Tx-wide share-price envelope bounded to the pre-tx vs post-tx comparison.
+    /// @dev Two-sided within tolerance — catches both dilution (decrease) and unexpected inflation
+    ///      (increase, e.g. a donation / direct-transfer share-price manipulation), regardless of the
+    ///      entrypoint used. Evaluated at exactly two fork points via `assetsMatchSharePriceAt`, so it
+    ///      stays within the assertion gas budget even for vaults with an expensive computed
+    ///      `totalAssets()`. Unlike `assertSharePriceEnvelope`, it does not inspect intermediate
+    ///      call-boundary forks; the per-call checks cover settlement during standard ERC-4626 ops.
+    function assertSharePriceEnvelopeBounded() external {
+        require(
+            ph.assetsMatchSharePriceAt(vault, sharePriceToleranceBps, _preTx(), _postTx()),
+            "ERC4626: tx-wide share price drift exceeds tolerance"
         );
     }
 

--- a/src/protection/vault/examples/MetaMorphoVaultAssertion.sol
+++ b/src/protection/vault/examples/MetaMorphoVaultAssertion.sol
@@ -59,7 +59,14 @@ contract MetaMorphoVaultAssertion is
     ///      asset-flow assertion because a healthy MetaMorpho vault can hold less on-hand USDC than
     ///      `totalAssets()` while its funds are allocated into Morpho markets.
     function triggers() external view override {
-        _registerSharePriceTriggers();
+        // Use the gas-bounded share-price triggers: MetaMorpho's computed `totalAssets()` loops the
+        // Morpho Blue supply queue, so the default envelope's all-fork-points `assetsMatchSharePrice`
+        // scan exhausts the assertion gas limit (PrecompileOOG) on unrelated high-call-count
+        // transactions that merely touch the vault, causing false invalidations. The bounded envelope
+        // compares only pre-tx vs post-tx (2 fork points) and is two-sided, so it still catches
+        // tx-wide dilution and donation/inflation through any entrypoint, while the per-call checks
+        // cover settlement during real deposit/mint/withdraw/redeem operations.
+        _registerBoundedSharePriceTriggers();
         _registerPreviewTriggers();
         _registerCumulativeOutflowTriggers();
     }


### PR DESCRIPTION
## Problem

The `metamorpho-top-5-vaults` deployment produced repeated **false-positive invalidations**. Backtesting against the assertion-replay service pinned the cause to the tx-wide share-price envelope in `ERC4626SharePriceAssertion`.

`assertSharePriceEnvelope()` is registered with `registerTxEndTrigger`, so it fires on **every** transaction that merely touches the vault — including read-only calls and unrelated protocol activity. Its first check, `ph.assetsMatchSharePrice(vault, tol)`, compares the pre-tx share price against **every** fork point in the transaction. Fork enumeration is `PostTx + PreCall(i) + PostCall(i)` per forkable call, so the vault's `totalAssets()`/`totalSupply()` are re-read at ~`1 + 2*callFrames` points.

MetaMorpho's `totalAssets()` is not a storage read — it loops the Morpho Blue supply queue (per-market interest accrual). On a high-call-count transaction (e.g. a 107-call AVS task submission that merely touches the vault), the envelope re-runs that computation ~215 times and exhausts the assertion gas limit → **PrecompileOOG → revert → false invalidation**. The share price itself was flat/rising across the offending blocks; there was no real violation.

## Fix

Add `assertSharePriceEnvelopeBounded()` — a tx-wide envelope evaluated at only the **pre-tx and post-tx** forks via `assetsMatchSharePriceAt` (2 fork points, O(1) in call-frame count, so it cannot OOG on high-call-count txs).

The precompile's deviation check is symmetric (`abs_diff`), so the bounded envelope is **two-sided**: it still catches both dilution (share price down) and unexpected inflation (share price up — e.g. a donation / direct-transfer manipulation) reached through **any** entrypoint, including non-ERC-4626 selectors the per-call check never observes. The per-call checks continue to cover settlement during standard `deposit`/`mint`/`withdraw`/`redeem` ops.

Trigger registration is split into named helpers (no conditional flag):

- `_registerSharePriceTriggers()` — keeps the exhaustive all-forks envelope (**unchanged default**; existing consumers such as the Curve/LlamaLend and Spark examples are unaffected)
- `_registerBoundedSharePriceTriggers()` — bounded envelope + per-call
- `_registerPerCallSharePriceTriggers()` — shared per-call registration

`MetaMorphoVaultAssertion.triggers()` now uses `_registerBoundedSharePriceTriggers()`.

## Trade-off

The bounded envelope does not inspect intermediate call-boundary forks, so a share-price dip that fully recovers *within* the same transaction via a non-standard entrypoint is no longer flagged tx-wide. Settlement during standard ERC-4626 ops is still covered per-call, and the net pre→post move (in both directions) is still enforced. For computed-`totalAssets()` vaults the exhaustive scan is not usable regardless.

## Verification

Replayed against the assertion-replay service over the previously-failing window (`25480001 + 560`). With the bounded bundle, both **Gauntlet USDC Prime** (`0xdd0f28…`) and **Steakhouse USDC** (`0xBEEF01…`) scan the **entire** block range with **no invalidation** — including the exact high-call-count transactions (Gauntlet block 25480541, Steakhouse 25480212) that previously OOG'd the envelope. The bounded envelope fires on those txs (it is a txEnd trigger) and completes within budget.

> Note: no local `forge`/`pcl test` regression is added — the reshiram share-price precompiles and fork snapshots aren't exercised by the local test runner, so validation is via the replay service (the environment these assertions actually run in).