### PR TITLE
Make testing guard upgrades more ergonomic

### DIFF
--- a/examples/credible-block/README.md
+++ b/examples/credible-block/README.md
@@ -122,7 +122,8 @@ run with:
   `--state-after` describe one guarded call.
 - The runner validates guard wiring and behavior, not the correctness or completeness of the
   upgrade process itself.
-- The `credible-block` Foundry profile is selected automatically.
+- The `credible-block` Foundry profile is selected only for the built-in fixture deployments;
+  user-supplied deployment commands keep their caller-provided Foundry profile.
 - On macOS, Foundry may abort while reading system proxy settings inside a restricted sandbox. Run
   the live integration outside that sandbox; `--validate-only` and the argument tests do not start
   Foundry and can remain sandboxed.

--- a/examples/credible-block/README.md
+++ b/examples/credible-block/README.md
@@ -109,6 +109,15 @@ run with:
 ./examples/credible-block/test/test-script-arguments.sh
 ```
 
+Expected state values must use the exact single-line representation printed by `cast call` (apart
+from numeric magnitude annotations such as ` [1e6]`, which the runner removes). In particular, ABI
+strings include their surrounding double quotes. The live string regression covers both a spaced
+call argument and the quoted state representation:
+
+```shell
+./examples/credible-block/test/test-string-state.sh
+```
+
 ## Requirements and limitations
 
 - `anvil`, `cast`, `forge`, and `jq` must be on `PATH`.
@@ -116,8 +125,9 @@ run with:
 - The marker account must be authorized by the supplied registry configuration.
 - The guarded account must have all target-specific balances, approvals, roles, and prerequisites.
   Deployment commands are responsible for arranging them.
-- `--state-read-call` must return one stable, directly comparable `cast call` value. For complex
-  effects, deploy a read-only adapter that returns a digest or scalar assertion value.
+- `--state-read-call` must return one stable, directly comparable `cast call` value. Pass string
+  expectations with the quotes emitted by `cast` (for example `--state-after '"hello world"'`). For
+  complex effects, deploy a read-only adapter that returns a digest or scalar assertion value.
 - Each success case starts from the same post-deployment snapshot, so `--state-before` and
   `--state-after` describe one guarded call.
 - The runner validates guard wiring and behavior, not the correctness or completeness of the

--- a/examples/credible-block/README.md
+++ b/examples/credible-block/README.md
@@ -1,55 +1,124 @@
-# Credible Block guard — upgrade tests
+# Credible-block live upgrade validation
 
-Integration scripts that exercise [`CredibleBlockGuard`](../../src/protection/credible_block/CredibleBlockGuard.sol)'s
-`onlyCredibleBlock` modifier against a **live anvil node**, so we can validate credible-layer
-contract upgrades end to end.
+This directory contains a live-Anvil integration runner for
+[`CredibleBlockGuard`](../../src/protection/credible_block/CredibleBlockGuard.sol). It proves the
+marker transaction and guarded user transaction can execute in the same manually mined block, and
+also exercises rejection and strict fail-open behavior.
 
-The forge unit tests in
-[`test/protection/credible_block/`](../../test/protection/credible_block/CredibleBlockGuard.t.sol)
-fake block state with `vm.roll` / `vm.prank`. That covers the pure decision logic, but it cannot
-reproduce the one thing that only exists on a real chain: a builder's *credible block marker*
-transaction and a *guarded* transaction landing in the **same block** (a bundle). These scripts seed
-a real node and drive mining manually so we can test exactly that.
+`GuardedCounter` is the default runnable fixture. A passing fixture run proves the harness and base
+guard work; it does **not** validate a protocol upgrade. Use target mode to validate the actual
+upgraded contract.
 
-## Contents
+## What is tested
 
-| File | Role |
-| ---- | ---- |
-| [`src/CredibleRegistry.sol`](./src/CredibleRegistry.sol) | Minimal deployable registry: a single immutable builder (set at construction) can mark the current block credible; implements [`ICredibleRegistry`](../../src/protection/credible_block/ICredibleRegistry.sol). The production registry ([`phylaxsystems/credible-registry`](https://github.com/phylaxsystems/credible-registry)) additionally has a timelocked admin, a builder whitelist, and timestamp slot-binding — none needed to exercise the guard. |
-| [`src/GuardedCounter.sol`](./src/GuardedCounter.sol) | A concrete `CredibleBlockGuard` standing in for an upgraded credible-layer contract; its `bump()` entrypoint is `onlyCredibleBlock`. |
-| [`script/test-credible-upgrades.sh`](./script/test-credible-upgrades.sh) | Orchestrator that boots anvil, deploys, and runs the three cases. |
+| Case | Expected transaction result | Required state proof |
+| --- | --- | --- |
+| Marker then guarded call, queued and mined together | Both succeed in the same block | Target state changes from `--state-before` to `--state-after` |
+| Guarded call alone while the builder window is live | Reverts with `--guard-error` | Target state remains `--state-before` |
+| Builder inactivity | Reverts at `gap == threshold`; succeeds at `gap > threshold` | State is unchanged at the boundary and changes after fail-open |
 
-## Cases
+The runner starts Anvil with FIFO transaction ordering, disables automining, submits both same-block
+transactions with `cast send --async`, and calls `evm_mine` once. Do not replace this with two
+automined sends: they would be in different blocks and would not test credible-block bundling.
 
-| Case | Scenario | Expectation |
-| ---- | -------- | ----------- |
-| **1. Credible block** | Bundle `[markCurrentBlockCredible, bump]` into one block via manual mining | Both txs succeed; counter increments |
-| **2. Non-credible block** | Send only `bump()` with no marker | Reverts with `NonCredibleBlock()`; counter unchanged |
-| **3. Fail-open** | Builder stops marking for `> failOpenBlockThreshold` blocks | Still reverts at the boundary (gap == threshold); passes once gap > threshold |
+## Fixture run
 
-## How the bundle is simulated
-
-Anvil auto-mines each tx into its own block by default, which would put the marker and the guarded
-call in different blocks. The script turns automine **off** (`evm_setAutomine false`), submits both
-txs with `cast send --async` (returns immediately without waiting for a receipt), then seals exactly
-one block with `evm_mine`. Both queued txs land together; `--order fifo` guarantees the marker
-executes first, so the guarded call sees the block already marked credible.
-
-## Running
-
-From the repo root:
+From the repository root:
 
 ```shell
 ./examples/credible-block/script/test-credible-upgrades.sh
 ```
 
-Requires `anvil`, `cast`, `forge`, and `jq` on `PATH`. Exits non-zero if any check fails. Env
-overrides: `RPC_PORT` (default `8545`), `FAIL_OPEN_THRESHOLD` (default `10`, kept small so the
-fail-open case runs quickly).
+This deploys the minimal [`CredibleRegistry`](./src/CredibleRegistry.sol) and
+[`GuardedCounter`](./src/GuardedCounter.sol), calls `bump()`, and reads `count()`. The expected output
+identifies the run as `GuardedCounter fixture coverage`, reports three case sections, and finishes
+with `Summary: 14 passed, 0 failed`.
 
-The script uses the `credible-block` foundry profile (see `foundry.toml`); it sets
-`FOUNDRY_PROFILE=credible-block` itself.
+## Real upgraded-contract run
 
-> On macOS, `cast`/`forge` read system proxy configuration at startup, which the Claude Code Bash
-> sandbox blocks (the process aborts with a NULL-object panic). Run this script with the sandbox
-> disabled.
+The target and registry must exist on the fresh Anvil instance started by the runner. Usually this
+means supplying deployment/upgrade commands:
+
+```shell
+./examples/credible-block/script/test-credible-upgrades.sh \
+  --registry-deploy-command \
+    'forge script script/DeployRegistry.s.sol --rpc-url "$RPC_URL" --broadcast; echo 0xREGISTRY' \
+  --target-deploy-command \
+    'forge script script/UpgradeVault.s.sol --rpc-url "$RPC_URL" --broadcast; echo 0xPROXY' \
+  --guarded-call 'deposit(uint256) 1000000' \
+  --state-read-call 'totalAssets()(uint256)' \
+  --state-before 0 \
+  --state-after 1000000 \
+  --expected-threshold 75 \
+  --marker-private-key 0xMARKER_PRIVATE_KEY \
+  --guarded-private-key 0xUSER_PRIVATE_KEY
+```
+
+Each deployment command must print its resulting address as the final stdout line. Commands receive
+these exported variables: `RPC_URL`, `REPO_ROOT`, `ADMIN_KEY`, `MARKER_KEY`, `GUARDED_KEY`,
+`MARKER_ADDRESS`, `GUARDED_ADDRESS`, `REGISTRY_ADDRESS` (for the target command), and
+`EXPECTED_THRESHOLD`. The commands are passed to `bash -c`; only run trusted command text.
+
+For contracts already created by a setup command, use `--registry-address` and `--target-address`.
+Because every run starts a fresh chain, addresses from another node are not usable.
+
+The full input surface is:
+
+```text
+--target-address ADDRESS | --target-deploy-command COMMAND
+--registry-address ADDRESS | --registry-deploy-command COMMAND
+--guarded-call "SIGNATURE [ARGS...]"
+--marker-call "SIGNATURE [ARGS...]"                 # default markCurrentBlockCredible()
+--state-read-call "SIGNATURE [ARGS...]"
+--state-before VALUE
+--state-after VALUE
+--expected-threshold BLOCKS
+--marker-private-key KEY
+--guarded-private-key KEY
+--admin-private-key KEY
+--guard-error SIGNATURE                             # default NonCredibleBlock()
+--rpc-port PORT
+--gas-limit GAS
+```
+
+The default configuration check calls `credibleRegistry()(address)` and
+`failOpenBlockThreshold()(uint256)` on the target. Override their signatures with
+`--registry-read-call` and `--threshold-read-call`. If the upgrade exposes no suitable getters,
+provide a contract-specific adapter/assertion:
+
+```shell
+--config-assert-command \
+  'cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "guardConfigHash()(bytes32)" |
+   grep -qi "$(cast keccak "$(cast abi-encode "f(address,uint256)" \
+     "$REGISTRY_ADDRESS" "$EXPECTED_THRESHOLD")")"'
+```
+
+The assertion must exit zero only after proving that `TARGET_ADDRESS` uses exactly
+`REGISTRY_ADDRESS` and `EXPECTED_THRESHOLD`. A deployment script may instead assert the immutable,
+storage slot, or emitted upgrade/configuration event and expose that assertion through this hook.
+The runner fails before behavioral cases when the assertion fails.
+
+Use `--validate-only` to check arguments without starting Anvil. Argument parsing regression tests
+run with:
+
+```shell
+./examples/credible-block/test/test-script-arguments.sh
+```
+
+## Requirements and limitations
+
+- `anvil`, `cast`, `forge`, and `jq` must be on `PATH`.
+- The selected RPC port must be unused; the runner refuses to adopt an existing node.
+- The marker account must be authorized by the supplied registry configuration.
+- The guarded account must have all target-specific balances, approvals, roles, and prerequisites.
+  Deployment commands are responsible for arranging them.
+- `--state-read-call` must return one stable, directly comparable `cast call` value. For complex
+  effects, deploy a read-only adapter that returns a digest or scalar assertion value.
+- Each success case starts from the same post-deployment snapshot, so `--state-before` and
+  `--state-after` describe one guarded call.
+- The runner validates guard wiring and behavior, not the correctness or completeness of the
+  upgrade process itself.
+- The `credible-block` Foundry profile is selected automatically.
+- On macOS, Foundry may abort while reading system proxy settings inside a restricted sandbox. Run
+  the live integration outside that sandbox; `--validate-only` and the argument tests do not start
+  Foundry and can remain sandboxed.

--- a/examples/credible-block/README.md
+++ b/examples/credible-block/README.md
@@ -45,7 +45,8 @@ means supplying deployment/upgrade commands:
     'forge script script/DeployRegistry.s.sol --rpc-url "$RPC_URL" --broadcast; echo 0xREGISTRY' \
   --target-deploy-command \
     'forge script script/UpgradeVault.s.sol --rpc-url "$RPC_URL" --broadcast; echo 0xPROXY' \
-  --guarded-call 'deposit(uint256) 1000000' \
+  --guarded-call 'deposit(uint256)' \
+  --guarded-call-arg 1000000 \
   --state-read-call 'totalAssets()(uint256)' \
   --state-before 0 \
   --state-after 1000000 \
@@ -67,9 +68,12 @@ The full input surface is:
 ```text
 --target-address ADDRESS | --target-deploy-command COMMAND
 --registry-address ADDRESS | --registry-deploy-command COMMAND
