### PR TITLE
fix(phevm): remove unsupported persistent cheatcodes

### DIFF
--- a/src/PhEvm.sol
+++ b/src/PhEvm.sol
@@ -350,28 +350,6 @@ interface PhEvm {
     function getLogsForCall(LogQuery calldata query, uint256 callId) external view returns (Log[] memory logs);
 
     // ---------------------------------------------------------------
-    //  V2: Persistent assertion storage
-    // ---------------------------------------------------------------
-
-    /// @notice Write a bytes32 value to persistent assertion storage.
-    /// @param key The storage key.
-    /// @param value The value to store.
-    function store(bytes32 key, bytes32 value) external;
-
-    /// @notice Read a bytes32 value from persistent assertion storage.
-    /// @param key The storage key.
-    /// @return value The stored value.
-    function load(bytes32 key) external view returns (bytes32 value);
-
-    /// @notice Check if a key exists in persistent assertion storage.
-    /// @param key The storage key.
-    /// @return doesExist True if the key has been written to.
-    function exists(bytes32 key) external view returns (bool doesExist);
-
-    /// @notice Returns remaining storage slots available to this assertion.
-    function values_left() external view returns (uint256 remaining);
-
-    // ---------------------------------------------------------------
     //  V2: Mapping tracing
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Remove the persistent assertion-storage functions that are not implemented by `credible-sdk`.

## Context
`PhEvm.sol` exposed four selectors that the executor does not define or dispatch, so assertion authors could compile calls that always fail at runtime.

## Changes
- Remove `store(bytes32,bytes32)`
- Remove `load(bytes32)`
- Remove `exists(bytes32)`
- Remove `values_left()`

## Testing
- `forge fmt --check src/PhEvm.sol`
- `forge build --contracts src/PhEvm.sol`

## Breaking Changes
Source-breaking only for callers of these unsupported functions; there is no working runtime behavior to migrate.

Prompted by: Odysseus