### PR TITLE
chore(interfaces): sync from released SDK artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,22 @@ on:
       - "*.*.*"
 
 jobs:
+  interfaces-in-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Require a released SDK interface lock
+        run: |
+          test -f credible-sdk-interfaces.lock || {
+            echo "credible-sdk-interfaces.lock is missing; sync a released credible-sdk first" >&2
+            exit 1
+          }
+          scripts/sync-credible-interfaces.sh --check
+
   release-github:
+    needs: interfaces-in-sync
     permissions:
       contents: write
     uses: phylaxsystems/actions/.github/workflows/release-github.yaml@main

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
 
 jobs:
+  interface-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Test released-interface synchronization
+        run: scripts/test-sync-credible-interfaces.sh
+
+      - name: Check pinned SDK interfaces
+        if: ${{ hashFiles('credible-sdk-interfaces.lock') != '' }}
+        run: scripts/sync-credible-interfaces.sh --check
+
   solidity-base:
     uses: phylaxsystems/actions/.github/workflows/solidity-base.yaml@main
     with:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ Standard library for implementing assertions in the Phylax Credible Layer (PCL).
 
 Full API documentation is available at: https://phylaxsystems.github.io/credible-std
 
+## SDK interface compatibility
+
+`IAssertion.sol`, `PhEvm.sol`, `TriggerRecorder.sol`, and `SpecRecorder.sol` are
+published by `credible-sdk` releases and vendored here so Foundry users do not
+need network access while compiling. To update them after an SDK release:
+
+```bash
+scripts/sync-credible-interfaces.sh <sdk-version>
+```
+
+The command verifies the release checksum, updates all four interfaces, and
+writes `credible-sdk-interfaces.lock`. CI compares the vendored files with that
+exact released archive, and the release workflow refuses to publish
+`credible-std` without a valid lock.
+
 ## Examples
 
 Assertion Book examples live in `examples/assertions-book`; micro-pattern examples

