### PR TITLE
fix(adapters): align Curve and Tydro with production ABIs

### DIFF
--- a/examples/curve/src/CurveUsdProtocol.sol
+++ b/examples/curve/src/CurveUsdProtocol.sol
@@ -186,7 +186,10 @@ abstract contract CurveUsdControllerProtocolHelpers is Assertion {
     }
 
     function _wordArg(bytes memory input, uint256 argIndex) internal pure returns (bytes32 word) {
-        uint256 offset = 4 + argIndex * 32;
+        // `PhEvm.getAllCallInputs` returns selector-stripped ABI arguments. Do not skip
+        // another four bytes here: doing so shifts every explicit-account overload into
+        // the next ABI word and can make the health checks inspect an unrelated address.
+        uint256 offset = argIndex * 32;
         require(input.length >= offset + 32, "CurveUSD: calldata arg missing");
         assembly {
             word := mload(add(add(input, 0x20), offset))

--- a/examples/curve/test/CurveUsdProtocol.t.sol
+++ b/examples/curve/test/CurveUsdProtocol.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CurveUsdControllerProtocolHelpers} from "../src/CurveUsdProtocol.sol";
+
+contract CurveUsdAccountDecoderHarness is CurveUsdControllerProtocolHelpers {
+    constructor() CurveUsdControllerProtocolHelpers(address(0), address(0), 0, 0) {}
+
+    function triggers() external view override {}
+
+    function account(bytes4 selector, address caller, bytes calldata selectorStrippedArgs)
+        external
+        pure
+        returns (address)
+    {
+        return _curveUsdAccountFromCall(
+            CurveUsdTriggeredCall({
+                selector: selector, caller: caller, input: selectorStrippedArgs, callStart: 1, callEnd: 2
+            })
+        );
+    }
+}
+
+contract CurveUsdProtocolTest is Test {
+    CurveUsdAccountDecoderHarness internal decoder;
+    address internal caller = makeAddr("caller");
+    address internal borrower = makeAddr("borrower");
+    address internal callback = makeAddr("callback");
+
+    function setUp() public {
+        decoder = new CurveUsdAccountDecoderHarness();
+    }
+
+    function testCreateLoanExplicitAccountUsesFourthWord() public view {
+        bytes4 selector = bytes4(keccak256("create_loan(uint256,uint256,uint256,address,address,bytes)"));
+        bytes memory args = abi.encode(11, 22, 33, borrower, callback, hex"aabb");
+        assertEq(decoder.account(selector, caller, args), borrower);
+    }
+
+    function testBorrowMoreExplicitAccountUsesThirdWord() public view {
+        bytes4 selector = bytes4(keccak256("borrow_more(uint256,uint256,address,address)"));
+        bytes memory args = abi.encode(11, 22, borrower, callback);
+        assertEq(decoder.account(selector, caller, args), borrower);
+    }
+
+    function testRemoveCollateralExplicitAccountUsesSecondWord() public view {
+        bytes4 selector = bytes4(keccak256("remove_collateral(uint256,address)"));
+        bytes memory args = abi.encode(11, borrower);
+        assertEq(decoder.account(selector, caller, args), borrower);
+    }
+
+    function testLiquidationExplicitAccountUsesFirstWord() public view {
+        bytes4 selector = bytes4(keccak256("liquidate(address,uint256,uint256,address,bytes)"));
+        bytes memory args = abi.encode(borrower, 22, 33, callback, hex"ccdd");
+        assertEq(decoder.account(selector, caller, args), borrower);
+    }
+}

--- a/examples/tydro/README.md
+++ b/examples/tydro/README.md
@@ -1,6 +1,12 @@
 # tydro examples
 
-Assertion examples and supporting helpers extracted from the `ink/assertions` branch.
+Assertion examples for the Tydro deployment on Ink.
+
+The adapter is pinned to the explorer-verified revision-11 L2 Pool at
+`0x6a056dA055C616cd89dBcd0dC4b3f4E0F6162eb6`. Its five-argument
+`finalizeTransfer`, compact amount sentinels, collateral flag, and liquidation
+receive mode intentionally follow that verified implementation. Do not attach
+this adapter to a different Pool revision based on ABI resemblance alone.
 
 ## Build
 

--- a/examples/tydro/src/TydroOperationSafety.sol
+++ b/examples/tydro/src/TydroOperationSafety.sol
@@ -21,9 +21,8 @@ interface ITydroPoolCurrent {
         address asset,
         address from,
         address to,
-        uint256 amount,
-        uint256 scaledBalanceFromBefore,
-        uint256 scaledBalanceToBefore
+        uint256 scaledAmount,
+        uint256 scaledBalanceFromBefore
     ) external;
     function setUserUseReserveAsCollateralOnBehalfOf(address asset, bool useAsCollateral, address onBehalfOf) external;
     function setUserEModeOnBehalfOf(uint8 categoryId, address onBehalfOf) external;
@@ -94,10 +93,9 @@ contract TydroProtectionSuite is AaveV3LikeProtectionSuite {
             operation.kind = OperationKind.Borrow;
             operation.account = triggered.caller;
             operation.asset = _assetByL2Id(args);
-            // Borrow shares the compact uint128 max sentinel: the Pool reads type(uint128).max as a
-            // full type(uint256).max borrow, so the operation context must expand it the same way
-            // withdraw does, or downstream amount checks see a shortened value.
-            operation.amount = _decodeL2Amount(args, true);
+            // Revision 11 expands the compact max sentinel for withdraw/repay/liquidation,
+            // but not for borrow. A max uint128 borrow therefore remains uint128.max.
+            operation.amount = _decodeL2Amount(args, false);
             operation.increasesDebt = operation.amount != 0;
             return operation;
         }
@@ -126,13 +124,13 @@ contract TydroProtectionSuite is AaveV3LikeProtectionSuite {
             if (operation.amount == L2_MAX_AMOUNT) {
                 operation.amount = type(uint256).max;
             }
-            operation.metadata = abi.encode(((uint256(args2) >> 128) & 1) == 0);
+            operation.metadata = abi.encode(((uint256(args2) >> 128) & 1) != 0);
             return operation;
         }
 
         if (triggered.selector == ITydroL2Pool.setUserUseReserveAsCollateral.selector) {
             bytes32 args = abi.decode(triggered.input[4:], (bytes32));
-            bool useAsCollateral = ((uint256(args) >> 16) & 1) == 0;
+            bool useAsCollateral = ((uint256(args) >> 16) & 1) != 0;
 
             if (!useAsCollateral) {
                 operation.kind = OperationKind.DisableCollateral;
@@ -152,14 +150,14 @@ contract TydroProtectionSuite is AaveV3LikeProtectionSuite {
         operation.caller = triggered.caller;
 
         if (triggered.selector == ITydroPoolCurrent.finalizeTransfer.selector) {
-            (address asset, address from, address to, uint256 amount,,) =
-                abi.decode(triggered.input[4:], (address, address, address, uint256, uint256, uint256));
+            (address asset, address from, address to, uint256 scaledAmount,) =
+                abi.decode(triggered.input[4:], (address, address, address, uint256, uint256));
             operation.kind = OperationKind.TransferCollateral;
             operation.account = from;
             operation.asset = asset;
             operation.counterparty = to;
-            operation.amount = amount;
-            operation.reducesEffectiveCollateral = from != to && amount != 0;
+            operation.amount = scaledAmount;
+            operation.reducesEffectiveCollateral = from != to && scaledAmount != 0;
             return operation;
         }
 

--- a/examples/tydro/test/TydroOperationSafety.t.sol
+++ b/examples/tydro/test/TydroOperationSafety.t.sol
@@ -107,9 +107,8 @@ contract TydroOperationSafetyTest is Test, CredibleTest {
         assertTrue(suite.shouldCheckPostOperationSolvency(op));
     }
 
-    function testL2BorrowDecodesMaxAmountSentinel() public view {
-        // The compact uint128 max sentinel must expand to a full uint256 max borrow, matching how
-        // the Pool interprets it; a shortened value would misreport the operation amount.
+    function testL2BorrowKeepsMaxUint128Amount() public view {
+        // Verified revision 11 does not expand the max sentinel in decodeBorrowParams.
         bytes32 args = _packL2Amount(0, type(uint128).max);
 
         ILendingProtectionSuite.OperationContext memory op = suite.decodeOperation(
@@ -119,7 +118,7 @@ contract TydroOperationSafetyTest is Test, CredibleTest {
         assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.Borrow));
         assertEq(op.account, caller);
         assertEq(op.asset, reserve);
-        assertEq(op.amount, type(uint256).max);
+        assertEq(op.amount, type(uint128).max);
         assertTrue(op.increasesDebt);
         assertTrue(suite.shouldCheckPostOperationSolvency(op));
     }
@@ -184,14 +183,14 @@ contract TydroOperationSafetyTest is Test, CredibleTest {
         );
 
         assertEq(aTokenOp.amount, type(uint256).max);
-        assertTrue(abi.decode(aTokenOp.metadata, (bool)));
+        assertFalse(abi.decode(aTokenOp.metadata, (bool)));
         assertEq(underlyingOp.amount, type(uint256).max);
-        assertFalse(abi.decode(underlyingOp.metadata, (bool)));
+        assertTrue(abi.decode(underlyingOp.metadata, (bool)));
     }
 
     function testL2DisableCollateralOnlyTriggersWhenTurningOff() public view {
-        bytes32 enableArgs = bytes32(uint256(0)); // bit clear means enable collateral
-        bytes32 disableArgs = bytes32(uint256(1) << 16); // bit set means disable collateral
+        bytes32 enableArgs = bytes32(uint256(1) << 16); // bit set means enable collateral
+        bytes32 disableArgs = bytes32(uint256(0)); // bit clear means disable collateral
 
         ILendingProtectionSuite.OperationContext memory disableOp = suite.decodeOperation(
             _triggered(
@@ -218,19 +217,19 @@ contract TydroOperationSafetyTest is Test, CredibleTest {
 
     function testFinalizeTransferUsesCanonicalSelectorAndAmount() public {
         address recipient = makeAddr("recipient");
-        uint256 amount = 42e18;
+        uint256 scaledAmount = 42e18;
         bytes memory input =
-            abi.encodeCall(ITydroPoolCurrent.finalizeTransfer, (reserve, caller, recipient, amount, 0, 0));
+            abi.encodeCall(ITydroPoolCurrent.finalizeTransfer, (reserve, caller, recipient, scaledAmount, 100e18));
 
         ILendingProtectionSuite.OperationContext memory op =
             suite.decodeOperation(_triggered(ITydroPoolCurrent.finalizeTransfer.selector, input));
 
-        assertEq(ITydroPoolCurrent.finalizeTransfer.selector, IAaveV3LikePool.finalizeTransfer.selector);
+        assertTrue(ITydroPoolCurrent.finalizeTransfer.selector != IAaveV3LikePool.finalizeTransfer.selector);
         assertEq(uint256(op.kind), uint256(ILendingProtectionSuite.OperationKind.TransferCollateral));
         assertEq(op.account, caller);
         assertEq(op.asset, reserve);
         assertEq(op.counterparty, recipient);
-        assertEq(op.amount, amount);
+        assertEq(op.amount, scaledAmount);
         assertTrue(op.reducesEffectiveCollateral);
         assertTrue(suite.shouldCheckPostOperationSolvency(op));
     }


### PR DESCRIPTION
## Summary
- decode Curve explicit-account overloads from selector-stripped arguments
- match Tydro Ink revision-11 finalizeTransfer ABI and compact bit semantics
- add production-faithful Curve and Tydro regression coverage

## Validation
- `FOUNDRY_PROFILE=curve forge test --offline --match-contract CurveUsdProtocolTest`
- `FOUNDRY_PROFILE=tydro pcl test`

Linear: ENG-4231