---guarded-call "SIGNATURE [ARGS...]"
---marker-call "SIGNATURE [ARGS...]"                 # default markCurrentBlockCredible()
---state-read-call "SIGNATURE [ARGS...]"
+--guarded-call "SIGNATURE"
+--guarded-call-arg "ARGUMENT"                      # repeat once per argument
+--marker-call "SIGNATURE"                          # default markCurrentBlockCredible()
+--marker-call-arg "ARGUMENT"                       # repeat once per argument
+--state-read-call "SIGNATURE"
+--state-read-call-arg "ARGUMENT"                   # repeat once per argument
 --state-before VALUE
 --state-after VALUE
 --expected-threshold BLOCKS

--- a/examples/credible-block/script/test-credible-upgrades.sh
+++ b/examples/credible-block/script/test-credible-upgrades.sh
@@ -19,8 +19,11 @@ TARGET_DEPLOY_COMMAND=""
 REGISTRY_ADDRESS=""
 REGISTRY_DEPLOY_COMMAND=""
 GUARDED_CALL=""
+GUARDED_CALL_ARGS=()
 MARKER_CALL="markCurrentBlockCredible()"
+MARKER_CALL_ARGS=()
 STATE_READ_CALL=""
+STATE_READ_CALL_ARGS=()
 STATE_BEFORE=""
 STATE_AFTER=""
 REGISTRY_READ_CALL="credibleRegistry()(address)"
@@ -38,8 +41,10 @@ Usage:
 Target options:
   --target-address ADDRESS                         Existing target on the fresh Anvil chain
   --target-deploy-command COMMAND                  Deploy/upgrade; final stdout line is its address
-  --guarded-call SIGNATURE                         e.g. 'deposit(uint256)' 100
+  --guarded-call SIGNATURE                         e.g. 'setName(string)'
+  --guarded-call-arg ARGUMENT                      Repeat for each argument, e.g. 'hello world'
   --state-read-call SIGNATURE                      e.g. 'totalAssets()(uint256)'
+  --state-read-call-arg ARGUMENT                   Repeat for each state-read argument
   --state-before VALUE                             Expected state before/after rejected calls
   --state-after VALUE                              Expected state after successful guarded call
 
@@ -47,6 +52,7 @@ Registry/configuration options:
   --registry-address ADDRESS                       Existing registry on the fresh Anvil chain
   --registry-deploy-command COMMAND                Deploy/configure; final stdout line is its address
   --marker-call SIGNATURE                          Default: markCurrentBlockCredible()
+  --marker-call-arg ARGUMENT                       Repeat for each marker-call argument
   --expected-threshold BLOCKS                      Default in fixture mode: 10
   --registry-read-call SIGNATURE                   Default: credibleRegistry()(address)
   --threshold-read-call SIGNATURE                  Default: failOpenBlockThreshold()(uint256)
@@ -80,8 +86,11 @@ while [[ $# -gt 0 ]]; do
         --registry-address)        need_value "$@"; REGISTRY_ADDRESS="$2"; shift 2 ;;
         --registry-deploy-command) need_value "$@"; REGISTRY_DEPLOY_COMMAND="$2"; shift 2 ;;
         --guarded-call)            need_value "$@"; GUARDED_CALL="$2"; shift 2 ;;
+        --guarded-call-arg)        need_value "$@"; GUARDED_CALL_ARGS+=("$2"); shift 2 ;;
         --marker-call)             need_value "$@"; MARKER_CALL="$2"; shift 2 ;;
+        --marker-call-arg)         need_value "$@"; MARKER_CALL_ARGS+=("$2"); shift 2 ;;
         --state-read-call)         need_value "$@"; STATE_READ_CALL="$2"; shift 2 ;;
+        --state-read-call-arg)     need_value "$@"; STATE_READ_CALL_ARGS+=("$2"); shift 2 ;;
         --state-before)            need_value "$@"; STATE_BEFORE="$2"; shift 2 ;;
         --state-after)             need_value "$@"; STATE_AFTER="$2"; shift 2 ;;
         --registry-read-call)      need_value "$@"; REGISTRY_READ_CALL="$2"; shift 2 ;;
