### PR TITLE
chore: gitignore root assertions and broadcast dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 cache/
 out/
 
-# Ignores development broadcast logs
-!/broadcast
-/broadcast/*/31337/
-/broadcast/**/dry-run/
+# pcl-generated assertions cache at repo root
+/assertions/
+
+# Forge broadcast logs at repo root
+/broadcast/
 
 # Docs
 docs/


### PR DESCRIPTION
Ignore the pcl-generated `/assertions/` cache and the forge `/broadcast/` logs at the repo root so they don't show up as untracked noise.

- `/assertions/` — anchored at root, so example suites under `examples/**/assertions/` stay tracked.
- `/broadcast/` — replaces the previous per-chain/dry-run broadcast rules.

Verified `git check-ignore` ignores both root dirs while `examples/assertions-book/assertions/src/*` remains tracked.