--- a/scripts/sync-credible-interfaces.sh
+++ b/scripts/sync-credible-interfaces.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly ROOT="${CREDIBLE_STD_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+readonly LOCK_FILE="${ROOT}/credible-sdk-interfaces.lock"
+readonly RELEASE_BASE_URL="${CREDIBLE_SDK_RELEASE_BASE_URL:-https://github.com/phylaxsystems/credible-sdk/releases/download}"
+readonly INTERFACES=(IAssertion.sol PhEvm.sol TriggerRecorder.sol SpecRecorder.sol)
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/sync-credible-interfaces.sh <sdk-version>
+  scripts/sync-credible-interfaces.sh --check
+
+Sync copies the canonical Solidity interfaces from a credible-sdk release and
+writes credible-sdk-interfaces.lock. Check verifies the vendored files against
+the exact released archive and pinned SHA-256.
+EOF
+}
+
+validate_version() {
+  local version="$1"
+  if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+    echo "invalid SDK release version: ${version}" >&2
+    exit 1
+  fi
+}
+
+download_release() {
+  local version="$1"
+  local destination="$2"
+  local archive_name="credible-solidity-interfaces-${version}.tar.gz"
+  local archive="${destination}/${archive_name}"
+  local checksum_file="${archive}.sha256"
+  local remote_sha
+  local actual_sha
+
+  curl -fsSL "${RELEASE_BASE_URL}/${version}/${archive_name}" -o "${archive}"
+  curl -fsSL "${RELEASE_BASE_URL}/${version}/${archive_name}.sha256" -o "${checksum_file}"
+
+  remote_sha="$(awk -v name="${archive_name}" '$2 == name || $2 == "*" name { print $1 }' "${checksum_file}")"
+  if [[ ! "${remote_sha}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "release checksum file is malformed for ${archive_name}" >&2
+    exit 1
+  fi
+
+  actual_sha="$(sha256sum "${archive}" | awk '{ print $1 }')"
+  if [[ "${actual_sha}" != "${remote_sha}" ]]; then
+    echo "release checksum mismatch for ${archive_name}" >&2
+    exit 1
+  fi
+
+  mapfile -t archive_entries < <(tar -tzf "${archive}" | LC_ALL=C sort)
+  mapfile -t expected_entries < <(printf '%s\n' "${INTERFACES[@]}" | LC_ALL=C sort)
+  if [[ "${archive_entries[*]}" != "${expected_entries[*]}" ]]; then
+    echo "release archive must contain exactly: ${INTERFACES[*]}" >&2
+    exit 1
+  fi
+
+  mkdir -p "${destination}/interfaces"
+  tar -xzf "${archive}" -C "${destination}/interfaces"
+  DOWNLOADED_SHA="${actual_sha}"
+  DOWNLOADED_INTERFACES="${destination}/interfaces"
+}
+
+read_lock() {
+  if [[ ! -f "${LOCK_FILE}" ]]; then
+    echo "${LOCK_FILE} is missing; sync a released SDK version first" >&2
+    exit 1
+  fi
+
+  LOCKED_VERSION="$(sed -n 's/^sdk_version=//p' "${LOCK_FILE}")"
+  LOCKED_SHA="$(sed -n 's/^sha256=//p' "${LOCK_FILE}")"
+  validate_version "${LOCKED_VERSION}"
+  if [[ ! "${LOCKED_SHA}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "invalid SHA-256 in ${LOCK_FILE}" >&2
+    exit 1
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+case "${1:-}" in
+  --check)
+    read_lock
+    download_release "${LOCKED_VERSION}" "${tmp}"
+    if [[ "${DOWNLOADED_SHA}" != "${LOCKED_SHA}" ]]; then
+      echo "released interface archive does not match the pinned SHA-256" >&2
+      exit 1
+    fi
+    for interface in "${INTERFACES[@]}"; do
+      diff -u "${DOWNLOADED_INTERFACES}/${interface}" "${ROOT}/src/${interface}"
+    done
+    echo "credible-std interfaces match credible-sdk ${LOCKED_VERSION}"
+    ;;
+  --help|-h)
+    usage
+    ;;
+  "")
+    usage >&2
+    exit 1
+    ;;
+  *)
+    validate_version "$1"
+    download_release "$1" "${tmp}"
+    mkdir -p "${ROOT}/src"
+    for interface in "${INTERFACES[@]}"; do
+      cp "${DOWNLOADED_INTERFACES}/${interface}" "${ROOT}/src/${interface}"
+    done
+    printf 'sdk_version=%s\nsha256=%s\n' "$1" "${DOWNLOADED_SHA}" > "${LOCK_FILE}"
+    echo "synced credible-sdk $1 interfaces; commit src/*.sol and credible-sdk-interfaces.lock"
+    ;;
+esac

--- a/scripts/test-sync-credible-interfaces.sh
+++ b/scripts/test-sync-credible-interfaces.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly SYNC="${SCRIPT_DIR}/sync-credible-interfaces.sh"
+readonly VERSION="9.9.9-test"
+readonly ARCHIVE="credible-solidity-interfaces-${VERSION}.tar.gz"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+release_dir="${tmp}/releases/${VERSION}"
+target="${tmp}/credible-std"
+mkdir -p "${release_dir}" "${target}/src"
+
+tar -czf "${release_dir}/${ARCHIVE}" \
+  -C "${ROOT}/src" \
+  IAssertion.sol PhEvm.sol TriggerRecorder.sol SpecRecorder.sol
+(
+  cd "${release_dir}"
+  sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
+)
+
+export CREDIBLE_STD_ROOT="${target}"
+export CREDIBLE_SDK_RELEASE_BASE_URL="file://${tmp}/releases"
+
+"${SYNC}" "${VERSION}"
+"${SYNC}" --check
+
+printf '\n// deliberate drift\n' >> "${target}/src/PhEvm.sol"
+if "${SYNC}" --check >/dev/null 2>&1; then
+  echo "interface check accepted a modified file" >&2
+  exit 1
+fi
+
+echo "interface sync tests passed"

--- a/src/Assertion.sol
+++ b/src/Assertion.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {PhEvm} from "./PhEvm.sol";
+import {IAssertion} from "./IAssertion.sol";
 import {TriggerRecorder} from "./TriggerRecorder.sol";
 import {SpecRecorder, AssertionSpec} from "./SpecRecorder.sol";
 import {StateChanges} from "./StateChanges.sol";
@@ -27,7 +28,7 @@ import {ForkUtils} from "./utils/ForkUtils.sol";
 ///     }
 /// }
 /// ```
-abstract contract Assertion is ForkUtils, StateChanges {
+abstract contract Assertion is IAssertion, ForkUtils, StateChanges {
     /// @notice The trigger recorder precompile for registering assertion triggers
     /// @dev Address is derived from a deterministic hash for consistency
     TriggerRecorder constant triggerRecorder = TriggerRecorder(address(uint160(uint256(keccak256("TriggerRecorder")))));
@@ -37,7 +38,7 @@ abstract contract Assertion is ForkUtils, StateChanges {
     SpecRecorder constant specRecorder = SpecRecorder(address(uint160(uint256(keccak256("SpecRecorder")))));
 
     /// @notice Used to record fn selectors and their triggers.
-    function triggers() external view virtual;
+    function triggers() external view virtual override;
 
     // ---------------------------------------------------------------
     //  Legacy trigger registration

--- a/src/IAssertion.sol
+++ b/src/IAssertion.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IAssertion
+/// @notice Runtime entrypoint the assertion extractor invokes after deployment.
+interface IAssertion {
+    /// @notice Registers the assertion's triggers with the trigger recorder.
+    function triggers() external view;
+}


### PR DESCRIPTION
## Summary
Add the release-pinned consumer side of the Solidity-interface synchronization introduced by [credible-sdk#1340](https://github.com/phylaxsystems/credible-sdk/pull/1340).

## Context
`credible-std` must consume published SDK interfaces without requiring network access from Foundry users and without pinning arbitrary commits.

This PR is intentionally draft until the first SDK release containing the interface archive is published. At that point, run `scripts/sync-credible-interfaces.sh <sdk-version>` and commit the generated lock plus vendored interfaces.

## Changes
- Add a one-command sync/check script for semver SDK release artifacts
- Pin both SDK version and SHA-256 in `credible-sdk-interfaces.lock` when syncing
- Verify exact archive contents before extraction
- Make `Assertion` inherit the canonical `IAssertion` entrypoint used by the extractor
- Exercise synchronization and drift detection on every PR
- Block `credible-std` releases unless the vendored files match a real pinned SDK release
- Document the release update workflow

## Testing
- `bash -n scripts/sync-credible-interfaces.sh scripts/test-sync-credible-interfaces.sh`
- `scripts/test-sync-credible-interfaces.sh`
- Local end-to-end sync/check against the archive built by credible-sdk#1340
- Verified that `--check` rejects a missing lock and modified interface
- `forge fmt --check`
- `forge build`

## Breaking Changes
None to Solidity consumers. The release workflow now requires an SDK interface lock before publishing.

Prompted by: Odysseus

Refs ENG-4433