@@ -118,7 +127,8 @@ if [[ -n "$TARGET_ADDRESS" || -n "$TARGET_DEPLOY_COMMAND" ]]; then
     [[ -n "$REGISTRY_ADDRESS" || -n "$REGISTRY_DEPLOY_COMMAND" ]] ||
         die "target mode requires --registry-address or --registry-deploy-command"
 else
-    [[ -z "$GUARDED_CALL$STATE_READ_CALL$STATE_BEFORE$STATE_AFTER$REGISTRY_ADDRESS$REGISTRY_DEPLOY_COMMAND$CONFIG_ASSERT_COMMAND" ]] ||
+    [[ -z "$GUARDED_CALL$STATE_READ_CALL$STATE_BEFORE$STATE_AFTER$REGISTRY_ADDRESS$REGISTRY_DEPLOY_COMMAND$CONFIG_ASSERT_COMMAND" &&
+        ${#GUARDED_CALL_ARGS[@]} -eq 0 && ${#STATE_READ_CALL_ARGS[@]} -eq 0 ]] ||
         die "target-specific options require --target-address or --target-deploy-command"
     GUARDED_CALL="bump()"
     STATE_READ_CALL="count()(uint256)"
@@ -162,10 +172,13 @@ rpc() { cast rpc --rpc-url "$RPC_URL" "$@" >/dev/null; }
 mine_blocks() { rpc anvil_mine "$(cast to-hex "$1")"; }
 receipt_status() { cast receipt --rpc-url "$RPC_URL" --async "$1" --json 2>/dev/null | jq -r '.status'; }
 receipt_block() { cast to-dec "$(cast receipt --rpc-url "$RPC_URL" --async "$1" --json | jq -r '.blockNumber')"; }
-read_state() { cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" $STATE_READ_CALL; }
+read_state() {
+    cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$STATE_READ_CALL" "${STATE_READ_CALL_ARGS[@]}"
+}
 send_async() {
-    local key="$1" address="$2" call="$3"
-    cast send --rpc-url "$RPC_URL" --private-key "$key" --gas-limit "$GAS_LIMIT" --async "$address" $call
+    local key="$1" address="$2" call="$3"; shift 3
+    cast send --rpc-url "$RPC_URL" --private-key "$key" --gas-limit "$GAS_LIMIT" \
+        --async "$address" "$call" "$@"
 }
 reset_state() {
     rpc evm_revert "$SNAPSHOT"
@@ -241,8 +254,8 @@ SNAPSHOT=$(cast rpc --rpc-url "$RPC_URL" evm_snapshot | tr -d '"')
 
 section "Case 1: marker + guarded call in one manually mined block"
 reset_state
-MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
-GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
+MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL" "${MARKER_CALL_ARGS[@]}")
+GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL" "${GUARDED_CALL_ARGS[@]}")
 rpc evm_mine
 check "marker transaction succeeded" "$(receipt_status "$MARKER_TX")" "0x1"
 check "guarded transaction succeeded" "$(receipt_status "$GUARDED_TX")" "0x1"
@@ -252,15 +265,15 @@ check "guarded action produced expected state" "$(read_state)" "$STATE_AFTER"
 
 section "Case 2: unmarked call while builder window is live"
 reset_state
-SEED_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
+SEED_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL" "${MARKER_CALL_ARGS[@]}")
 rpc evm_mine
-GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
+GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL" "${GUARDED_CALL_ARGS[@]}")
 rpc evm_mine
 check "guarded transaction reverted" "$(receipt_status "$GUARDED_TX")" "0x0"
 check "rejected call left target state unchanged" "$(read_state)" "$STATE_BEFORE"
 ERROR_SELECTOR=$(cast sig "$GUARD_ERROR")
 CALL_OUT=$(cast call --rpc-url "$RPC_URL" --from "$GUARDED_ADDRESS" \
-    "$TARGET_ADDRESS" $GUARDED_CALL 2>&1 || true)
+    "$TARGET_ADDRESS" "$GUARDED_CALL" "${GUARDED_CALL_ARGS[@]}" 2>&1 || true)
 if grep -qi "$ERROR_SELECTOR" <<<"$CALL_OUT"; then
     echo "  ${GREEN}PASS${NC} static call reverted with $GUARD_ERROR"
     PASS_COUNT=$((PASS_COUNT + 1))
@@ -271,15 +284,15 @@ fi
 
 section "Case 3: builder inactivity boundary and strict fail-open"
 reset_state
-MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
+MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL" "${MARKER_CALL_ARGS[@]}")
 rpc evm_mine
 M=$(receipt_block "$MARKER_TX")
 mine_blocks $((FAIL_OPEN_THRESHOLD - 1))
-BOUNDARY_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
+BOUNDARY_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL" "${GUARDED_CALL_ARGS[@]}")
 rpc evm_mine
 check "gap == threshold still reverts" "$(receipt_status "$BOUNDARY_TX")" "0x0"
 check "boundary rejection left target state unchanged" "$(read_state)" "$STATE_BEFORE"
-OPEN_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
+OPEN_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL" "${GUARDED_CALL_ARGS[@]}")
 rpc evm_mine
 check "gap > threshold succeeds" "$(receipt_status "$OPEN_TX")" "0x1"
 check "fail-open call produced expected state" "$(read_state)" "$STATE_AFTER"

--- a/examples/credible-block/script/test-credible-upgrades.sh
+++ b/examples/credible-block/script/test-credible-upgrades.sh
@@ -78,6 +78,7 @@ EOF
 
 die() { echo "ERROR: $*" >&2; exit 2; }
 need_value() { [[ $# -ge 2 && -n "$2" ]] || die "$1 requires a value"; }
+need_operand() { [[ $# -ge 2 ]] || die "$1 requires a value"; }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -86,11 +87,11 @@ while [[ $# -gt 0 ]]; do
         --registry-address)        need_value "$@"; REGISTRY_ADDRESS="$2"; shift 2 ;;
         --registry-deploy-command) need_value "$@"; REGISTRY_DEPLOY_COMMAND="$2"; shift 2 ;;
         --guarded-call)            need_value "$@"; GUARDED_CALL="$2"; shift 2 ;;
-        --guarded-call-arg)        need_value "$@"; GUARDED_CALL_ARGS+=("$2"); shift 2 ;;
+        --guarded-call-arg)        need_operand "$@"; GUARDED_CALL_ARGS+=("$2"); shift 2 ;;
         --marker-call)             need_value "$@"; MARKER_CALL="$2"; shift 2 ;;
-        --marker-call-arg)         need_value "$@"; MARKER_CALL_ARGS+=("$2"); shift 2 ;;
+        --marker-call-arg)         need_operand "$@"; MARKER_CALL_ARGS+=("$2"); shift 2 ;;
         --state-read-call)         need_value "$@"; STATE_READ_CALL="$2"; shift 2 ;;
-        --state-read-call-arg)     need_value "$@"; STATE_READ_CALL_ARGS+=("$2"); shift 2 ;;
+        --state-read-call-arg)     need_operand "$@"; STATE_READ_CALL_ARGS+=("$2"); shift 2 ;;
         --state-before)            need_value "$@"; STATE_BEFORE="$2"; shift 2 ;;
         --state-after)             need_value "$@"; STATE_AFTER="$2"; shift 2 ;;
         --registry-read-call)      need_value "$@"; REGISTRY_READ_CALL="$2"; shift 2 ;;
