### PR TITLE
fix(accounting): bind protocol assertions to actual value movement

### DIFF
--- a/examples/cap/README.md
+++ b/examples/cap/README.md
@@ -26,26 +26,15 @@ Verified with `pcl` 1.4.0 (commit `a600e1d`).
 - `CapRedemptionGateAssertion.sol` — currently registers no triggers. Strategy divest inflows net
   against redemption outflows in the executor, while the watcher denominator is idle custody.
 
-### Liquidations — debt is repaid, proceeds stay in the protocol
+### Quarantined liquidation and OFT prototypes
 
-- `CapLiquidationAssertion.sol` — deployed against the `Lender`. A liquidation that moves value
-  must strictly reduce the borrower's debt for the liquidated asset (no seizing collateral without
-  repaying debt), and the vault's claimable backing (`availableBalance = totalSupplies -
-  totalBorrows`) may not fall below its pre-call value minus the restaker interest the liquidation
-  legitimately realizes (proceeds stay in the protocol as backing rather than draining the vault).
-  Each check is scoped per `liquidate` call via PreCall/PostCall snapshots.
+- `CapLiquidationAssertion.sol` — registers no triggers. Reported debt and available-balance deltas
+  do not prove that realized repayment value stayed in the authorized protocol boundary.
 - `CapLiquidationHelpers.sol` — triggered-call resolution and fork-aware reads (all in asset units).
 - `CapLiquidationInterfaces.sol`
 
-### Cross-chain backing — keep the OFT lockbox honest
-
-- `CapOFTLockboxBackingAssertion.sol` — on the home chain, the gross outflow of locked cUSD from the
-  `OFTLockbox` (LayerZero `OFTAdapter`) must be covered by endpoint-driven `lzReceive` calls, each
-  credited at `min(message-authorized amount, amount actually released inside the call)`. Capping by
-  the decoded OFT message amount binds the release to what the remote chain verifiably burned (a
-  faulty/upgraded adapter over-releasing trips); the in-call release floor gates success (a reverted
-  receive credits nothing). A drain therefore cannot ride alongside an unrelated, reverted, or
-  dust-sized bridge-in and leave remote `L2Token` supply unbacked.
+- `CapOFTLockboxBackingAssertion.sol` — registers no triggers until the live endpoint, origin peer,
+  token, conversion domain, and intended recipient are all bound to each credited receive.
 - `CapOFTLockboxInterfaces.sol`
 
 ### Existing examples

--- a/examples/cap/src/CapLiquidationAssertion.sol
+++ b/examples/cap/src/CapLiquidationAssertion.sol
@@ -33,8 +33,8 @@ contract CapLiquidationAssertion is CapLiquidationHelpers {
     }
 
     function triggers() external view override {
-        registerFnCallTrigger(this.assertLiquidationReducesDebt.selector, ICapLenderLike.liquidate.selector);
-        registerFnCallTrigger(this.assertLiquidationRetainsBacking.selector, ICapLenderLike.liquidate.selector);
+        // Quarantined: reported debt/backing deltas do not prove that liquidation repayment value
+        // remained inside the authorized protocol accounting boundary.
     }
 
     /// @notice A value-moving liquidation must reduce the protocol-reported debt.

--- a/examples/cap/src/CapOFTLockboxBackingAssertion.sol
+++ b/examples/cap/src/CapOFTLockboxBackingAssertion.sol
@@ -59,11 +59,8 @@ contract CapOFTLockboxBackingAssertion is Assertion {
     }
 
     function triggers() external view override {
-        // Covers every transaction that calls the adapter, including a valid receive combined
-        // with an unrelated outflow. The ERC-20 change trigger additionally covers direct token
-        // allowance pulls that never call the adapter itself.
-        registerTxEndTrigger(this.assertReleaseOnlyOnReceive.selector);
-        registerErc20ChangeTrigger(this.assertReleaseOnlyOnReceive.selector, LOCKED_TOKEN);
+        // Quarantined: payload amount alone does not bind the configured origin peer, intended
+        // recipient, live endpoint/token relationship, or production conversion domain.
     }
 
     /// @notice Locked cUSD may only leave the lockbox via a verified endpoint `lzReceive`, and only

--- a/examples/cap/test/CapLiquidationAssertion.t.sol
+++ b/examples/cap/test/CapLiquidationAssertion.t.sol
@@ -117,13 +117,23 @@ contract CapLiquidationAssertionTest is Test, CredibleTest {
         cl.assertion(address(lender), createData, CapLiquidationAssertion.assertLiquidationRetainsBacking.selector);
     }
 
-    function testHonestLiquidationReducesDebt() public {
+    function testPublishedWrapperCannotRegisterUnsafeChecks() public {
+        CapLiquidationAssertion assertion = new CapLiquidationAssertion();
+        vm.mockCallRevert(
+            address(uint160(uint256(keccak256("SpecRecorder")))),
+            bytes(""),
+            bytes("quarantined wrapper registered a trigger")
+        );
+        assertion.triggers();
+    }
+
+    function retiredHonestLiquidationReducesDebt() public {
         _armReducesDebt();
         vm.prank(liquidator);
         lender.liquidate(agent, usdc, 60e6, 0);
     }
 
-    function testNoRepayLiquidationTrips() public {
+    function retiredNoRepayLiquidationTrips() public {
         lender.setMode(MockLender.Mode.NoRepay);
         _armReducesDebt();
         vm.expectRevert(bytes("CapLiquidation: debt not reduced"));
@@ -131,7 +141,7 @@ contract CapLiquidationAssertionTest is Test, CredibleTest {
         lender.liquidate(agent, usdc, 60e6, 0);
     }
 
-    function testPartialLiquidationWithHighInterestPasses() public {
+    function retiredPartialLiquidationWithHighInterestPasses() public {
         // `debt()` includes the accrued interest before the call, so repaying five units still
         // lowers the reported debt from 110 to 105.
         lender.seed(agent, usdc, 100e6, 10e6, 1_000e6);
@@ -140,20 +150,20 @@ contract CapLiquidationAssertionTest is Test, CredibleTest {
         lender.liquidate(agent, usdc, 5e6, 0);
     }
 
-    function testZeroAmountLiquidationIgnored() public {
+    function retiredZeroAmountLiquidationIgnored() public {
         _armReducesDebt();
         // No value moves; the debt-reduction check skips it rather than false-tripping.
         vm.prank(liquidator);
         lender.liquidate(agent, usdc, 0, 0);
     }
 
-    function testHonestLiquidationRetainsBacking() public {
+    function retiredHonestLiquidationRetainsBacking() public {
         _armRetainsBacking();
         vm.prank(liquidator);
         lender.liquidate(agent, usdc, 60e6, 0);
     }
 
-    function testDrainBackingTrips() public {
+    function retiredDrainBackingTrips() public {
         lender.setMode(MockLender.Mode.DrainBacking);
         _armRetainsBacking();
         vm.expectRevert(bytes("CapLiquidation: backing drained by liquidation"));
@@ -161,7 +171,7 @@ contract CapLiquidationAssertionTest is Test, CredibleTest {
         lender.liquidate(agent, usdc, 60e6, 0);
     }
 
-    function testDeploys() public {
+    function retiredDeploys() public {
         CapLiquidationAssertion assertion = new CapLiquidationAssertion();
         assertTrue(address(assertion) != address(0));
     }

--- a/examples/cap/test/CapLiquidationAssertion.t.sol
+++ b/examples/cap/test/CapLiquidationAssertion.t.sol
@@ -120,7 +120,7 @@ contract CapLiquidationAssertionTest is Test, CredibleTest {
     function testPublishedWrapperCannotRegisterUnsafeChecks() public {
         CapLiquidationAssertion assertion = new CapLiquidationAssertion();
         vm.mockCallRevert(
-            address(uint160(uint256(keccak256("SpecRecorder")))),
+            address(uint160(uint256(keccak256("TriggerRecorder")))),
             bytes(""),
             bytes("quarantined wrapper registered a trigger")
         );

--- a/examples/cap/test/CapOFTLockboxBackingAssertion.t.sol
+++ b/examples/cap/test/CapOFTLockboxBackingAssertion.t.sol
@@ -111,7 +111,7 @@ contract CapOFTLockboxBackingAssertionTest is Test, CredibleTest {
         CapOFTLockboxBackingAssertion assertion =
             new CapOFTLockboxBackingAssertion(address(lockbox), address(cusd), address(endpoint), 1e12);
         vm.mockCallRevert(
-            address(uint160(uint256(keccak256("SpecRecorder")))),
+            address(uint160(uint256(keccak256("TriggerRecorder")))),
             bytes(""),
             bytes("quarantined wrapper registered a trigger")
         );

--- a/examples/cap/test/CapOFTLockboxBackingAssertion.t.sol
+++ b/examples/cap/test/CapOFTLockboxBackingAssertion.t.sol
@@ -107,20 +107,31 @@ contract CapOFTLockboxBackingAssertionTest is Test, CredibleTest {
         _arm(address(lockbox));
     }
 
-    function testReceiveReleaseAllowed() public {
+    function testPublishedWrapperCannotRegisterUnsafeChecks() public {
+        CapOFTLockboxBackingAssertion assertion =
+            new CapOFTLockboxBackingAssertion(address(lockbox), address(cusd), address(endpoint), 1e12);
+        vm.mockCallRevert(
+            address(uint160(uint256(keccak256("SpecRecorder")))),
+            bytes(""),
+            bytes("quarantined wrapper registered a trigger")
+        );
+        assertion.triggers();
+    }
+
+    function retiredReceiveReleaseAllowed() public {
         _arm();
         // Verified bridge-in: endpoint drives lzReceive, releasing locked cUSD.
         endpoint.deliver(address(lockbox), recipient, 100e18);
     }
 
-    function testUnauthorizedDrainTrips() public {
+    function retiredUnauthorizedDrainTrips() public {
         _arm();
         vm.expectRevert(bytes("CapLockbox: locked cUSD released beyond verified receives"));
         vm.prank(attacker);
         lockbox.drain(attacker, 100e18);
     }
 
-    function testDrainRidingVerifiedReceiveTrips() public {
+    function retiredDrainRidingVerifiedReceiveTrips() public {
         AttackBundler bundler = new AttackBundler(endpoint, lockbox);
         _arm();
         // A 1 cUSD verified bridge-in cannot launder a 500 cUSD drain in the same transaction:
@@ -130,7 +141,7 @@ contract CapOFTLockboxBackingAssertionTest is Test, CredibleTest {
         bundler.rideAlong(recipient, 1e18, attacker, 500e18);
     }
 
-    function testFaultyAdapterOverReleaseTrips() public {
+    function retiredFaultyAdapterOverReleaseTrips() public {
         // A faulty/upgraded adapter releases 500x what the verified message authorizes. Crediting
         // by the message amount (not the adapter's own transfer logs) catches the excess.
         MockLockbox faulty = new MockLockbox(address(cusd), address(endpoint), 500);
@@ -140,7 +151,7 @@ contract CapOFTLockboxBackingAssertionTest is Test, CredibleTest {
         endpoint.deliver(address(faulty), recipient, 1e18);
     }
 
-    function testDeploys() public {
+    function retiredDeploys() public {
         CapOFTLockboxBackingAssertion assertion =
             new CapOFTLockboxBackingAssertion(address(lockbox), address(cusd), address(endpoint), 1e12);
         assertTrue(address(assertion) != address(0));

--- a/examples/royco/README.md
+++ b/examples/royco/README.md
@@ -2,8 +2,9 @@
 
 Assertion examples and supporting helpers extracted from the `royco-dawn` branch.
 
-The active bundle is narrowed to v1.2-compatible NAV conservation, ordinary non-bypass coverage,
-self-liquidation deleveraging, and state-effect checks around tranche operations. The invalid
+The Kernel bundle is narrowed to v1.2-compatible NAV conservation, ordinary non-bypass coverage,
+and self-liquidation deleveraging. The tranche operation wrapper is quarantined and registers no
+triggers because share and return deltas do not prove the official asset movement. The invalid
 perpetual-health predicate, preview-to-preview recovery checks, v1.2 virtual-offset deposit formula,
 and idle-balance cumulative-flow policies are not registered. Live mixed v1.2/v1.3 deployments
 must still be version-bound before activation.

--- a/examples/royco/src/RoycoVaultTrancheAssertion.sol
+++ b/examples/royco/src/RoycoVaultTrancheAssertion.sol
@@ -20,6 +20,7 @@ contract RoycoVaultTrancheAssertion is RoycoVaultTrancheOperationAssertion {
     }
 
     function triggers() external view override {
-        _registerOperationInvariantTriggers();
+        // Quarantined: preview, return, and share deltas do not prove the official asset transfer
+        // into the Kernel on deposit or to the receiver on redeem.
     }
 }

--- a/examples/royco/src/RoycoVaultTrancheAssertion.sol
+++ b/examples/royco/src/RoycoVaultTrancheAssertion.sol
@@ -7,7 +7,7 @@ import {RoycoVaultTrancheOperationAssertion} from "./RoycoVaultTrancheOperationA
 
 /// @title RoycoVaultTrancheAssertion
 /// @author Phylax Systems
-/// @notice Executive summary: this bundle checks the tranche-facing share mechanics and call
+/// @notice This bundle checks the tranche-facing share mechanics and call
 ///         ordering that LPs rely on. It keeps deposit/redeem previews aligned with actual
 ///         execution, verifies receiver/owner share effects, and ensures redeem paths call
 ///         into the kernel before shares are burned.

--- a/examples/royco/test/RoycoVaultTrancheAssertion.t.sol
+++ b/examples/royco/test/RoycoVaultTrancheAssertion.t.sol
@@ -158,7 +158,7 @@ contract RoycoVaultTrancheAssertionTest is Test, CredibleTest {
         RoycoVaultTrancheAssertion assertion =
             new RoycoVaultTrancheAssertion(address(tranche), address(kernel), RoycoTrancheType.SENIOR);
         vm.mockCallRevert(
-            address(uint160(uint256(keccak256("SpecRecorder")))),
+            address(uint160(uint256(keccak256("TriggerRecorder")))),
             bytes(""),
             bytes("quarantined wrapper registered a trigger")
         );

--- a/examples/royco/test/RoycoVaultTrancheAssertion.t.sol
+++ b/examples/royco/test/RoycoVaultTrancheAssertion.t.sol
@@ -115,14 +115,14 @@ contract RoycoVaultTrancheAssertionTest is Test, CredibleTest {
         kernel.setTranche(address(tranche));
     }
 
-    function testDepositMintsExactUserAndProtocolFeeShares() public {
+    function retiredDepositMintsExactUserAndProtocolFeeShares() public {
         kernel.setExpectedFeeShares(5 ether);
         _arm(RoycoVaultTrancheOperationAssertion.assertDepositPreviewConsistency.selector);
 
         tranche.deposit(100 ether, user);
     }
 
-    function testDepositRejectsExtraThirdPartyMint() public {
+    function retiredDepositRejectsExtraThirdPartyMint() public {
         kernel.setExpectedFeeShares(5 ether);
         tranche.configureExtraMint(attacker, 1);
         _arm(RoycoVaultTrancheOperationAssertion.assertDepositPreviewConsistency.selector);
@@ -131,14 +131,14 @@ contract RoycoVaultTrancheAssertionTest is Test, CredibleTest {
         tranche.deposit(100 ether, user);
     }
 
-    function testDepositAccountsForFeeSharesWhenReceiverIsFeeRecipient() public {
+    function retiredDepositAccountsForFeeSharesWhenReceiverIsFeeRecipient() public {
         kernel.setExpectedFeeShares(7 ether);
         _arm(RoycoVaultTrancheOperationAssertion.assertDepositPreviewConsistency.selector);
 
         tranche.deposit(100 ether, feeRecipient);
     }
 
-    function testRedeemAccountsForFeeSharesWhenOwnerIsFeeRecipient() public {
+    function retiredRedeemAccountsForFeeSharesWhenOwnerIsFeeRecipient() public {
         tranche.seed(feeRecipient, 100 ether);
         kernel.setExpectedFeeShares(150 ether);
         _arm(RoycoVaultTrancheOperationAssertion.assertRedeemPreviewConsistency.selector);
@@ -152,5 +152,16 @@ contract RoycoVaultTrancheAssertionTest is Test, CredibleTest {
             abi.encode(address(tranche), address(kernel), RoycoTrancheType.SENIOR)
         );
         cl.assertion(address(tranche), createData, fnSelector);
+    }
+
+    function testPublishedWrapperCannotRegisterUnsafeChecks() public {
+        RoycoVaultTrancheAssertion assertion =
+            new RoycoVaultTrancheAssertion(address(tranche), address(kernel), RoycoTrancheType.SENIOR);
+        vm.mockCallRevert(
+            address(uint160(uint256(keccak256("SpecRecorder")))),
+            bytes(""),
+            bytes("quarantined wrapper registered a trigger")
+        );
+        assertion.triggers();
     }
 }

--- a/examples/veda/README.md
+++ b/examples/veda/README.md
@@ -2,6 +2,9 @@
 
 Assertion examples and supporting helpers extracted from the `ink/assertions` branch.
 
+Every zero-asset-amount exit is treated as a share-only burn, regardless of the supplied asset
+address, and requires an explicitly authorized caller.
+
 ## Build
 
 ```sh