@@ -174,7 +175,11 @@ receipt_status() { cast receipt --rpc-url "$RPC_URL" --async "$1" --json 2>/dev/
 receipt_block() { cast to-dec "$(cast receipt --rpc-url "$RPC_URL" --async "$1" --json | jq -r '.blockNumber')"; }
 normalize_cast_value() {
     local value="$1"
-    printf '%s' "${value%% \[*}"
+    if [[ "$value" =~ ^-?[0-9]+\ \[[^][]+\]$ ]]; then
+        printf '%s' "${value%% \[*}"
+    else
+        printf '%s' "$value"
+    fi
 }
 read_state() {
     local value
@@ -213,6 +218,12 @@ for _ in $(seq 1 50); do
 done
 cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1 ||
     die "Anvil did not become ready on $RPC_URL"
+
+if [[ -n "$TARGET_ADDRESS" ]]; then
+    TARGET_ADDRESS=$(cast to-check-sum-address "$TARGET_ADDRESS" 2>/dev/null) ||
+        die "target address is not a valid address"
+    export TARGET_ADDRESS
+fi
 
 if [[ -n "$REGISTRY_DEPLOY_COMMAND" ]]; then
     REGISTRY_ADDRESS=$(run_address_command "registry deployment/configuration" "$REGISTRY_DEPLOY_COMMAND")

--- a/examples/credible-block/script/test-credible-upgrades.sh
+++ b/examples/credible-block/script/test-credible-upgrades.sh
@@ -145,13 +145,13 @@ for command in anvil cast forge jq; do
     command -v "$command" >/dev/null || die "required command not found on PATH: $command"
 done
 
-export FOUNDRY_PROFILE=credible-block
 RPC_URL="http://127.0.0.1:${RPC_PORT}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 MARKER_ADDRESS=$(cast wallet address "$MARKER_KEY")
 GUARDED_ADDRESS=$(cast wallet address "$GUARDED_KEY")
 export RPC_URL REPO_ROOT ADMIN_KEY MARKER_KEY GUARDED_KEY MARKER_ADDRESS GUARDED_ADDRESS
+export EXPECTED_THRESHOLD="$FAIL_OPEN_THRESHOLD"
 
 RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; NC=$'\033[0m'
 PASS_COUNT=0; FAIL_COUNT=0; ANVIL_PID=""
@@ -172,8 +172,14 @@ rpc() { cast rpc --rpc-url "$RPC_URL" "$@" >/dev/null; }
 mine_blocks() { rpc anvil_mine "$(cast to-hex "$1")"; }
 receipt_status() { cast receipt --rpc-url "$RPC_URL" --async "$1" --json 2>/dev/null | jq -r '.status'; }
 receipt_block() { cast to-dec "$(cast receipt --rpc-url "$RPC_URL" --async "$1" --json | jq -r '.blockNumber')"; }
+normalize_cast_value() {
+    local value="$1"
+    printf '%s' "${value%% \[*}"
+}
 read_state() {
-    cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$STATE_READ_CALL" "${STATE_READ_CALL_ARGS[@]}"
+    local value
+    value=$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$STATE_READ_CALL" "${STATE_READ_CALL_ARGS[@]}")
+    normalize_cast_value "$value"
 }
 send_async() {
     local key="$1" address="$2" call="$3"; shift 3
@@ -211,19 +217,19 @@ cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1 ||
 if [[ -n "$REGISTRY_DEPLOY_COMMAND" ]]; then
     REGISTRY_ADDRESS=$(run_address_command "registry deployment/configuration" "$REGISTRY_DEPLOY_COMMAND")
 elif [[ -z "$REGISTRY_ADDRESS" ]]; then
-    REGISTRY_ADDRESS=$(cd "$REPO_ROOT" && forge create \
+    REGISTRY_ADDRESS=$(cd "$REPO_ROOT" && FOUNDRY_PROFILE=credible-block forge create \
         examples/credible-block/src/CredibleRegistry.sol:CredibleRegistry \
         --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
         --constructor-args "$MARKER_ADDRESS" | jq -r '.deployedTo')
 fi
 REGISTRY_ADDRESS=$(cast to-check-sum-address "$REGISTRY_ADDRESS" 2>/dev/null) ||
     die "registry address is not a valid address"
-export REGISTRY_ADDRESS EXPECTED_THRESHOLD="$FAIL_OPEN_THRESHOLD"
+export REGISTRY_ADDRESS
 
 if [[ -n "$TARGET_DEPLOY_COMMAND" ]]; then
     TARGET_ADDRESS=$(run_address_command "target deployment/upgrade" "$TARGET_DEPLOY_COMMAND")
 elif [[ -z "$TARGET_ADDRESS" ]]; then
-    TARGET_ADDRESS=$(cd "$REPO_ROOT" && forge create \
+    TARGET_ADDRESS=$(cd "$REPO_ROOT" && FOUNDRY_PROFILE=credible-block forge create \
         examples/credible-block/src/GuardedCounter.sol:GuardedCounter \
         --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
         --constructor-args "$REGISTRY_ADDRESS" "$FAIL_OPEN_THRESHOLD" | jq -r '.deployedTo')
@@ -243,10 +249,13 @@ if [[ -n "$CONFIG_ASSERT_COMMAND" ]]; then
         die "contract-specific configuration assertion failed"
     fi
 else
+    CONFIG_FAILURES=$FAIL_COUNT
     check "target uses expected registry" \
         "$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$REGISTRY_READ_CALL")" "$REGISTRY_ADDRESS"
     check "target uses expected fail-open threshold" \
-        "$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$THRESHOLD_READ_CALL")" "$FAIL_OPEN_THRESHOLD"
+        "$(normalize_cast_value "$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$THRESHOLD_READ_CALL")")" \
+        "$FAIL_OPEN_THRESHOLD"
+    [[ "$FAIL_COUNT" -eq "$CONFIG_FAILURES" ]] || die "target configuration verification failed"
 fi
 check "initial target state" "$(read_state)" "$STATE_BEFORE"
 

--- a/examples/credible-block/script/test-credible-upgrades.sh
+++ b/examples/credible-block/script/test-credible-upgrades.sh
@@ -1,226 +1,289 @@
 #!/usr/bin/env bash
 #
-# Integration test for the Credible Layer block guard against a live anvil node.
+# Live-Anvil integration test for CredibleBlockGuard.
 #
-# Unlike the forge unit tests (which fake block state with vm.roll/vm.prank), this drives a real
-# node so we can exercise the one thing that only matters on a real chain: whether a builder's
-# "credible block marker" tx and a guarded tx land in the SAME block (a bundle).
-#
-# It seeds anvil with:
-#   - a CredibleRegistry (examples/credible-block/src/CredibleRegistry.sol) with a single immutable
-#     builder baked in at construction (the production registry additionally gates builders behind a
-#     timelocked admin and a whitelist; none of that is needed to exercise the guard),
-#   - a "builder" account we control, passed in as that immutable builder,
-#   - a GuardedCounter (a concrete CredibleBlockGuard) standing in for an upgraded credible contract.
-#
-# Then it verifies three cases:
-#   1. Credible block  — bundle [marker tx, guarded tx] into one block; both must succeed.
-#   2. Non-credible    — send only the guarded tx (no marker); it must revert (NonCredibleBlock).
-#   3. Fail-open       — after the builder stops marking for > failOpenBlockThreshold blocks, the
-#                        guarded tx must start passing again (and must still revert at the boundary).
-#
-# Usage:  ./examples/credible-block/script/test-credible-upgrades.sh   (run from the repo root)
-# Requires: anvil, cast, forge, jq on PATH.
+# With no target arguments this deploys the GuardedCounter example fixture. For a real upgrade,
+# provide --target-address or --target-deploy-command plus the target-specific call/read inputs.
 
 set -euo pipefail
 
-# --------------------------------------------------------------------------------------------------
-# Config
-# --------------------------------------------------------------------------------------------------
 RPC_PORT="${RPC_PORT:-8545}"
-RPC_URL="http://127.0.0.1:${RPC_PORT}"
-FAIL_OPEN_THRESHOLD="${FAIL_OPEN_THRESHOLD:-10}" # kept small so the fail-open case runs quickly
+FAIL_OPEN_THRESHOLD="${FAIL_OPEN_THRESHOLD:-10}"
+ADMIN_KEY="${ADMIN_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+MARKER_KEY="${MARKER_KEY:-0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d}"
+GUARDED_KEY="${GUARDED_KEY:-0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a}"
+GAS_LIMIT="${GAS_LIMIT:-2000000}"
+
+TARGET_ADDRESS=""
+TARGET_DEPLOY_COMMAND=""
+REGISTRY_ADDRESS=""
+REGISTRY_DEPLOY_COMMAND=""
+GUARDED_CALL=""
+MARKER_CALL="markCurrentBlockCredible()"
+STATE_READ_CALL=""
+STATE_BEFORE=""
+STATE_AFTER=""
+REGISTRY_READ_CALL="credibleRegistry()(address)"
+THRESHOLD_READ_CALL="failOpenBlockThreshold()(uint256)"
+CONFIG_ASSERT_COMMAND=""
+GUARD_ERROR="NonCredibleBlock()"
+VALIDATE_ONLY=false
+
+usage() {
+    cat <<'EOF'
+Usage:
+  test-credible-upgrades.sh                         # GuardedCounter fixture
+  test-credible-upgrades.sh [target options]
+
+Target options:
+  --target-address ADDRESS                         Existing target on the fresh Anvil chain
+  --target-deploy-command COMMAND                  Deploy/upgrade; final stdout line is its address
+  --guarded-call SIGNATURE                         e.g. 'deposit(uint256)' 100
+  --state-read-call SIGNATURE                      e.g. 'totalAssets()(uint256)'
+  --state-before VALUE                             Expected state before/after rejected calls
+  --state-after VALUE                              Expected state after successful guarded call
+
+Registry/configuration options:
+  --registry-address ADDRESS                       Existing registry on the fresh Anvil chain
+  --registry-deploy-command COMMAND                Deploy/configure; final stdout line is its address
+  --marker-call SIGNATURE                          Default: markCurrentBlockCredible()
+  --expected-threshold BLOCKS                      Default in fixture mode: 10
+  --registry-read-call SIGNATURE                   Default: credibleRegistry()(address)
+  --threshold-read-call SIGNATURE                  Default: failOpenBlockThreshold()(uint256)
+  --config-assert-command COMMAND                  Adapter for targets without public getters
+                                                    (replaces both getter checks)
+  --guard-error SIGNATURE                          Default: NonCredibleBlock()
+
+Accounts/runtime:
+  --marker-private-key KEY                         Marker transaction account
+  --guarded-private-key KEY                        Guarded call account
+  --admin-private-key KEY                          Fixture/deployment account
+  --rpc-port PORT                                  Default: 8545
+  --gas-limit GAS                                  Default: 2000000
+  --validate-only                                  Parse and validate without starting Anvil
+  -h, --help
+
+Commands run via `bash -c` with RPC_URL, REPO_ROOT, ADMIN_KEY, MARKER_KEY, GUARDED_KEY,
+MARKER_ADDRESS, GUARDED_ADDRESS, REGISTRY_ADDRESS, TARGET_ADDRESS and EXPECTED_THRESHOLD exported.
+Deployment commands must print the deployed address as their final stdout line. A config assertion
+command must exit zero only when TARGET_ADDRESS uses REGISTRY_ADDRESS and EXPECTED_THRESHOLD.
+EOF
+}
+
+die() { echo "ERROR: $*" >&2; exit 2; }
+need_value() { [[ $# -ge 2 && -n "$2" ]] || die "$1 requires a value"; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target-address)          need_value "$@"; TARGET_ADDRESS="$2"; shift 2 ;;
+        --target-deploy-command)   need_value "$@"; TARGET_DEPLOY_COMMAND="$2"; shift 2 ;;
+        --registry-address)        need_value "$@"; REGISTRY_ADDRESS="$2"; shift 2 ;;
+        --registry-deploy-command) need_value "$@"; REGISTRY_DEPLOY_COMMAND="$2"; shift 2 ;;
+        --guarded-call)            need_value "$@"; GUARDED_CALL="$2"; shift 2 ;;
+        --marker-call)             need_value "$@"; MARKER_CALL="$2"; shift 2 ;;
+        --state-read-call)         need_value "$@"; STATE_READ_CALL="$2"; shift 2 ;;
+        --state-before)            need_value "$@"; STATE_BEFORE="$2"; shift 2 ;;
+        --state-after)             need_value "$@"; STATE_AFTER="$2"; shift 2 ;;
+        --registry-read-call)      need_value "$@"; REGISTRY_READ_CALL="$2"; shift 2 ;;
+        --threshold-read-call)     need_value "$@"; THRESHOLD_READ_CALL="$2"; shift 2 ;;
+        --config-assert-command)   need_value "$@"; CONFIG_ASSERT_COMMAND="$2"; shift 2 ;;
+        --guard-error)             need_value "$@"; GUARD_ERROR="$2"; shift 2 ;;
+        --expected-threshold)      need_value "$@"; FAIL_OPEN_THRESHOLD="$2"; shift 2 ;;
+        --marker-private-key)      need_value "$@"; MARKER_KEY="$2"; shift 2 ;;
+        --guarded-private-key)     need_value "$@"; GUARDED_KEY="$2"; shift 2 ;;
+        --admin-private-key)       need_value "$@"; ADMIN_KEY="$2"; shift 2 ;;
+        --rpc-port)                need_value "$@"; RPC_PORT="$2"; shift 2 ;;
+        --gas-limit)               need_value "$@"; GAS_LIMIT="$2"; shift 2 ;;
+        --validate-only)           VALIDATE_ONLY=true; shift ;;
+        -h|--help)                 usage; exit 0 ;;
+        *)                         die "unknown argument: $1 (use --help)" ;;
+    esac
+done
+
+[[ "$FAIL_OPEN_THRESHOLD" =~ ^[1-9][0-9]*$ ]] ||
+    die "--expected-threshold must be a positive integer"
+[[ "$RPC_PORT" =~ ^[0-9]+$ ]] || die "--rpc-port must be an integer"
+[[ -z "$TARGET_ADDRESS" || -z "$TARGET_DEPLOY_COMMAND" ]] ||
+    die "provide only one of --target-address and --target-deploy-command"
+[[ -z "$REGISTRY_ADDRESS" || -z "$REGISTRY_DEPLOY_COMMAND" ]] ||
+    die "provide only one of --registry-address and --registry-deploy-command"
+
+CUSTOM_MODE=false
+if [[ -n "$TARGET_ADDRESS" || -n "$TARGET_DEPLOY_COMMAND" ]]; then
+    CUSTOM_MODE=true
+    [[ -n "$GUARDED_CALL" ]] || die "target mode requires --guarded-call"
+    [[ -n "$STATE_READ_CALL" ]] || die "target mode requires --state-read-call"
+    [[ -n "$STATE_BEFORE" ]] || die "target mode requires --state-before"
+    [[ -n "$STATE_AFTER" ]] || die "target mode requires --state-after"
+    [[ -n "$REGISTRY_ADDRESS" || -n "$REGISTRY_DEPLOY_COMMAND" ]] ||
+        die "target mode requires --registry-address or --registry-deploy-command"
+else
+    [[ -z "$GUARDED_CALL$STATE_READ_CALL$STATE_BEFORE$STATE_AFTER$REGISTRY_ADDRESS$REGISTRY_DEPLOY_COMMAND$CONFIG_ASSERT_COMMAND" ]] ||
+        die "target-specific options require --target-address or --target-deploy-command"
+    GUARDED_CALL="bump()"
+    STATE_READ_CALL="count()(uint256)"
+    STATE_BEFORE="0"
+    STATE_AFTER="1"
+fi
+
+if $VALIDATE_ONLY; then
+    echo "configuration valid (mode=$($CUSTOM_MODE && echo target || echo fixture), threshold=$FAIL_OPEN_THRESHOLD)"
+    exit 0
+fi
+
+for command in anvil cast forge jq; do
+    command -v "$command" >/dev/null || die "required command not found on PATH: $command"
+done
 
 export FOUNDRY_PROFILE=credible-block
-
-# Deterministic anvil dev accounts (default mnemonic).
-ADMIN_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80   # account 0 (deployer/admin)
-BUILDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d # account 1 (credible builder)
-USER_KEY=0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a   # account 2 (unprivileged caller)
-BUILDER_ADDR=$(cast wallet address "$BUILDER_KEY")
-USER_ADDR=$(cast wallet address "$USER_KEY")
-
-GAS_LIMIT=2000000 # explicit so `cast send` skips eth_estimateGas (which would fail on reverting txs)
-
+RPC_URL="http://127.0.0.1:${RPC_PORT}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MARKER_ADDRESS=$(cast wallet address "$MARKER_KEY")
+GUARDED_ADDRESS=$(cast wallet address "$GUARDED_KEY")
+export RPC_URL REPO_ROOT ADMIN_KEY MARKER_KEY GUARDED_KEY MARKER_ADDRESS GUARDED_ADDRESS
 
 RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; NC=$'\033[0m'
-PASS_COUNT=0; FAIL_COUNT=0
-ANVIL_PID=""
-
+PASS_COUNT=0; FAIL_COUNT=0; ANVIL_PID=""
 cleanup() { [[ -n "$ANVIL_PID" ]] && kill "$ANVIL_PID" 2>/dev/null || true; }
 trap cleanup EXIT