--- a/examples/veda/src/BoringVaultAssertion.sol
+++ b/examples/veda/src/BoringVaultAssertion.sol
@@ -127,11 +127,14 @@ contract BoringVaultAssertion is BoringVaultHelpers {
         require(postSupply == preSupply - shareAmount, "BoringVault: exit supply delta mismatch");
         require(postOwnerShares == preOwnerShares - shareAmount, "BoringVault: exit share delta mismatch");
 
-        if (asset == address(0)) {
-            require(assetAmount == 0, "BoringVault: nonzero amount on share-only exit");
+        // BoringVault skips the transfer whenever `assetAmount == 0`, regardless of the supplied
+        // asset address. Every zero-amount share burn is therefore a share-only operation and must
+        // use an explicitly authorized production path.
+        if (assetAmount == 0) {
             _requireShareOnlyCaller(ctx);
             return;
         }
+        require(asset != address(0), "BoringVault: zero asset");
 
         uint256 preVaultAssets = _assetBalanceAt(asset, vault, beforeFork);
         uint256 postVaultAssets = _assetBalanceAt(asset, vault, afterFork);

--- a/examples/veda/test/BoringVaultAssertion.t.sol
+++ b/examples/veda/test/BoringVaultAssertion.t.sol
@@ -87,10 +87,19 @@ contract BoringVaultAssertionTest is Test, CredibleTest {
         vault.enter(address(0), address(0), 0, alice, 100 ether);
     }
 
-    function testNonzeroAssetZeroAmountExitPasses() public {
+    function testAuthorizedNonzeroAssetZeroAmountExitPasses() public {
         vault.enter(address(0), address(0), 0, alice, 100 ether);
         _arm(BoringVaultAssertion.assertExitAccounting.selector);
 
+        vault.exit(alice, address(asset), 0, alice, 50 ether);
+    }
+
+    function testUnauthorizedNonzeroAssetZeroAmountExitTrips() public {
+        vault.enter(address(0), address(0), 0, alice, 100 ether);
+        _arm(BoringVaultAssertion.assertExitAccounting.selector);
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("BoringVault: unauthorized share-only caller"));
         vault.exit(alice, address(asset), 0, alice, 50 ether);
     }
 

--- a/src/protection/swaps/examples/CowSettlementAssertion.sol
+++ b/src/protection/swaps/examples/CowSettlementAssertion.sol
@@ -30,10 +30,8 @@ contract CowSettlementAssertion is CowSettlementHelpers {
 
     /// @notice Registers the per-token outflow reconciliation at transaction end and on token changes.
     function triggers() external view override {
-        registerTxEndTrigger(this.assertBufferConserved.selector);
-        for (uint256 i; i < bufferTokens.length; ++i) {
-            registerErc20ChangeTrigger(this.assertBufferConserved.selector, bufferTokens[i]);
-        }
+        // Quarantined: aggregate Trade sell volume is not causally tied to watched-token buffer
+        // outflow and can authorize an unrelated drain in the same settlement transaction.
     }
 
     /// @notice Watched-token outflow must be explained by same-token trade volume or a DAO sweep.

--- a/test/protection/swaps/CowSettlementAssertion.t.sol
+++ b/test/protection/swaps/CowSettlementAssertion.t.sol
@@ -200,24 +200,37 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         assertEq(IGPv2SettlementLike.swap.selector, bytes4(0x845a101f), "swap mainnet selector");
     }
 
+    function testPublishedWrapperCannotRegisterUnsafeChecks() public {
+        address[] memory bufferTokens = new address[](1);
+        bufferTokens[0] = address(dai);
+        CowSettlementAssertion assertion =
+            new CowSettlementAssertion(address(settlement), sweepRecipient, bufferTokens, 0);
+        vm.mockCallRevert(
+            address(uint160(uint256(keccak256("SpecRecorder")))),
+            bytes(""),
+            bytes("quarantined wrapper registered a trigger")
+        );
+        assertion.triggers();
+    }
+
     // ----------------------------------------------------------------
     //  Inventory protection — assertBufferConserved
     // ----------------------------------------------------------------
 
-    function testAuthorizedBufferSweepPasses() public {
+    function retiredAuthorizedBufferSweepPasses() public {
         _armBuffer();
         vm.prank(solver, solver);
         settlement.sweep(address(dai), sweepRecipient, 50_000e18);
     }
 
-    function testBufferDrainToUnauthorizedRecipientTrips() public {
+    function retiredBufferDrainToUnauthorizedRecipientTrips() public {
         _armBuffer();
         vm.expectRevert(bytes("CowSettlement: external buffer drain"));
         vm.prank(attacker, attacker);
         settlement.drainTo(address(dai), attacker, 200_000e18);
     }
 
-    function testSameTransactionPrefundingDoesNotHideGrossOutflow() public {
+    function retiredSameTransactionPrefundingDoesNotHideGrossOutflow() public {
         uint256 amount = 100_000e18;
         MockAllowanceDrainer drainer = new MockAllowanceDrainer();
         settlement.approveToken(address(dai), address(drainer));
@@ -231,7 +244,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         drainer.prefundSettleAndDrain(dai, settlement, attacker, amount);
     }
 
-    function testSettlementCallOnlyAuthorizesReportedTokenVolume() public {
+    function retiredSettlementCallOnlyAuthorizesReportedTokenVolume() public {
         MockAllowanceDrainer drainer = new MockAllowanceDrainer();
         settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
         settlement.approveToken(address(buyToken), address(drainer));
@@ -242,7 +255,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         drainer.settleAndDrain(buyToken, settlement, attacker, SURPLUS);
     }
 
-    function testHonestTradeCanPaySweepSafe() public {
+    function retiredHonestTradeCanPaySweepSafe() public {
         settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
         settlement.configureReceiver(sweepRecipient);
 
@@ -251,7 +264,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         _settle();
     }
 
-    function testTradeToSweepSafeCannotAuthorizeAdditionalDrain() public {
+    function retiredTradeToSweepSafeCannotAuthorizeAdditionalDrain() public {
         MockAllowanceDrainer drainer = new MockAllowanceDrainer();
         settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
         settlement.configureReceiver(sweepRecipient);
@@ -268,7 +281,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
     ///      indistinguishable from a trade paying the Safe combined with an equal-sized drain
     ///      (Trade events carry no receiver), so the bundle quarantines the combination instead of
     ///      crediting both allowances. This documents that known false positive.
-    function testTradeVolumePlusSeparateSweepIsQuarantined() public {
+    function retiredTradeVolumePlusSeparateSweepIsQuarantined() public {
         settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
         buyToken.mint(address(settlement), 50_000e18);
 
@@ -278,7 +291,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         settlement.settleAndSweep(address(buyToken), sweepRecipient, 50_000e18);
     }
 
-    function testWatchedTokenCanBeUsedAsSettlementLiquidity() public {
+    function retiredWatchedTokenCanBeUsedAsSettlementLiquidity() public {
         settlement.configureTrade(SELL, BUY, 0, MockGPv2Settlement.Mode.Honest);
 
         _armBufferFor(address(buyToken));

--- a/test/protection/swaps/CowSettlementAssertion.t.sol
+++ b/test/protection/swaps/CowSettlementAssertion.t.sol
@@ -206,7 +206,7 @@ contract CowSettlementAssertionTest is Test, CredibleTest {
         CowSettlementAssertion assertion =
             new CowSettlementAssertion(address(settlement), sweepRecipient, bufferTokens, 0);
         vm.mockCallRevert(
-            address(uint160(uint256(keccak256("SpecRecorder")))),
+            address(uint160(uint256(keccak256("TriggerRecorder")))),
             bytes(""),
             bytes("quarantined wrapper registered a trigger")
         );


### PR DESCRIPTION
## Summary
- require authorization for every Veda zero-amount share-only exit, including nonzero asset addresses
- quarantine Cap liquidation/OFT, Royco tranche, and CoW buffer checks whose current observations cannot prove causal value movement
- update public protocol docs to describe unavailable protections accurately

## Validation
- `FOUNDRY_PROFILE=veda pcl test` (8 passing)
- Cap, Royco, and root profiles build offline

Linear: ENG-4233