-
-info()    { echo "${BLUE}==>${NC} $*"; }
+info() { echo "${BLUE}==>${NC} $*"; }
 section() { echo; echo "${BOLD}$*${NC}"; }
-
-# check <description> <actual> <expected>
 check() {
     local desc="$1" actual="$2" expected="$3"
     if [[ "$actual" == "$expected" ]]; then
-        echo "  ${GREEN}PASS${NC} $desc"
-        PASS_COUNT=$((PASS_COUNT + 1))
+        echo "  ${GREEN}PASS${NC} $desc"; PASS_COUNT=$((PASS_COUNT + 1))
     else
         echo "  ${RED}FAIL${NC} $desc (expected '$expected', got '$actual')"
         FAIL_COUNT=$((FAIL_COUNT + 1))
     fi
 }
-
-rpc()            { cast rpc --rpc-url "$RPC_URL" "$@" >/dev/null; }
-mine_blocks()    { rpc anvil_mine "$(cast to-hex "$1")"; }              # mine N blocks instantly
+rpc() { cast rpc --rpc-url "$RPC_URL" "$@" >/dev/null; }
+mine_blocks() { rpc anvil_mine "$(cast to-hex "$1")"; }
 receipt_status() { cast receipt --rpc-url "$RPC_URL" --async "$1" --json 2>/dev/null | jq -r '.status'; }
-receipt_block()  { cast to-dec "$(cast receipt --rpc-url "$RPC_URL" --async "$1" --json | jq -r '.blockNumber')"; }
-counter()        { cast call --rpc-url "$RPC_URL" "$GUARD" "count()(uint256)"; }
-
-# Submit a tx WITHOUT waiting for it to be mined; echoes the tx hash.
+receipt_block() { cast to-dec "$(cast receipt --rpc-url "$RPC_URL" --async "$1" --json | jq -r '.blockNumber')"; }
+read_state() { cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" $STATE_READ_CALL; }
 send_async() {
-    local key="$1"; shift
-    cast send --rpc-url "$RPC_URL" --private-key "$key" --gas-limit "$GAS_LIMIT" --async "$@"
+    local key="$1" address="$2" call="$3"
+    cast send --rpc-url "$RPC_URL" --private-key "$key" --gas-limit "$GAS_LIMIT" --async "$address" $call
 }
-
-# Reset chain state to the post-deployment snapshot and re-arm the snapshot for the next case.
 reset_state() {
     rpc evm_revert "$SNAPSHOT"
     SNAPSHOT=$(cast rpc --rpc-url "$RPC_URL" evm_snapshot | tr -d '"')
-    rpc evm_setAutomine false # manual mining for deterministic block composition
+    rpc evm_setAutomine false
+}
+run_address_command() {
+    local description="$1" command_text="$2" output address
+    output=$(bash -c "$command_text") || die "$description command failed"
+    address=$(printf '%s\n' "$output" | tail -n 1 | tr -d '[:space:]')
+    [[ "$address" =~ ^0x[0-9a-fA-F]{40}$ ]] ||
+        die "$description command must print a contract address as its final line (got '$address')"
+    printf '%s' "$address"
 }
 
-# --------------------------------------------------------------------------------------------------
-# Boot anvil + deploy
-# --------------------------------------------------------------------------------------------------
-section "Booting anvil (fifo mempool ordering) and deploying contracts"
-
-# Refuse to run against a pre-existing RPC listener: if the port is taken, our anvil would exit and
-# the readiness loop below would happily adopt (and snapshot/revert/disable-automine) a foreign node.
+section "Booting Anvil (FIFO mempool)"
 if cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
-    echo "${RED}ERROR${NC} something is already listening on $RPC_URL; refusing to run. Set RPC_PORT to a free port." >&2
-    exit 1
+    die "something is already listening on $RPC_URL; set --rpc-port to a free port"
 fi
-
-# fifo ordering guarantees the marker tx (submitted first) is included before the guarded tx when
-# both share a block, so the guarded call sees the block already marked credible.
 anvil --port "$RPC_PORT" --order fifo --silent &
 ANVIL_PID=$!
-
-# Poll for readiness, but bail if our anvil child died (e.g. the port was grabbed between the check
-# above and launch) rather than proceeding against whatever else may be answering on the port.
 for _ in $(seq 1 50); do
-    if ! kill -0 "$ANVIL_PID" 2>/dev/null; then
-        echo "${RED}ERROR${NC} anvil (pid $ANVIL_PID) exited before becoming ready; check the port is free." >&2
-        exit 1
-    fi
+    kill -0 "$ANVIL_PID" 2>/dev/null || die "Anvil exited before becoming ready"
     cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1 && break
     sleep 0.1
 done
+cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1 ||
+    die "Anvil did not become ready on $RPC_URL"
 
-if ! cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
-    echo "${RED}ERROR${NC} anvil did not become ready on $RPC_URL within the timeout." >&2
-    exit 1
+if [[ -n "$REGISTRY_DEPLOY_COMMAND" ]]; then
+    REGISTRY_ADDRESS=$(run_address_command "registry deployment/configuration" "$REGISTRY_DEPLOY_COMMAND")
+elif [[ -z "$REGISTRY_ADDRESS" ]]; then
+    REGISTRY_ADDRESS=$(cd "$REPO_ROOT" && forge create \
+        examples/credible-block/src/CredibleRegistry.sol:CredibleRegistry \
+        --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
+        --constructor-args "$MARKER_ADDRESS" | jq -r '.deployedTo')
 fi
+REGISTRY_ADDRESS=$(cast to-check-sum-address "$REGISTRY_ADDRESS" 2>/dev/null) ||
+    die "registry address is not a valid address"
+export REGISTRY_ADDRESS EXPECTED_THRESHOLD="$FAIL_OPEN_THRESHOLD"
 
-pushd "$REPO_ROOT" >/dev/null
+if [[ -n "$TARGET_DEPLOY_COMMAND" ]]; then
+    TARGET_ADDRESS=$(run_address_command "target deployment/upgrade" "$TARGET_DEPLOY_COMMAND")
+elif [[ -z "$TARGET_ADDRESS" ]]; then
+    TARGET_ADDRESS=$(cd "$REPO_ROOT" && forge create \
+        examples/credible-block/src/GuardedCounter.sol:GuardedCounter \
+        --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
+        --constructor-args "$REGISTRY_ADDRESS" "$FAIL_OPEN_THRESHOLD" | jq -r '.deployedTo')
+fi
+TARGET_ADDRESS=$(cast to-check-sum-address "$TARGET_ADDRESS" 2>/dev/null) ||
+    die "target address is not a valid address"
+export TARGET_ADDRESS
+info "mode: $($CUSTOM_MODE && echo 'real target validation' || echo 'GuardedCounter fixture coverage')"
+info "registry: $REGISTRY_ADDRESS; target: $TARGET_ADDRESS"
 
-# Deploy the registry with the builder account we control baked in as its sole marker.
-REGISTRY=$(forge create examples/credible-block/src/CredibleRegistry.sol:CredibleRegistry \
-    --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
-    --constructor-args "$BUILDER_ADDR" | jq -r '.deployedTo')
-info "CredibleRegistry:  $REGISTRY (builder=$BUILDER_ADDR)"
-
-GUARD=$(forge create examples/credible-block/src/GuardedCounter.sol:GuardedCounter \
-    --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json \
-    --constructor-args "$REGISTRY" "$FAIL_OPEN_THRESHOLD" | jq -r '.deployedTo')
-info "GuardedCounter:    $GUARD (failOpenBlockThreshold=$FAIL_OPEN_THRESHOLD)"
-
-popd >/dev/null
-
-check "registry builder is the account we control" \
-    "$(cast call --rpc-url "$RPC_URL" "$REGISTRY" "builder()(address)")" \
-    "$BUILDER_ADDR"
+section "Verifying target configuration"
+if [[ -n "$CONFIG_ASSERT_COMMAND" ]]; then
+    if bash -c "$CONFIG_ASSERT_COMMAND"; then
+        echo "  ${GREEN}PASS${NC} contract-specific configuration assertion"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        die "contract-specific configuration assertion failed"
+    fi
+else
+    check "target uses expected registry" \
+        "$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$REGISTRY_READ_CALL")" "$REGISTRY_ADDRESS"
+    check "target uses expected fail-open threshold" \
+        "$(cast call --rpc-url "$RPC_URL" "$TARGET_ADDRESS" "$THRESHOLD_READ_CALL")" "$FAIL_OPEN_THRESHOLD"
+fi
+check "initial target state" "$(read_state)" "$STATE_BEFORE"
 
 SNAPSHOT=$(cast rpc --rpc-url "$RPC_URL" evm_snapshot | tr -d '"')
 
-# --------------------------------------------------------------------------------------------------
-# Case 1: credible block — bundle [marker, guarded] into one block; both succeed.
-# --------------------------------------------------------------------------------------------------
-section "Case 1: credible block (marker + guarded tx bundled in one block)"
+section "Case 1: marker + guarded call in one manually mined block"
 reset_state
+MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
+GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
+rpc evm_mine
+check "marker transaction succeeded" "$(receipt_status "$MARKER_TX")" "0x1"
+check "guarded transaction succeeded" "$(receipt_status "$GUARDED_TX")" "0x1"
+check "marker and guarded transaction share a block" \
+    "$(receipt_block "$MARKER_TX")" "$(receipt_block "$GUARDED_TX")"
+check "guarded action produced expected state" "$(read_state)" "$STATE_AFTER"
 
-# The marker must be submitted first (fifo) so it executes before the guarded call in the block.
-MARKER_TX=$(send_async "$BUILDER_KEY" "$REGISTRY" "markCurrentBlockCredible()")
-GUARDED_TX=$(send_async "$USER_KEY" "$GUARD" "bump()")
-rpc evm_mine # seal ONE block containing both queued txs
-
-info "marker tx:  $MARKER_TX"
-info "guarded tx: $GUARDED_TX"
-check "marker tx succeeded"          "$(receipt_status "$MARKER_TX")"  "0x1"
-check "guarded tx succeeded"         "$(receipt_status "$GUARDED_TX")" "0x1"
-check "both txs in the same block"   "$(receipt_block "$MARKER_TX")"   "$(receipt_block "$GUARDED_TX")"
-check "counter incremented to 1"     "$(counter)"                      "1"
-
-# --------------------------------------------------------------------------------------------------
-# Case 2: non-credible block — guarded tx alone must revert.
-# --------------------------------------------------------------------------------------------------
-section "Case 2: non-credible block (guarded tx with no marker reverts)"
+section "Case 2: unmarked call while builder window is live"
 reset_state
-
-# Seed one credible block first. Without it lastCredibleBlock stays 0, and the blocks already mined
-# by deployment would put block.number - 0 past a small FAIL_OPEN_THRESHOLD override — tripping
-# fail-open, so the guarded tx would wrongly pass and this case would report a false failure. With a
-# recent credible block M seeded, the guarded tx below lands at M+1 (gap 1); since the guard rejects
-# a zero threshold, every deployable threshold is >= 1, so gap 1 is never > threshold and fail-open
-# stays inactive — leaving the block correctly non-credible.
-SEED_TX=$(send_async "$BUILDER_KEY" "$REGISTRY" "markCurrentBlockCredible()")
+SEED_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
 rpc evm_mine
-info "seeded credible block at $(receipt_block "$SEED_TX")"
-
-# The guarded tx's own block carries no marker, so it must revert.
-GUARDED_TX=$(send_async "$USER_KEY" "$GUARD" "bump()")
+GUARDED_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
 rpc evm_mine
-check "guarded tx reverted on-chain" "$(receipt_status "$GUARDED_TX")" "0x0"
-check "counter still 0"              "$(counter)"                      "0"
-
-# Static call at the now-current (non-credible) tip surfaces the revert reason. cast can't decode the
-# custom error without the ABI, so we match its 4-byte selector directly.
-NON_CREDIBLE_SIG=$(cast sig "NonCredibleBlock()") # 0x95ad9b59
-CALL_OUT=$(cast call --rpc-url "$RPC_URL" --from "$USER_ADDR" "$GUARD" "bump()" 2>&1 || true)
-if echo "$CALL_OUT" | grep -qi "$NON_CREDIBLE_SIG"; then
-    echo "  ${GREEN}PASS${NC} static call reverts with NonCredibleBlock()"; PASS_COUNT=$((PASS_COUNT + 1))
+check "guarded transaction reverted" "$(receipt_status "$GUARDED_TX")" "0x0"
+check "rejected call left target state unchanged" "$(read_state)" "$STATE_BEFORE"
+ERROR_SELECTOR=$(cast sig "$GUARD_ERROR")
+CALL_OUT=$(cast call --rpc-url "$RPC_URL" --from "$GUARDED_ADDRESS" \
+    "$TARGET_ADDRESS" $GUARDED_CALL 2>&1 || true)
+if grep -qi "$ERROR_SELECTOR" <<<"$CALL_OUT"; then
+    echo "  ${GREEN}PASS${NC} static call reverted with $GUARD_ERROR"
+    PASS_COUNT=$((PASS_COUNT + 1))
 else
-    echo "  ${RED}FAIL${NC} static call did not revert with NonCredibleBlock() (got: $CALL_OUT)"; FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "  ${RED}FAIL${NC} expected $GUARD_ERROR ($ERROR_SELECTOR), got: $CALL_OUT"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
-# --------------------------------------------------------------------------------------------------
-# Case 3: fail-open — after the builder stops marking for > threshold blocks, guarded tx passes.
-# --------------------------------------------------------------------------------------------------
-section "Case 3: fail-open once no credible block for > failOpenBlockThreshold blocks"
+section "Case 3: builder inactivity boundary and strict fail-open"
 reset_state
-
-THRESHOLD=$(cast call --rpc-url "$RPC_URL" "$GUARD" "failOpenBlockThreshold()(uint256)")
-info "failOpenBlockThreshold = $THRESHOLD"
-
-# Mark one block credible so lastCredibleBlock is set to a concrete block M.
-MARKER_TX=$(send_async "$BUILDER_KEY" "$REGISTRY" "markCurrentBlockCredible()")
+MARKER_TX=$(send_async "$MARKER_KEY" "$REGISTRY_ADDRESS" "$MARKER_CALL")
 rpc evm_mine
 M=$(receipt_block "$MARKER_TX")
-info "last credible block M = $M"
-
-# Advance so the NEXT sealed block is M+THRESHOLD (gap == threshold, NOT > threshold => still guarded).
-mine_blocks $(( THRESHOLD - 1 ))
-BOUNDARY_TX=$(send_async "$USER_KEY" "$GUARD" "bump()")
+mine_blocks $((FAIL_OPEN_THRESHOLD - 1))
+BOUNDARY_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
 rpc evm_mine
-check "at gap == threshold (block $(receipt_block "$BOUNDARY_TX")), guarded tx still reverts" \
-    "$(receipt_status "$BOUNDARY_TX")" "0x0"
-
-# One more block: gap == threshold+1 (> threshold) => fail-open active, guarded tx passes.
-OPEN_TX=$(send_async "$USER_KEY" "$GUARD" "bump()")
+check "gap == threshold still reverts" "$(receipt_status "$BOUNDARY_TX")" "0x0"
+check "boundary rejection left target state unchanged" "$(read_state)" "$STATE_BEFORE"
+OPEN_TX=$(send_async "$GUARDED_KEY" "$TARGET_ADDRESS" "$GUARDED_CALL")
 rpc evm_mine
-check "at gap > threshold (block $(receipt_block "$OPEN_TX")), fail-open lets guarded tx pass" \
-    "$(receipt_status "$OPEN_TX")" "0x1"
-check "counter incremented to 1 via fail-open" "$(counter)" "1"
+check "gap > threshold succeeds" "$(receipt_status "$OPEN_TX")" "0x1"
+check "fail-open call produced expected state" "$(read_state)" "$STATE_AFTER"
+info "last credible block=$M, threshold=$FAIL_OPEN_THRESHOLD"
 
-# --------------------------------------------------------------------------------------------------
-# Summary
-# --------------------------------------------------------------------------------------------------
 section "Summary: ${GREEN}${PASS_COUNT} passed${NC}, ${RED}${FAIL_COUNT} failed${NC}"
 [[ "$FAIL_COUNT" -eq 0 ]]

--- a/examples/credible-block/src/GuardedName.sol
+++ b/examples/credible-block/src/GuardedName.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {CredibleBlockGuard} from "credible-std/protection/credible_block/CredibleBlockGuard.sol";
+import {ICredibleRegistry} from "credible-std/protection/credible_block/ICredibleRegistry.sol";
+
+/// @notice String-valued fixture for exercising target-mode argument and state handling.
+contract GuardedName is CredibleBlockGuard {
+    string public name;
+
+    constructor(ICredibleRegistry credibleRegistry_, uint256 failOpenBlockThreshold_)
+        CredibleBlockGuard(credibleRegistry_, failOpenBlockThreshold_)
+    {}
+
+    function setName(string calldata newName) external onlyCredibleBlock {
+        name = newName;
+    }
+}

--- a/examples/credible-block/test/test-script-arguments.sh
+++ b/examples/credible-block/test/test-script-arguments.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/script/test-credible-upgrades.sh"
+PASS=0
+
+expect_ok() {
+    local expected="$1"; shift
+    local output
+    output=$("$SCRIPT" --validate-only "$@")
+    [[ "$output" == *"$expected"* ]] || {
+        echo "FAIL: expected '$expected', got '$output'" >&2; exit 1;
+    }
+    PASS=$((PASS + 1))
+}
+
+expect_fail() {
+    local expected="$1"; shift
+    local output
+    if output=$("$SCRIPT" --validate-only "$@" 2>&1); then
+        echo "FAIL: command unexpectedly succeeded: $*" >&2; exit 1
+    fi
+    [[ "$output" == *"$expected"* ]] || {
+        echo "FAIL: expected '$expected', got '$output'" >&2; exit 1;
+    }
+    PASS=$((PASS + 1))
+}
+
+expect_ok "mode=fixture"
+expect_ok "mode=target" \
+    --target-address 0x1111111111111111111111111111111111111111 \
+    --registry-address 0x2222222222222222222222222222222222222222 \
+    --guarded-call "bump()" --state-read-call "count()(uint256)" \
+    --state-before 0 --state-after 1 --expected-threshold 75
+expect_fail "unknown argument: --wat" --wat
+expect_fail "target mode requires --guarded-call" \
+    --target-address 0x1111111111111111111111111111111111111111 \
+    --registry-address 0x2222222222222222222222222222222222222222
+expect_fail "provide only one of --target-address and --target-deploy-command" \
+    --target-address 0x1111111111111111111111111111111111111111 \
+    --target-deploy-command "echo 0x1111111111111111111111111111111111111111"
+expect_fail "--expected-threshold must be a positive integer" --expected-threshold 0
+expect_fail "target-specific options require" --guarded-call "bump()"
+
+echo "$PASS argument parsing/failure-message tests passed"

--- a/examples/credible-block/test/test-script-arguments.sh
+++ b/examples/credible-block/test/test-script-arguments.sh
@@ -32,6 +32,13 @@ expect_ok "mode=target" \
     --registry-address 0x2222222222222222222222222222222222222222 \
     --guarded-call "bump()" --state-read-call "count()(uint256)" \
     --state-before 0 --state-after 1 --expected-threshold 75
+expect_ok "mode=target" \
+    --target-address 0x1111111111111111111111111111111111111111 \
+    --registry-address 0x2222222222222222222222222222222222222222 \
+    --guarded-call "setName(string)" --guarded-call-arg "hello world" \
+    --state-read-call "nameOf(address)(string)" \
+    --state-read-call-arg 0x3333333333333333333333333333333333333333 \
+    --state-before old --state-after "hello world"
 expect_fail "unknown argument: --wat" --wat
 expect_fail "target mode requires --guarded-call" \
     --target-address 0x1111111111111111111111111111111111111111 \

--- a/examples/credible-block/test/test-script-arguments.sh
+++ b/examples/credible-block/test/test-script-arguments.sh
@@ -38,6 +38,11 @@ expect_ok "mode=target" \
     --guarded-call "setName(string)" --guarded-call-arg "hello world" \
     --state-read-call "name()(string)" \
     --state-before '"old value"' --state-after '"hello world"'
+expect_ok "mode=target" \
+    --target-address 0x1111111111111111111111111111111111111111 \
+    --registry-address 0x2222222222222222222222222222222222222222 \
+    --guarded-call "setName(string)" --guarded-call-arg "" \
+    --state-read-call "name()(string)" --state-before '"old"' --state-after '""'
 expect_fail "unknown argument: --wat" --wat
 expect_fail "target mode requires --guarded-call" \
     --target-address 0x1111111111111111111111111111111111111111 \

--- a/examples/credible-block/test/test-script-arguments.sh
+++ b/examples/credible-block/test/test-script-arguments.sh
@@ -36,9 +36,8 @@ expect_ok "mode=target" \
     --target-address 0x1111111111111111111111111111111111111111 \
     --registry-address 0x2222222222222222222222222222222222222222 \
     --guarded-call "setName(string)" --guarded-call-arg "hello world" \
-    --state-read-call "nameOf(address)(string)" \
-    --state-read-call-arg 0x3333333333333333333333333333333333333333 \
-    --state-before old --state-after "hello world"
+    --state-read-call "name()(string)" \
+    --state-before '"old value"' --state-after '"hello world"'
 expect_fail "unknown argument: --wat" --wat
 expect_fail "target mode requires --guarded-call" \
     --target-address 0x1111111111111111111111111111111111111111 \

--- a/examples/credible-block/test/test-string-state.sh
+++ b/examples/credible-block/test/test-string-state.sh
@@ -10,8 +10,18 @@ TARGET_DEPLOY_COMMAND='cd "$REPO_ROOT" && FOUNDRY_PROFILE=credible-block forge c
     --registry-deploy-command "$REGISTRY_DEPLOY_COMMAND" \
     --target-deploy-command "$TARGET_DEPLOY_COMMAND" \
     --guarded-call "setName(string)" \
-    --guarded-call-arg "hello world" \
+    --guarded-call-arg "hello [world]" \
     --state-read-call "name()(string)" \
     --state-before '""' \
-    --state-after '"hello world"' \
+    --state-after '"hello [world]"' \
     --rpc-port "${RPC_PORT:-18545}"
+
+"$SCRIPT" \
+    --registry-deploy-command "$REGISTRY_DEPLOY_COMMAND" \
+    --target-deploy-command "$TARGET_DEPLOY_COMMAND" \
+    --guarded-call "setName(string)" \
+    --guarded-call-arg "" \
+    --state-read-call "name()(string)" \
+    --state-before '""' \
+    --state-after '""' \
+    --rpc-port "${EMPTY_RPC_PORT:-18546}"

--- a/examples/credible-block/test/test-string-state.sh
+++ b/examples/credible-block/test/test-string-state.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/script/test-credible-upgrades.sh"
+
+REGISTRY_DEPLOY_COMMAND='cd "$REPO_ROOT" && FOUNDRY_PROFILE=credible-block forge create examples/credible-block/src/CredibleRegistry.sol:CredibleRegistry --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json --constructor-args "$MARKER_ADDRESS" | jq -r ".deployedTo"'
+TARGET_DEPLOY_COMMAND='cd "$REPO_ROOT" && FOUNDRY_PROFILE=credible-block forge create examples/credible-block/src/GuardedName.sol:GuardedName --rpc-url "$RPC_URL" --private-key "$ADMIN_KEY" --broadcast --json --constructor-args "$REGISTRY_ADDRESS" "$EXPECTED_THRESHOLD" | jq -r ".deployedTo"'
+
+"$SCRIPT" \
+    --registry-deploy-command "$REGISTRY_DEPLOY_COMMAND" \
+    --target-deploy-command "$TARGET_DEPLOY_COMMAND" \
+    --guarded-call "setName(string)" \
+    --guarded-call-arg "hello world" \
+    --state-read-call "name()(string)" \
+    --state-before '""' \
+    --state-after '"hello world"' \
+    --rpc-port "${RPC_PORT:-18545}"


### PR DESCRIPTION
## Summary

- generalize the live-Anvil credible-block integration runner to test a caller-specified upgraded contract and registry configuration
- verify guard configuration, expected revert behavior, strict fail-open boundaries, and caller-provided state effects
- keep `GuardedCounter` as a clearly labeled default fixture and document real-upgrade usage
- add argument parsing and failure-message regression tests

## Validation

- `./examples/credible-block/test/test-script-arguments.sh` — 7 passed
- default live-Anvil fixture run — 14 passed, 0 failed
- configurable deployment-command live-Anvil run — 14 passed, 0 failed
- `bash -n` and `git diff --check` — passed